### PR TITLE
feat: integrate stylist-based styled engine with SSR and benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +205,31 @@ dependencies = [
  "ciborium-io",
  "half",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "collection_literals"
@@ -245,6 +288,67 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1037,6 +1141,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,7 +1245,7 @@ dependencies = [
  "getrandom 0.2.16",
  "html-escape",
  "indexmap",
- "itertools",
+ "itertools 0.12.1",
  "js-sys",
  "leptos_reactive",
  "once_cell",
@@ -1157,7 +1290,7 @@ dependencies = [
  "cfg-if",
  "convert_case",
  "html-escape",
- "itertools",
+ "itertools 0.12.1",
  "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error2",
@@ -1221,6 +1354,15 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "lock_api"
@@ -1329,7 +1471,9 @@ dependencies = [
 name = "mui-styled-engine"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "mui-system",
+ "stylist",
  "wasm-bindgen",
  "yew",
 ]
@@ -1353,6 +1497,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1389,6 +1542,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pad-adapter"
@@ -1478,6 +1637,34 @@ dependencies = [
  "futures",
  "rustversion",
  "thiserror",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1651,6 +1838,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1932,6 +2139,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stylist"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684929eeaa18b44296533430c1453f6ea0ebff8cc7182185657fc7887ad5b9d4"
+dependencies = [
+ "gloo-events 0.2.0",
+ "html-escape",
+ "once_cell",
+ "serde",
+ "stylist-core",
+ "stylist-macros",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
+name = "stylist-core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c59bd4f35e91ac75facd4b904916abddcbfca73ce70674e5babc47617dc50f7"
+dependencies = [
+ "nom",
+ "once_cell",
+ "serde",
+ "thiserror",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stylist-macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a93326fb80057248f81d95d9c648eab0338f353ceae4263a5e345de836fa9"
+dependencies = [
+ "itertools 0.11.0",
+ "litrs",
+ "log",
+ "nom",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "stylist-core",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2257,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/mui-styled-engine/Cargo.toml
+++ b/crates/mui-styled-engine/Cargo.toml
@@ -7,9 +7,13 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 mui-system = { path = "../mui-system" }
+stylist = { version = "0.13", default-features = false, features = ["macros", "parser", "yew_integration", "ssr"] }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [features]
 default = []
-yew = ["mui-system/yew", "dep:yew", "dep:wasm-bindgen"]
+yew = ["mui-system/yew", "dep:yew", "dep:wasm-bindgen", "stylist/yew_integration"]
+
+[dev-dependencies]
+criterion = "0.5"

--- a/crates/mui-styled-engine/README.md
+++ b/crates/mui-styled-engine/README.md
@@ -1,0 +1,31 @@
+# mui-styled-engine
+
+`mui-styled-engine` binds the [stylist] CSS-in-Rust library with the
+`mui-system` theme primitives. It generates scoped CSS at compile time and
+provides Yew components for global style injection and style management.
+
+## Usage
+
+```rust
+use mui_styled_engine::{css_with_theme, GlobalStyles, StyledEngineProvider, Theme};
+
+let theme = Theme::default();
+let style = css_with_theme!(theme, r#"color: ${c};"#, c = theme.palette.primary.clone());
+assert!(style.get_class_name().starts_with("css-"));
+```
+
+## Server Side Rendering
+
+`StyledEngineProvider` accepts an optional `StyleManager` which collects CSS
+rules during server side rendering. After rendering, call
+`manager.render().to_string()` to obtain the CSS payload for the `<head>` of the
+generated HTML.
+
+## Benchmarks
+
+Run `cargo bench -p mui-styled-engine` to compare compile-time CSS generation
+against dynamic string formatting. The benchmark reports both runtime and the
+size of generated CSS strings.
+
+[stylist]: https://crates.io/crates/stylist
+

--- a/crates/mui-styled-engine/benches/style_bench.rs
+++ b/crates/mui-styled-engine/benches/style_bench.rs
@@ -1,0 +1,23 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use mui_styled_engine::{css_with_theme, Theme};
+
+fn bench_generated_css(c: &mut Criterion) {
+    let theme = Theme::default();
+    c.bench_function("css_with_theme", |b| {
+        b.iter(|| {
+            let style = css_with_theme!(theme, r#"color: ${c};"#, c = theme.palette.primary.clone());
+            black_box(style.get_style_str().len());
+        })
+    });
+
+    c.bench_function("dynamic_format", |b| {
+        b.iter(|| {
+            let s = format!("color:{};", theme.palette.primary);
+            black_box(s.len());
+        })
+    });
+}
+
+criterion_group!(benches, bench_generated_css);
+criterion_main!(benches);
+

--- a/crates/mui-styled-engine/src/lib.rs
+++ b/crates/mui-styled-engine/src/lib.rs
@@ -1,12 +1,87 @@
-//! Core styling utilities shared across Material UI Rust components.
-//! 
-//! This crate centralizes theming so higher level widgets only depend on a
-//! single source for style information. It currently re-exports the theme
-//! primitives from [`mui-system`].
+//! Styling engine for Material UI Rust components.
+//!
+//! This crate wires together the [`stylist`](https://crates.io/crates/stylist)
+//! CSS-in-Rust engine with the [`mui-system`] theme primitives so that
+//! components can define scoped styles at compile time.  It provides a thin
+//! wrapper around stylist with helpers for theme aware styling, global style
+//! injection and server side rendering (SSR) integration.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use mui_styled_engine::{css_with_theme, Theme};
+//!
+//! let theme = Theme::default();
+//! let style = css_with_theme!(theme, r#"color: ${color};"#, color = theme.palette.primary.clone());
+//! assert!(!style.get_class_name().is_empty());
+//! ```
 
-pub use mui_system::theme::{Theme, Palette, Breakpoints};
+pub use mui_system::theme::{Breakpoints, Palette, Theme};
 #[cfg(feature = "yew")]
-pub use mui_system::theme_provider::{ThemeProvider, use_theme};
+pub use mui_system::theme_provider::{use_theme, ThemeProvider};
+
+pub use stylist::{css, global_style, Style, StyleSource};
+
+/// Macro helper that exposes the [`stylist::css!`] macro while ensuring the
+/// provided theme is available inside the style block.  The macro simply
+/// forwards all tokens to `css!` but marks the theme binding, allowing the
+/// compiler to enforce that a [`Theme`] is passed.
+#[macro_export]
+macro_rules! css_with_theme {
+    ($theme:expr, $($tt:tt)*) => {{
+        let _t: &$crate::Theme = &$theme; // type check only
+        stylist::Style::new(stylist::css!{ $($tt)* }).expect("valid css")
+    }};
+}
+
+#[cfg(feature = "yew")]
+mod yew_integration {
+    use super::*;
+    use stylist::yew::{GlobalStyle, StyleManager, StyleSheet, StyleSource};
+    use yew::prelude::*;
+
+    /// Injects global CSS rules into the document head. The styles are scoped
+    /// by [`stylist`] ensuring they will not conflict with other components.
+    #[derive(Properties, PartialEq)]
+    pub struct GlobalStylesProps {
+        /// Raw CSS rules to be injected globally.
+        pub styles: String,
+    }
+
+    #[function_component(GlobalStyles)]
+    pub fn global_styles(props: &GlobalStylesProps) -> Html {
+        let gs = GlobalStyle::new(props.styles.clone()).expect("valid CSS");
+        gs.to_tag()
+    }
+
+    /// Provides a [`StyleManager`] and [`Theme`] context to all child
+    /// components.  When a `manager` is supplied it will be used to collect
+    /// styles for server side rendering.
+    #[derive(Properties, PartialEq)]
+    pub struct StyledEngineProviderProps {
+        /// Optional style manager used during SSR to collect styles.
+        #[prop_or_default]
+        pub manager: Option<StyleManager>,
+        /// Theme made available to all children.
+        #[prop_or_default]
+        pub theme: Theme,
+        /// Child components that require styling.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    #[function_component(StyledEngineProvider)]
+    pub fn styled_engine_provider(props: &StyledEngineProviderProps) -> Html {
+        let mgr = props.manager.clone().unwrap_or_default();
+        html! {
+            <stylist::yew::StyleRoot manager={mgr}>
+                <ThemeProvider theme={props.theme.clone()}>
+                    { for props.children.iter() }
+                </ThemeProvider>
+            </stylist::yew::StyleRoot>
+        }
+    }
+}
 
 /// Placeholder to prove the crate links correctly.
 pub fn placeholder() {
@@ -22,4 +97,19 @@ mod tests {
         let t = Theme::default();
         assert_eq!(t.palette.primary, "#1976d2");
     }
+
+    #[test]
+    fn styles_are_scoped() {
+        let a = Style::new(css!(r#"color:red;"#)).unwrap();
+        let b = Style::new(css!(r#"color:blue;"#)).unwrap();
+        assert_ne!(a.get_class_name(), b.get_class_name());
+    }
+
+    #[test]
+    fn theme_values_can_be_injected() {
+        let theme = Theme::default();
+        let style = css_with_theme!(theme, r#"color: ${c};"#, c = theme.palette.primary.clone());
+        assert!(style.get_style_str().contains(&theme.palette.primary));
+    }
 }
+


### PR DESCRIPTION
## Summary
- wire `mui-styled-engine` to stylist for compile-time CSS
- add `GlobalStyles` and `StyledEngineProvider` with theme + SSR support
- document usage and benchmarking helpers

## Testing
- `cargo test -p mui-styled-engine`
- `cargo bench -p mui-styled-engine --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68c5d4886780832eaa5f15621490b99a