### PR TITLE
feat(system): port core primitives with typed theming and yew support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,8 @@ name = "mui-system"
 version = "0.1.0"
 dependencies = [
  "leptos",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "yew",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ license = "MIT OR Apache-2.0"
 wasm-bindgen = "0.2"
 leptos = { version = "0.6", default-features = false }
 yew = { version = "0.21", features = ["csr"], default-features = false }
+serde = { version = "1.0", features = ["derive"], default-features = false }
+serde_json = "1.0"
 
 [profile.dev]
 # Development builds prioritize compile time over runtime performance.

--- a/crates/mui-system/Cargo.toml
+++ b/crates/mui-system/Cargo.toml
@@ -8,7 +8,19 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Use shared versions from the workspace. These dependencies are optional
 # and can be enabled when the crate needs to integrate with a specific
-# front-end framework.
-leptos.workspace = true
-yew.workspace = true
-wasm-bindgen.workspace = true
+# front-end framework. Serde is pulled in to allow JSON serialization of
+# theme structures.
+serde.workspace = true
+serde_json.workspace = true
+leptos = { workspace = true, optional = true }
+yew = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+
+[features]
+default = []
+yew = ["dep:yew", "dep:wasm-bindgen"]
+leptos = ["dep:leptos", "dep:wasm-bindgen"]
+
+[[example]]
+name = "basic"
+required-features = ["yew"]

--- a/crates/mui-system/examples/basic.rs
+++ b/crates/mui-system/examples/basic.rs
@@ -1,0 +1,24 @@
+//! Minimal usage example demonstrating theming and layout helpers.
+//!
+//! Run with `cargo run --example basic --features yew` targeting `wasm32`.
+
+use mui_system::{style_props, Box, Grid, Theme, ThemeProvider};
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    let theme = Theme::default();
+    html! {
+        <ThemeProvider theme={theme}>
+            <Box style={style_props!{ padding: "16px" }}>
+                <Grid span={6} columns={12} style={style_props!{ background_color: "#eee" }}>
+                    {"Responsive grid item"}
+                </Grid>
+            </Box>
+        </ThemeProvider>
+    }
+}
+
+fn main() {
+    yew::Renderer::<App>::new().render();
+}

--- a/crates/mui-system/src/box.rs
+++ b/crates/mui-system/src/box.rs
@@ -1,0 +1,20 @@
+#![cfg(feature = "yew")]
+use yew::prelude::*;
+
+/// Lightweight wrapper around a `div` that accepts style properties.
+#[derive(Properties, PartialEq)]
+pub struct BoxProps {
+    /// Inline CSS style string typically generated via the `style_props!` macro.
+    #[prop_or_default]
+    pub style: String,
+    /// Child elements to render inside the container.
+    #[prop_or_default]
+    pub children: Children,
+}
+
+/// Basic building block analogous to the `Box` component from MUI's JS
+/// ecosystem. Additional props and behaviors can be layered on over time.
+#[function_component(Box)]
+pub fn box_component(props: &BoxProps) -> Html {
+    html! { <div style={props.style.clone()}>{ for props.children.iter() }</div> }
+}

--- a/crates/mui-system/src/grid.rs
+++ b/crates/mui-system/src/grid.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "yew")]
+use yew::prelude::*;
+use crate::responsive::grid_span_to_percent;
+
+/// Simple grid item that computes its own width based on `span` and `columns`.
+#[derive(Properties, PartialEq)]
+pub struct GridProps {
+    /// Total number of columns in the grid container.
+    #[prop_or(12)]
+    pub columns: u16,
+    /// Number of columns this item should span.
+    #[prop_or(12)]
+    pub span: u16,
+    /// Additional inline styles merged with the computed width.
+    #[prop_or_default]
+    pub style: String,
+    /// Child elements of the grid item.
+    #[prop_or_default]
+    pub children: Children,
+}
+
+#[function_component(Grid)]
+pub fn grid(props: &GridProps) -> Html {
+    let width = grid_span_to_percent(props.span, props.columns);
+    let style = format!("{}width:{}%;", props.style, width);
+    html! { <div style={style}>{ for props.children.iter() }</div> }
+}

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -1,11 +1,35 @@
 //! Core styling primitives for Material UI in Rust.
 //!
-//! This crate provides the building blocks used by higher level Material
-//! components. At the moment it's just a placeholder, but the documentation
-//! outlines the intent so contributors know where to add new abstractions.
+//! This crate mirrors the structure of the upstream `packages/mui-system`
+//! JavaScript package. It provides foundational building blocks like `Box`,
+//! `Grid`, theming utilities and responsive helpers that higher level crates
+//! can build upon.
+//!
+//! Features are gated so that downstream users only compile the code required
+//! for their target framework (`yew`, `leptos`, ...).
 
