### PR TITLE
feat: add Joy UI crate and theme tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mui-joy"
+version = "0.1.0"
+dependencies = [
+ "gloo-utils 0.2.0",
+ "leptos",
+ "mui-system",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "mui-material"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/mui-icons",
     "crates/mui-icons-material",
     "crates/mui-utils",
+    "crates/mui-joy",
 ]
 
 # Use Cargo's second feature resolver so optional dependencies don't
@@ -71,7 +72,7 @@ proc-macro2 = "1.0"
 once_cell = "1.21.3"
 proptest = "1.2"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window"] }
+web-sys = { version = "0.3", features = ["Window", "HtmlElement", "Event", "EventTarget"] }
 
 [profile.dev]
 # Development builds prioritize compile time over runtime performance.

--- a/crates/mui-joy/Cargo.toml
+++ b/crates/mui-joy/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mui-joy"
+version = "0.1.0"
+edition = "2021"
+description = "Joy UI components implemented in Rust leveraging mui-system."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+mui-system = { path = "../mui-system" }
+leptos = { workspace = true, optional = true }
+yew = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true
+gloo-utils = "0.2"
+web-sys = { workspace = true, features = ["HtmlElement", "Event", "EventTarget"] }
+
+[features]
+default = []
+yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew"]
+leptos = ["dep:leptos", "dep:wasm-bindgen", "mui-system/leptos"]

--- a/crates/mui-joy/README.md
+++ b/crates/mui-joy/README.md
@@ -1,0 +1,20 @@
+# mui-joy
+
+Experimental Joy UI component library for Rust.
+
+This crate mirrors the `mui-material` crate but targets the Joy design
+language.  It showcases how additional design tokens such as `neutral` and
+`danger` palette colors or corner `radius` can be modeled in Rust.
+
+## Differences from Material
+
+* Extra palette colors: `neutral` and `danger`.
+* Joy specific tokens grouped under `Theme::joy` like `radius` for rounded
+  corners.
+* Component variants `solid`, `soft`, `outlined`, and `plain`.
+
+## Examples
+
+```bash
+cargo run -p mui-joy --example button --features yew
+```

--- a/crates/mui-joy/examples/button.rs
+++ b/crates/mui-joy/examples/button.rs
@@ -1,0 +1,28 @@
+//! Simple example showcasing the Joy `Button` component.
+//!
+//! Run with:
+//! `cargo run -p mui-joy --example button --features yew`
+
+use mui_joy::Button;
+use mui_system::theme_provider::ThemeProvider;
+use mui_system::Theme;
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    let count = use_state(|| 0);
+    let onclick = {
+        let count = count.clone();
+        Callback::from(move |_| count.set(*count + 1))
+    };
+    html! {
+        <ThemeProvider theme={Theme::default()}>
+            <Button label="Add" {onclick} />
+            <p>{ format!("Clicks: {}", *count) }</p>
+        </ThemeProvider>
+    }
+}
+
+fn main() {
+    yew::Renderer::<App>::new().render();
+}

--- a/crates/mui-joy/src/button.rs
+++ b/crates/mui-joy/src/button.rs
@@ -1,0 +1,58 @@
+use mui_system::theme_provider::use_theme;
+use yew::prelude::*;
+
+use crate::{joy_enum, joy_props};
+
+joy_enum!(ButtonColor {
+    Primary,
+    Neutral,
+    Danger
+});
+joy_enum!(ButtonVariant {
+    Solid,
+    Soft,
+    Outlined,
+    Plain
+});
+
+joy_props!(ButtonProps {
+    /// Text displayed inside the button.
+    label: String,
+    /// Visual color scheme of the button.
+    color: ButtonColor,
+    /// Variant controlling the button's background and border.
+    variant: ButtonVariant,
+    /// Click handler for interactive behavior.
+    onclick: Callback<MouseEvent>,
+});
+
+/// A basic Joy UI button.
+#[function_component(Button)]
+pub fn button(props: &ButtonProps) -> Html {
+    let theme = use_theme();
+    let color = match props.color {
+        ButtonColor::Primary => theme.palette.primary.clone(),
+        ButtonColor::Neutral => theme.palette.neutral.clone(),
+        ButtonColor::Danger => theme.palette.danger.clone(),
+    };
+    let style = match props.variant {
+        ButtonVariant::Solid => format!(
+            "background:{};color:#fff;border-radius:{}px;",
+            color, theme.joy.radius
+        ),
+        ButtonVariant::Soft => format!(
+            "background:{}33;color:{};border-radius:{}px;",
+            color, color, theme.joy.radius
+        ),
+        ButtonVariant::Outlined => format!(
+            "color:{};border:1px solid {};background:transparent;border-radius:{}px;",
+            color, color, theme.joy.radius
+        ),
+        ButtonVariant::Plain => format!(
+            "color:{};background:transparent;border-radius:{}px;",
+            color, theme.joy.radius
+        ),
+    };
+    let onclick = props.onclick.clone();
+    html! { <button style={style} onclick={onclick}>{ &props.label }</button> }
+}

