### PR TITLE
feat: add experimental mui-lab crate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Here are a few guidelines that will help you along the way.
 - [Contributing to the documentation](#contributing-to-the-documentation)
   - [How to find docs issues to work on](#how-to-find-docs-issues-to-work-on)
   - [How to add a new demo to the docs](#how-to-add-a-new-demo-to-the-docs)
+- [Experimental features](#experimental-features)
 - [How can I use a change that hasn't been released yet?](#how-can-i-use-a-change-that-hasnt-been-released-yet)
 - [Roadmap](#roadmap)
 - [License](#license)
@@ -325,6 +326,16 @@ Add a header and a brief description of the demo and its use case, along with th
 Now you're ready to [open a PR](#sending-a-pull-request) to add your new demo to the docs.
 
 Check out [this Toggle Button demo PR](https://github.com/mui/material-ui/pull/19582/files) for an example of what your new and edited files should look like when opening your own demo PR.
+
+## Experimental features
+
+The `mui-lab` crate contains opt-in, unstable widgets. When proposing changes to these components:
+
+- Gate new functionality behind a dedicated Cargo feature.
+- Include unit tests that cover localization and keyboard navigation.
+- Document the feature in `crates/mui-lab/README.md` so other users know how to try it out.
+
+Expect rapid iteration and potentially breaking changes as feedback is incorporated.
 
 ## How can I use a change that hasn't been released yet?
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +222,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +451,15 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive-where"
@@ -1099,6 +1134,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mui-lab"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "mui-material"
 version = "0.1.0"
 dependencies = [
@@ -1690,6 +1759,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -1873,6 +1948,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2617,6 +2698,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,10 +3210,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/mui-icons-material",
     "crates/mui-utils",
     "crates/mui-joy",
+    "crates/mui-lab",
 ]
 
 # Use Cargo's second feature resolver so optional dependencies don't
@@ -73,6 +74,8 @@ once_cell = "1.21.3"
 proptest = "1.2"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["Window", "HtmlElement", "Event", "EventTarget"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 
 [profile.dev]
 # Development builds prioritize compile time over runtime performance.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Keep in mind that the maintainers are primarily focused on other projects and ma
 
 View the [Joy UI documentation](https://mui.com/joy-ui/getting-started/).
 
+## MUI Lab (Rust)
+
+This repository also includes `mui-lab`, a crate that houses
+experimental widgets for the Rust port.  The APIs are feature gated and
+unstable; expect breaking changes.  See `crates/mui-lab/README.md` for
+contribution guidelines and current status.
+
 ## Sponsors
 
 ### Diamond 💎

--- a/crates/mui-lab/Cargo.toml
+++ b/crates/mui-lab/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "mui-lab"
+version = "0.1.0"
+edition = "2021"
+description = "Experimental widgets for MUI Rust. These APIs are unstable and subject to change."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+once_cell.workspace = true
+serde.workspace = true
+
+# Optional date/time backends
+chrono = { workspace = true, optional = true }
+time = { workspace = true, optional = true }
+
+[features]
+default = []
+# Enable experimental widgets individually to keep compile times lean.
+date-picker = []
+time-picker = []
+# Features toggling which date library backing to use.
+chrono = ["dep:chrono"]
+time = ["dep:time"]
+
+[dev-dependencies]
+# Use chrono in tests for deterministic date math.
+chrono = { workspace = true }

--- a/crates/mui-lab/README.md
+++ b/crates/mui-lab/README.md
@@ -1,0 +1,22 @@
+# MUI Lab (Rust)
+
+Experimental widgets for the Rust port of Material UI.  APIs in this crate are
+**unstable** and may change at any time.  Each component is guarded behind a
+Cargo feature so that consumers explicitly opt in to new widgets.
+
+## Stability
+
+The code in this crate is considered pre-production and is not covered by the
+standard SemVer guarantees.  Breaking changes may land in any release.  Use it
+at your own risk and pin versions accordingly.
+
+## Contributing
+
+Community contributions are welcome!  To minimize churn:
+
+- Gate new experimental widgets behind a dedicated Cargo feature.
+- Include thorough unit tests covering localization and keyboard navigation.
+- Provide locale packs via `LocalizationProvider` so the community can share
+  translations.
+- Document any new feature in this README before submitting a pull request.
+

--- a/crates/mui-lab/src/adapters.rs
+++ b/crates/mui-lab/src/adapters.rs
@@ -1,0 +1,63 @@
+//! Trait-based date API so widgets can remain agnostic about the
+//! underlying date/time library.  This mirrors the adapter pattern used
+//! in the upstream MUI project and enables the community to plug in their
+//! preferred chrono or time implementation without code changes.
+
+/// Abstraction over a date library.
+pub trait DateAdapter {
+    /// Concrete date type used by the adapter.
+    type Date: Clone + PartialEq + core::fmt::Debug;
+
+    /// Returns today's date according to the adapter.
+    fn today(&self) -> Self::Date;
+
+    /// Adds the specified number of days to `date`.
+    fn add_days(&self, date: &Self::Date, days: i32) -> Self::Date;
+
+    /// Formats the date into a user visible string using the adapter's
+    /// default locale.
+    fn format(&self, date: &Self::Date) -> String;
+}
+
+/// Adapter powered by the `chrono` crate.
+#[cfg(feature = "chrono")]
+pub struct AdapterChrono;
+
+#[cfg(feature = "chrono")]
+impl DateAdapter for AdapterChrono {
+    type Date = chrono::NaiveDate;
+
+    fn today(&self) -> Self::Date {
+        chrono::Local::now().date_naive()
+    }
+
+    fn add_days(&self, date: &Self::Date, days: i32) -> Self::Date {
+        *date + chrono::Duration::days(days as i64)
+    }
+
+    fn format(&self, date: &Self::Date) -> String {
+        date.to_string()
+    }
+}
+
+/// Adapter powered by the `time` crate.
+#[cfg(feature = "time")]
+pub struct AdapterTime;
+
+#[cfg(feature = "time")]
+impl DateAdapter for AdapterTime {
+    type Date = time::Date;
+
+    fn today(&self) -> Self::Date {
+        time::OffsetDateTime::now_utc().date()
+    }
+
+    fn add_days(&self, date: &Self::Date, days: i32) -> Self::Date {
+        *date + time::Duration::days(days as i64)
+    }
+
+    fn format(&self, date: &Self::Date) -> String {
+        date.to_string()
+    }
+}
+

--- a/crates/mui-lab/src/date_picker.rs
+++ b/crates/mui-lab/src/date_picker.rs
@@ -1,0 +1,45 @@
+//! Minimal date picker used for tests and as a reference implementation.
+//! Real applications are expected to build richer UIs on top of the core
+//! logic showcased here.
+
+use crate::adapters::DateAdapter;
+
+/// Keyboard keys handled by the picker.  Limited to left/right for
+/// demonstration purposes.
+#[derive(Debug, Clone, Copy)]
+pub enum Key {
+    Left,
+    Right,
+}
+
+/// Extremely small date picker that only tracks the selected date.
+/// In a real widget this would manage focus, overlays and rendering but
+/// here we keep it intentionally tiny so tests run fast and contributors
+/// can understand the code quickly.
+pub struct DatePicker<A: DateAdapter> {
+    /// Adapter powering all date math and formatting.
+    pub adapter: A,
+    /// Currently selected date.
+    pub selected: A::Date,
+}
+
+impl<A: DateAdapter> DatePicker<A> {
+    /// Creates a new picker starting at today's date.
+    pub fn new(adapter: A) -> Self {
+        let today = adapter.today();
+        Self {
+            adapter,
+            selected: today,
+        }
+    }
+
+    /// Handles a keyboard event by moving the selection.
+    pub fn handle_key(&mut self, key: Key) {
+        let delta = match key {
+            Key::Left => -1,
+            Key::Right => 1,
+        };
+        self.selected = self.adapter.add_days(&self.selected, delta);
+    }
+}
+

--- a/crates/mui-lab/src/lib.rs
+++ b/crates/mui-lab/src/lib.rs
@@ -1,0 +1,21 @@
+//! Experimental widgets for the Rust port of Material UI.
+//!
+//! This crate hosts pre-release components that require real world
+//! feedback before graduating into the stable crates.  Each module is
+//! guarded behind a Cargo feature flag to keep compile times lean and to
+//! signal the unstable nature of the APIs.
+//!
+//! The design favors pluggable abstractions (e.g. [`DateAdapter`]) so
+//! downstream applications can swap implementations without touching
+//! widget logic.  This is intended to scale to enterprise grade usage
+//! where different teams may standardize on different date/time crates.
+
+pub mod adapters;
+pub mod localization;
+
+#[cfg(feature = "date-picker")]
+pub mod date_picker;
+
+#[cfg(feature = "time-picker")]
+pub mod time_picker;
+

--- a/crates/mui-lab/src/localization.rs
+++ b/crates/mui-lab/src/localization.rs
@@ -1,0 +1,91 @@
+//! Runtime locale management inspired by MUI's `LocalizationProvider`.
+//! Consumers can register locale packs at startup and widgets will pull
+//! the appropriate translations dynamically.  This keeps translation
+//! responsibilities decoupled from rendering logic and scales to large
+//! applications maintained by many teams.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use once_cell::sync::Lazy;
+
+use crate::adapters::DateAdapter;
+
+/// Trait representing a bundle of localized strings and formatting rules.
+/// The trait is object safe so locale packs can be stored behind `dyn`.
+pub trait LocalePack: Send + Sync {
+    /// Returns the BCP-47 locale code (e.g. `en-US`).
+    fn code(&self) -> &'static str;
+
+    /// Formats a preformatted ISO date string.  The adapter is responsible
+    /// for generating the base representation.
+    fn format_date(&self, iso: &str) -> String;
+}
+
+/// Global registry of locale packs.  Community crates can register their
+/// translations at runtime.
+static LOCALES: Lazy<RwLock<HashMap<String, Box<dyn LocalePack>>>> = Lazy::new(|| {
+    RwLock::new(HashMap::new())
+});
+
+/// Registers a locale pack.  Existing registrations are overwritten so
+/// version bumps can replace outdated translations automatically.
+pub fn register_locale<L: LocalePack + 'static>(locale: L) {
+    LOCALES
+        .write()
+        .expect("locale registry poisoned")
+        .insert(locale.code().to_string(), Box::new(locale));
+}
+
+/// Provider used by widgets to access locale data.
+pub struct LocalizationProvider {
+    locale: String,
+}
+
+impl LocalizationProvider {
+    /// Creates a provider for the given locale if it was registered.
+    pub fn new(locale: &str) -> Option<Self> {
+        if LOCALES
+            .read()
+            .expect("locale registry poisoned")
+            .contains_key(locale)
+        {
+            Some(Self {
+                locale: locale.to_string(),
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Formats a date using the locale pack and adapter.
+    pub fn format_date<A: DateAdapter>(&self, date: &A::Date, adapter: &A) -> String {
+        let iso = adapter.format(date);
+        LOCALES
+            .read()
+            .expect("locale registry poisoned")
+            .get(&self.locale)
+            .expect("locale not registered")
+            .format_date(&iso)
+    }
+}
+
+/// Basic English locale pack used as a fallback.
+pub struct EnUs;
+
+impl LocalePack for EnUs {
+    fn code(&self) -> &'static str {
+        "en-US"
+    }
+
+    fn format_date(&self, iso: &str) -> String {
+        iso.to_string()
+    }
+}
+
+/// Initializes the registry with the default English locale.  Tests call
+/// this to ensure a baseline environment.
+pub fn init_default_locales() {
+    register_locale(EnUs);
+}
+

--- a/crates/mui-lab/src/time_picker.rs
+++ b/crates/mui-lab/src/time_picker.rs
@@ -1,0 +1,13 @@
+//! Placeholder time picker demonstrating feature gating.  The full widget
+//! is intentionally minimal until real-world requirements surface.
+
+/// Simple struct representing a time picker. Additional functionality can
+/// be added incrementally as the community experiments with the API.
+pub struct TimePicker;
+
+impl TimePicker {
+    pub fn new() -> Self {
+        TimePicker
+    }
+}
+

--- a/crates/mui-lab/tests/lab.rs
+++ b/crates/mui-lab/tests/lab.rs
@@ -1,0 +1,43 @@
+use mui_lab::adapters::{AdapterChrono, DateAdapter};
+use mui_lab::date_picker::{DatePicker, Key};
+use mui_lab::localization::{init_default_locales, register_locale, LocalizationProvider, LocalePack};
+
+/// Custom locale used to prove that the provider can be extended at
+/// runtime by the community.
+struct CustomLocale;
+
+impl LocalePack for CustomLocale {
+    fn code(&self) -> &'static str {
+        "test"
+    }
+
+    fn format_date(&self, iso: &str) -> String {
+        format!("test:{iso}")
+    }
+}
+
+#[test]
+fn localization_supports_custom_locale() {
+    init_default_locales();
+    register_locale(CustomLocale);
+
+    let adapter = AdapterChrono;
+    let provider = LocalizationProvider::new("test").expect("locale registered");
+    let date = adapter.today();
+    assert_eq!(
+        provider.format_date(&date, &adapter),
+        format!("test:{}", adapter.format(&date))
+    );
+}
+
+#[test]
+fn keyboard_navigation_moves_selection() {
+    init_default_locales();
+    let adapter = AdapterChrono;
+    let mut picker = DatePicker::new(adapter);
+    let start = picker.selected.clone();
+    picker.handle_key(Key::Left);
+    let expected = picker.adapter.add_days(&start, -1);
+    assert_eq!(picker.selected, expected);
+}
+


### PR DESCRIPTION
## Summary
- add `mui-lab` crate for feature-gated experimental widgets
- introduce trait-based date adapter and localization provider
- document experimental contribution guidelines and add tests for localization and keyboard navigation

## Testing
- `cargo test -p mui-lab --features "date-picker chrono"`


------
https://chatgpt.com/codex/tasks/task_e_68c63900bfa0832eaed8cdb389c6b441