-/// A no-op function proving the crate compiles. Real functionality will be
-/// added as the project evolves.
+pub mod style;
+pub mod theme;
+pub mod responsive;
+
+#[cfg(feature = "yew")]
+pub mod r#box;
+#[cfg(feature = "yew")]
+pub mod grid;
+#[cfg(feature = "yew")]
+pub mod theme_provider;
+
+pub use responsive::{grid_span_to_percent, Responsive};
+pub use theme::{Breakpoints, Palette, Theme};
+#[cfg(feature = "yew")]
+pub use r#box::Box;
+#[cfg(feature = "yew")]
+pub use grid::Grid;
+#[cfg(feature = "yew")]
+pub use theme_provider::{use_theme, ThemeProvider};
+
+/// Legacy no-op function retained to keep dependent crates compiling while
+/// more features are ported. New functionality resides in the modules above.
 pub fn placeholder() {}
 
 #[cfg(test)]
@@ -13,7 +37,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn placeholder_works() {
-        placeholder();
+    fn grid_span_math_is_sound() {
+        assert!((grid_span_to_percent(3, 12) - 25.0).abs() < f32::EPSILON);
     }
 }

--- a/crates/mui-system/src/responsive.rs
+++ b/crates/mui-system/src/responsive.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+use crate::theme::Breakpoints;
+
+/// Helper structure representing values that change across breakpoints.
+/// Missing values fall back to the next smallest defined one, mirroring
+/// the cascading behavior of CSS media queries.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Responsive<T> {
+    pub xs: T,
+    pub sm: Option<T>,
+    pub md: Option<T>,
+    pub lg: Option<T>,
+    pub xl: Option<T>,
+}
+
+impl<T: Clone> Responsive<T> {
+    /// Resolves the appropriate value for a given viewport width.
+    pub fn resolve(&self, width: u32, bp: &Breakpoints) -> T {
+        if width >= bp.xl {
+            self.xl.as_ref()
+                .or(self.lg.as_ref())
+                .or(self.md.as_ref())
+                .or(self.sm.as_ref())
+                .unwrap_or(&self.xs)
+                .clone()
+        } else if width >= bp.lg {
+            self.lg.as_ref()
+                .or(self.md.as_ref())
+                .or(self.sm.as_ref())
+                .unwrap_or(&self.xs)
+                .clone()
+        } else if width >= bp.md {
+            self.md.as_ref()
+                .or(self.sm.as_ref())
+                .unwrap_or(&self.xs)
+                .clone()
+        } else if width >= bp.sm {
+            self.sm.as_ref().unwrap_or(&self.xs).clone()
+        } else {
+            self.xs.clone()
+        }
+    }
+}
+
+/// Computes the percentage width a grid item should occupy given its span
+/// and the total number of columns.
+pub fn grid_span_to_percent(span: u16, columns: u16) -> f32 {
+    (span as f32 / columns as f32) * 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::Theme;
+
+    #[test]
+    fn resolves_breakpoint_values() {
+        let theme = Theme::default();
+        let values = Responsive {
+            xs: 1,
+            sm: Some(2),
+            md: Some(3),
+            lg: None,
+            xl: Some(5),
+        };
+        assert_eq!(values.resolve(500, &theme.breakpoints), 1);
+        assert_eq!(values.resolve(700, &theme.breakpoints), 2);
+        assert_eq!(values.resolve(1000, &theme.breakpoints), 3);
+        assert_eq!(values.resolve(1300, &theme.breakpoints), 3); // fallback
+        assert_eq!(values.resolve(1600, &theme.breakpoints), 5);
+    }
+
+    #[test]
+    fn grid_span_calculates_percentage() {
+        assert!((grid_span_to_percent(6, 12) - 50.0).abs() < f32::EPSILON);
+    }
+}