--- a/crates/mui-joy/src/lib.rs
+++ b/crates/mui-joy/src/lib.rs
@@ -1,0 +1,10 @@
+//! Joy UI component library.
+//!
+//! This crate mirrors the structure of `mui-material` but implements
+//! components and tokens from the Joy design system. The goal is to provide
+//! a fully typed Rust API that can scale with additional components.
+
+pub mod button;
+pub mod macros;
+
+pub use button::{Button, ButtonColor, ButtonProps, ButtonVariant};

--- a/crates/mui-joy/src/macros.rs
+++ b/crates/mui-joy/src/macros.rs
@@ -1,0 +1,29 @@
+//! Helper macros for defining Joy UI component props and enums.
+
+/// Generates a `yew::Properties` struct with `Default` implementation and
+/// automatic `#[prop_or_default]` markers for ergonomics.
+#[macro_export]
+macro_rules! joy_props {
+    ($name:ident { $( $(#[$meta:meta])* $field:ident : $ty:ty ),* $(,)? }) => {
+        #[cfg(feature = "yew")]
+        #[derive(yew::Properties, Clone, PartialEq, Default)]
+        pub struct $name {
+            $( $(#[$meta])* #[prop_or_default] pub $field: $ty, )*
+        }
+    };
+}
+
+/// Declares a simple enum and implements `Default` for the first variant.
+#[macro_export]
+macro_rules! joy_enum {
+    ($name:ident { $first:ident $(, $rest:ident)* $(,)? }) => {
+        #[derive(Clone, PartialEq)]
+        pub enum $name {
+            $first,
+            $( $rest, )*
+        }
+        impl Default for $name {
+            fn default() -> Self { Self::$first }
+        }
+    };
+}

--- a/crates/mui-joy/tests/wasm.rs
+++ b/crates/mui-joy/tests/wasm.rs
@@ -1,0 +1,39 @@
+use mui_joy::Button;
+use mui_system::theme_provider::ThemeProvider;
+use mui_system::Theme;
+use wasm_bindgen_test::*;
+use yew::prelude::*;
+use yew::Renderer;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn button_clicks_increment() {
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        let count = use_state(|| 0);
+        let onclick = {
+            let count = count.clone();
+            Callback::from(move |_| count.set(*count + 1))
+        };
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <Button label="Add" {onclick} />
+                <div id="count">{*count}</div>
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+
+    let button = mount.query_selector("button").unwrap().unwrap();
+    let event = web_sys::Event::new("click").unwrap();
+    button.dispatch_event(&event).unwrap();
+
+    let count = mount.query_selector("#count").unwrap().unwrap();
+    assert_eq!(count.text_content().unwrap(), "1");
+}

--- a/crates/mui-system/src/theme.rs
+++ b/crates/mui-system/src/theme.rs
@@ -13,8 +13,10 @@ pub struct Theme {
     pub spacing: u16,
     /// Responsive breakpoints measured in pixels.
     pub breakpoints: Breakpoints,
-    /// Primary and secondary colors expressed as hex strings.
+    /// Primary, secondary and extended palette colors expressed as hex strings.
     pub palette: Palette,
+    /// Joy specific design tokens such as corner radius.
+    pub joy: JoyTokens,
 }
 
 impl Default for Theme {
@@ -23,6 +25,7 @@ impl Default for Theme {
             spacing: 8,
             breakpoints: Breakpoints::default(),
             palette: Palette::default(),
+            joy: JoyTokens::default(),
         }
     }
 }
@@ -61,6 +64,10 @@ impl Default for Breakpoints {
 pub struct Palette {
     pub primary: String,
     pub secondary: String,
+    /// Neutral color used by Joy components.
+    pub neutral: String,
+    /// Danger color used by Joy components.
+    pub danger: String,
 }
 
 impl Default for Palette {
@@ -68,7 +75,22 @@ impl Default for Palette {
         Self {
             primary: "#1976d2".to_string(),
             secondary: "#dc004e".to_string(),
+            neutral: "#64748b".to_string(),
+            danger: "#d32f2f".to_string(),
         }
+    }
+}
+
+/// Joy specific design tokens that do not exist in the core Material theme.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct JoyTokens {
+    /// Default corner radius applied to Joy components.
+    pub radius: u8,
+}
+
+impl Default for JoyTokens {
+    fn default() -> Self {
+        Self { radius: 4 }
     }
 }
 
@@ -81,6 +103,9 @@ mod tests {
         let theme = Theme::default();
         // Verify spacing helper
         assert_eq!(theme.spacing(2), 16);
+        // Joy tokens available
+        assert_eq!(theme.joy.radius, 4);
+        assert_eq!(theme.palette.neutral, "#64748b");
 
         // Round trip through JSON to ensure `serde` wiring is correct
         let json = serde_json::to_string(&theme).expect("serialize");


### PR DESCRIPTION
## Summary
- add new `mui-joy` crate with Joy design button and macros
- extend theme with Joy palette colors and radius tokens
- provide example and wasm-based interaction test for Joy button

## Testing
- `cargo test -p mui-system`
- `cargo test -p mui-joy --features yew` *(test harness runs but wasm tests require a WebAssembly runner)*

------
https://chatgpt.com/codex/tasks/task_e_68c6351bc2c0832e9aa978e54eac16f0