### PR TITLE
feat: add initial material components with styling engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
 
 [[package]]
+name = "cc"
+version = "1.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +304,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fnv"
@@ -1252,6 +1268,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,7 +1316,19 @@ dependencies = [
 name = "mui-material"
 version = "0.1.0"
 dependencies = [
+ "gloo-utils 0.2.0",
  "leptos",
+ "mui-styled-engine",
+ "mui-system",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "yew",
+]
+
+[[package]]
+name = "mui-styled-engine"
+version = "0.1.0"
+dependencies = [
  "mui-system",
  "wasm-bindgen",
  "yew",
@@ -1860,6 +1898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2296,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80cc7f8a4114fdaa0c58383caf973fc126cf004eba25c9dc639bccd3880d55ad"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ada2ab788d46d4bda04c9d567702a79c8ced14f51f221646a16ed39d0e6a5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@
 # this file and point to directories under `crates/`.
 members = [
     "crates/mui-system",
+    "crates/mui-styled-engine",
     "crates/mui-material",
     "crates/mui-icons",
 ]
@@ -60,6 +61,7 @@ leptos = { version = "0.6", default-features = false }
 yew = { version = "0.21", features = ["csr"], default-features = false }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0"
+wasm-bindgen-test = "0.3"
 
 [profile.dev]
 # Development builds prioritize compile time over runtime performance.

--- a/crates/mui-material/Cargo.toml
+++ b/crates/mui-material/Cargo.toml
@@ -6,7 +6,17 @@ description = "Material Design components implemented in Rust leveraging mui-sys
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+mui-styled-engine = { path = "../mui-styled-engine" }
 mui-system = { path = "../mui-system" }
-leptos.workspace = true
-yew.workspace = true
-wasm-bindgen.workspace = true
+leptos = { workspace = true, optional = true }
+yew = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true
+gloo-utils = "0.2"
+
+[features]
+default = []
+yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew", "mui-styled-engine/yew"]
+leptos = ["dep:leptos", "dep:wasm-bindgen", "mui-system/leptos"]

--- a/crates/mui-material/README.md
+++ b/crates/mui-material/README.md
@@ -1,0 +1,20 @@
+# mui-material
+
+Rust translation of Material UI components. Built on top of [`mui-styled-engine`](../mui-styled-engine) and [`mui-system`](../mui-system).
+
+## Example
+
+```rust
+use mui_material::{Button};
+use mui_styled_engine::{ThemeProvider, Theme};
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    html! {
+        <ThemeProvider theme={Theme::default()}>
+            <Button label="Press" />
+        </ThemeProvider>
+    }
+}
+```

--- a/crates/mui-material/src/button.rs
+++ b/crates/mui-material/src/button.rs
@@ -1,0 +1,32 @@
+use yew::prelude::*;
+use mui_styled_engine::use_theme;
+
+use crate::{material_enum, material_props};
+
+material_enum!(ButtonColor { Primary, Secondary });
+material_enum!(ButtonVariant { Text, Contained, Outlined });
+
+material_props!(ButtonProps {
+    /// Text displayed inside the button.
+    label: String,
+    /// Visual color scheme of the button.
+    color: ButtonColor,
+    /// Variant controlling the button's background and border.
+    variant: ButtonVariant,
+});
+
+/// A basic Material Design button.
+#[function_component(Button)]
+pub fn button(props: &ButtonProps) -> Html {
+    let theme = use_theme();
+    let color = match props.color {
+        ButtonColor::Primary => theme.palette.primary.clone(),
+        ButtonColor::Secondary => theme.palette.secondary.clone(),
+    };
+    let style = match props.variant {
+        ButtonVariant::Contained => format!("background:{};color:#fff;", color),
+        ButtonVariant::Outlined => format!("color:{};border:1px solid {}", color, color),
+        ButtonVariant::Text => format!("color:{};", color),
+    };
+    html! { <button style={style}>{ &props.label }</button> }
+}

--- a/crates/mui-material/src/card.rs
+++ b/crates/mui-material/src/card.rs
@@ -1,0 +1,21 @@
+use yew::prelude::*;
+use mui_styled_engine::use_theme;
+
+use crate::material_props;
+
+material_props!(CardProps {
+    /// Content of the card.
+    children: Children,
+});
+
+/// Simple container with themed border and padding.
+#[function_component(Card)]
+pub fn card(props: &CardProps) -> Html {
+    let theme = use_theme();
+    let style = format!(
+        "border:1px solid {};padding:{}px;",
+        theme.palette.primary,
+        theme.spacing(2)
+    );
+    html! { <div style={style}>{ for props.children.iter() }</div> }
+}

--- a/crates/mui-material/src/dialog.rs
+++ b/crates/mui-material/src/dialog.rs
@@ -1,0 +1,26 @@
+use yew::prelude::*;
+use mui_styled_engine::use_theme;
+
+use crate::material_props;
+
+material_props!(DialogProps {
+    /// Whether the dialog is shown.
+    open: bool,
+    /// Dialog contents.
+    children: Children,
+});
+
+/// Minimal dialog implementation that toggles visibility.
+#[function_component(Dialog)]
+pub fn dialog(props: &DialogProps) -> Html {
+    if !props.open {
+        return Html::default();
+    }
+    let theme = use_theme();
+    let style = format!(
+        "border:2px solid {};padding:{}px;",
+        theme.palette.secondary,
+        theme.spacing(3)
+    );
+    html! { <div style={style}>{ for props.children.iter() }</div> }
+}

--- a/crates/mui-material/src/lib.rs
+++ b/crates/mui-material/src/lib.rs
@@ -1,15 +1,40 @@
-//! Higher level Material Design components.
+//! Material Design components built on top of [`mui-styled-engine`].
 //!
-//! This crate builds on top of `mui-system` to provide widgets like buttons,
-//! dialogs, and layout utilities. The initial version simply re-exports
-//! `mui-system` to show the intended layering.
+//! The crate currently provides a small subset of widgets such as [`Button`],
+//! [`Card`] and [`Dialog`]. Each component consumes the shared [`Theme`]
+//! provided by `mui-styled-engine` so applications have a single source of
+//! truth for styling.
+//!
+//! # Example
+//! ```rust
+//! use mui_material::{Button, ButtonProps};
+//! use mui_styled_engine::{ThemeProvider, Theme};
+//! use yew::prelude::*;
+//!
+//! #[function_component(App)]
+//! fn app() -> Html {
+//!     html! {
+//!         <ThemeProvider theme={Theme::default()}>
+//!             <Button label="Click me" />
+//!         </ThemeProvider>
+//!     }
+//! }
+//! ```
 
-pub use mui_system as system;
+mod macros;
+mod button;
+mod card;
+mod dialog;
 
-/// Confirms that the crate links to `mui-system` and compiles.
+pub use button::{Button, ButtonProps, ButtonColor, ButtonVariant};
+pub use card::{Card, CardProps};
+pub use dialog::{Dialog, DialogProps};
+
+pub use mui_styled_engine::Theme;
+
+/// Confirms that the crate links to `mui-styled-engine` and compiles.
 pub fn placeholder() {
-    // Call into the system crate to prevent dead code warnings
-    system::placeholder();
+    mui_styled_engine::placeholder();
 }
 
 #[cfg(test)]

--- a/crates/mui-material/src/macros.rs
+++ b/crates/mui-material/src/macros.rs
@@ -1,0 +1,30 @@
+//! Helper macros for defining Material UI component props and enums.
+
+/// Generates a `yew::Properties` struct with `Default` implementation.
+/// Each field automatically receives `#[prop_or_default]` so callers can
+/// omit them.
+#[macro_export]
+macro_rules! material_props {
+    ($name:ident { $( $(#[$meta:meta])* $field:ident : $ty:ty ),* $(,)? }) => {
+        #[cfg(feature = "yew")]
+        #[derive(yew::Properties, Clone, PartialEq, Default)]
+        pub struct $name {
+            $( $(#[$meta])* #[prop_or_default] pub $field: $ty, )*
+        }
+    };
+}
+
+/// Declares a simple enum and implements `Default` for the first variant.
+#[macro_export]
+macro_rules! material_enum {
+    ($name:ident { $first:ident $(, $rest:ident)* $(,)? }) => {
+        #[derive(Clone, PartialEq)]
+        pub enum $name {
+            $first,
+            $( $rest, )*
+        }
+        impl Default for $name {
+            fn default() -> Self { Self::$first }
+        }
+    };
+}

--- a/crates/mui-material/tests/wasm.rs
+++ b/crates/mui-material/tests/wasm.rs
@@ -1,0 +1,31 @@
+use wasm_bindgen_test::*;
+use yew::prelude::*;
+use yew::Renderer;
+use mui_styled_engine::{ThemeProvider, Theme};
+use mui_material::{Button, ButtonProps};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn button_renders_with_theme_color() {
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <Button label="Hello" />
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+
+    let button = mount
+        .query_selector("button")
+        .unwrap()
+        .expect("button rendered");
+    assert_eq!(button.text_content().unwrap(), "Hello");
+}

--- a/crates/mui-styled-engine/Cargo.toml
+++ b/crates/mui-styled-engine/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mui-styled-engine"
+version = "0.1.0"
+edition = "2021"
+description = "Styling engine for Material UI Rust components providing theme primitives."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+mui-system = { path = "../mui-system" }
+yew = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+
+[features]
+default = []
+yew = ["mui-system/yew", "dep:yew", "dep:wasm-bindgen"]

--- a/crates/mui-styled-engine/src/lib.rs
+++ b/crates/mui-styled-engine/src/lib.rs
@@ -1,0 +1,25 @@
+//! Core styling utilities shared across Material UI Rust components.
+//! 
+//! This crate centralizes theming so higher level widgets only depend on a
+//! single source for style information. It currently re-exports the theme
+//! primitives from [`mui-system`].
+
+pub use mui_system::theme::{Theme, Palette, Breakpoints};
+#[cfg(feature = "yew")]
+pub use mui_system::theme_provider::{ThemeProvider, use_theme};
+
+/// Placeholder to prove the crate links correctly.
+pub fn placeholder() {
+    mui_system::placeholder();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_theme_available() {
+        let t = Theme::default();
+        assert_eq!(t.palette.primary, "#1976d2");
+    }
+}

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -24,6 +24,7 @@ pub fn theme_provider(props: &ThemeProviderProps) -> Html {
 /// instead of dealing with `use_context` directly which keeps the call sites
 /// concise.
 #[cfg(feature = "yew")]
+#[hook]
 pub fn use_theme() -> Theme {
     use_context::<Theme>().unwrap_or_default()
 }


### PR DESCRIPTION
## Summary
- introduce `mui-styled-engine` crate re-exporting system theming utilities
- add `Button`, `Card`, and `Dialog` components with macro-defined props
- provide wasm-bindgen integration test for theme-aware rendering

## Testing
- `cargo test -p mui-styled-engine --features yew`
- `cargo test -p mui-system --features yew`
- `cargo test -p mui-material --features yew --target wasm32-unknown-unknown` *(fails: could not execute process `mui_material-...wasm`)*


------
https://chatgpt.com/codex/tasks/task_e_68c5c8ffb9b0832ea7f6fbf52bf46ca4