--- a/crates/mui-system/src/style.rs
+++ b/crates/mui-system/src/style.rs
@@ -1,0 +1,45 @@
+///! Utility macros for generating CSS style strings.
+///
+/// The macros favor code generation over manual string concatenation which
+/// keeps component implementations terse and less error prone.
+
+/// Generates a style string from `key: value` pairs.
+///
+/// ```rust
+/// use mui_system::style_props;
+/// let style = style_props! { width: "100%", margin_top: "8px" };
+/// assert_eq!(style, "width:100%;margin-top:8px;");
+/// ```
+#[macro_export]
+macro_rules! style_props {
+    ( $( $name:ident : $value:expr ),* $(,)? ) => {{
+        let mut s = String::new();
+        $(
+            // Convert snake_case identifiers to kebab-case CSS property names.
+            let prop = stringify!($name).replace('_', "-");
+            s.push_str(&prop);
+            s.push(':');
+            s.push_str(&$value);
+            s.push(';');
+        )*
+        s
+    }};
+}
+
+/// Declares a helper function for a single CSS property.
+///
+/// ```rust
+/// use mui_system::define_style_prop;
+/// define_style_prop!(margin_top, "margin-top");
+/// let style = margin_top("8px");
+/// assert_eq!(style, "margin-top:8px;");
+/// ```
+#[macro_export]
+macro_rules! define_style_prop {
+    ($func:ident, $prop:expr) => {
+        /// Macro generated style helper.
+        pub fn $func<V: Into<String>>(value: V) -> String {
+            format!("{}:{};", $prop, value.into())
+        }
+    };
+}

--- a/crates/mui-system/src/theme.rs
+++ b/crates/mui-system/src/theme.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+/// Typed representation of the design system theme.
+///
+/// The struct mirrors the JS theme object but leverages Rust's strong
+/// typing so invalid configurations are caught at compile time. `serde`
+/// support enables seamless JSON (de)serialization for interop with
+/// existing tooling and configuration files.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Theme {
+    /// Base spacing unit used by the `spacing` helper. Expressed in pixels
+    /// to simplify calculations across platforms.
+    pub spacing: u16,
+    /// Responsive breakpoints measured in pixels.
+    pub breakpoints: Breakpoints,
+    /// Primary and secondary colors expressed as hex strings.
+    pub palette: Palette,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            spacing: 8,
+            breakpoints: Breakpoints::default(),
+            palette: Palette::default(),
+        }
+    }
+}
+
+impl Theme {
+    /// Calculates a spacing value by multiplying the base unit with the
+    /// provided factor. This mirrors the JS `theme.spacing` utility.
+    pub fn spacing(&self, factor: u16) -> u16 {
+        self.spacing * factor
+    }
+}
+
+/// Breakpoint definitions in ascending order. Consumers can extend this
+/// struct if additional breakpoints are required.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Breakpoints {
+    pub sm: u32,
+    pub md: u32,
+    pub lg: u32,
+    pub xl: u32,
+}
+
+impl Default for Breakpoints {
+    fn default() -> Self {
+        Self {
+            sm: 600,
+            md: 900,
+            lg: 1200,
+            xl: 1536,
+        }
+    }
+}
+
+/// Minimal color palette capturing primary and secondary accents.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Palette {
+    pub primary: String,
+    pub secondary: String,
+}
+
+impl Default for Palette {
+    fn default() -> Self {
+        Self {
+            primary: "#1976d2".to_string(),
+            secondary: "#dc004e".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn theme_serializes_and_spacing_works() {
+        let theme = Theme::default();
+        // Verify spacing helper
+        assert_eq!(theme.spacing(2), 16);
+
+        // Round trip through JSON to ensure `serde` wiring is correct
+        let json = serde_json::to_string(&theme).expect("serialize");
+        let de: Theme = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(theme, de);
+    }
+}

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "yew")]
+use yew::prelude::*;
+use crate::theme::Theme;
+
+/// Provides the current [`Theme`] to descendant components via Yew's
+/// `ContextProvider` mechanism.
+#[derive(Properties, PartialEq)]
+pub struct ThemeProviderProps {
+    pub theme: Theme,
+    #[prop_or_default]
+    pub children: Children,
+}
+
+#[function_component(ThemeProvider)]
+pub fn theme_provider(props: &ThemeProviderProps) -> Html {
+    html! {
+        <ContextProvider<Theme> context={props.theme.clone()}>
+            { for props.children.iter() }
+        </ContextProvider<Theme>>
+    }
+}
+
+/// Retrieves the current theme from context. Components can call this helper
+/// instead of dealing with `use_context` directly which keeps the call sites
+/// concise.
+#[cfg(feature = "yew")]
+pub fn use_theme() -> Theme {
+    use_context::<Theme>().unwrap_or_default()
+}


### PR DESCRIPTION
## Summary
- add typed `Theme` with serde and responsive helpers
- introduce `style_props!` macros and generate style helpers
- port Box, Grid, ThemeProvider components using Yew
- provide usage example and unit tests for layout and theming

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c1142520832ea92bd7fc3987e3bb