### PR TITLE
docs: add Rust guide and Yew example

### DIFF
--- a/.github/workflows/rust-docs.yml
+++ b/.github/workflows/rust-docs.yml
@@ -1,0 +1,49 @@
+name: Rust Documentation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.36'
+      - name: Build API docs
+        run: cargo doc --no-deps --all
+      - name: Build mdBook guide
+        run: |
+          mdbook build docs/rust-book
+          mkdir -p public/api
+          cp -r target/doc/* public/api/
+          cp -r docs/rust-book/book/* public/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: docs
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ packed
 
 # Rust build artifacts
 /target
+
+docs/rust-book/book/

--- a/crates/mui-system/src/grid.rs
+++ b/crates/mui-system/src/grid.rs
@@ -19,9 +19,16 @@ pub struct GridProps {
     pub children: Children,
 }
 
+/// Render a grid item as a `<div>` with a calculated percentage width.
+///
+/// Using percentages keeps the layout responsive without forcing the browser
+/// to recalculate layout on every resize event.  The function component keeps
+/// the render path simple and therefore easy to inline by the optimizer.
 #[function_component(Grid)]
 pub fn grid(props: &GridProps) -> Html {
+    // Convert the span to a percentage so it scales with the parent container.
     let width = grid_span_to_percent(props.span, props.columns);
+    // Merge caller supplied styles with the computed width.
     let style = format!("{}width:{}%;", props.style, width);
     html! { <div style={style}>{ for props.children.iter() }</div> }
 }

--- a/docs/rust-book/book.toml
+++ b/docs/rust-book/book.toml
@@ -1,0 +1,11 @@
+[book]
+title = "MUI Rust Guide"
+description = "Rust-first documentation for building interfaces with MUI crates."
+authors = ["MUI Contributors"]
+language = "en"
+
+[build]
+build-dir = "book"
+
+[output.html]
+default-theme = "rust"

--- a/docs/rust-book/src/SUMMARY.md
+++ b/docs/rust-book/src/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Introduction](./introduction.md)
+- [Migrating from React](./migration.md)

--- a/docs/rust-book/src/introduction.md
+++ b/docs/rust-book/src/introduction.md
@@ -1,0 +1,13 @@
+# Introduction
+
+Welcome to the **MUI Rust Guide**.  This `mdBook` offers Rust-first guidance on
+building user interfaces with the `mui-*` crates.  The content is designed to be
+automatically generated and kept in sync with the code base.
+
+```bash
+# Build the book and open it locally
+mdbook build docs/rust-book && xdg-open docs/rust-book/book/index.html
+```
+
+The book complements the API documentation produced by `cargo doc` and is
+published alongside it from continuous integration.

--- a/docs/rust-book/src/migration.md
+++ b/docs/rust-book/src/migration.md
@@ -1,0 +1,23 @@
+# Migrating from React/JS to Rust WebAssembly
+
+Many teams start with a React application and gradually move performance
+critical paths to Rust compiled to WebAssembly.  The `mui-*` crates expose the
+same design vocabulary as their JavaScript counterparts which makes the
+migration incremental.
+
+1. **Identify hot components** – profiler output in React often reveals the
+   components that dominate runtime.  Re‑implement these in a Rust framework
+   such as [Yew](https://yew.rs) or [Leptos](https://leptos.dev) and compile to
+   WebAssembly using `wasm-bindgen`.
+2. **Share styles and themes** – the `Theme` structure is serializable with
+   `serde`, allowing existing JSON theme definitions to be reused directly in
+   Rust.
+3. **Leverage cargo workspaces** – colocate Rust crates and JavaScript packages
+   in a single repository.  Automated scripts can build both via CI ensuring the
+   generated assets stay in lock‑step.
+4. **Deploy static artifacts** – `trunk build --release` produces an optimized
+   WebAssembly binary.  Serve it from a CDN alongside the `cargo doc` output for
+   near‑zero runtime overhead and effortless horizontal scaling.
+
+> Tip: WebAssembly modules are immutable and cacheable.  Enable HTTP cache
+> headers so repeat visitors avoid re‑downloading the module.

--- a/examples/mui-yew/Cargo.toml
+++ b/examples/mui-yew/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mui-yew-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+yew.workspace = true
+mui-system = { path = "../../crates/mui-system", features = ["yew"] }

--- a/examples/mui-yew/README.md
+++ b/examples/mui-yew/README.md
@@ -1,0 +1,22 @@
+# MUI Yew Example
+
+This example demonstrates how to combine the `mui-system` crate with the
+[Yew](https://yew.rs) framework.  It is configured for production builds so the
+output can be served from a static host or CDN.
+
+## Development
+
+```bash
+trunk serve --open
+```
+
+## Production
+
+```bash
+trunk build --release
+# Deploy the `dist/` directory behind a CDN such as Vercel or Cloudflare
+# Workers for globally distributed hosting.
+```
+
+The release build enables `wasm-opt` by default which keeps the WebAssembly
+binary small and fast to download.

--- a/examples/mui-yew/Trunk.toml
+++ b/examples/mui-yew/Trunk.toml
@@ -1,0 +1,5 @@
+[build]
+release = true
+
+[serve]
+port = 8080

--- a/examples/mui-yew/index.html
+++ b/examples/mui-yew/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>MUI Yew Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- Trunk will replace this link with the compiled WebAssembly module -->
+    <link data-trunk rel="rust" href="Cargo.toml" />
+  </body>
+</html>

--- a/examples/mui-yew/src/main.rs
+++ b/examples/mui-yew/src/main.rs
@@ -1,0 +1,19 @@
+use yew::prelude::*;
+use mui_system::Box;
+
+/// Entry component showcasing a minimal Material UI setup in Yew.
+/// The example favors static generation via `trunk build --release`
+/// which yields a tiny, cacheable WebAssembly artifact.
+#[function_component(App)]
+fn app() -> Html {
+    html! {
+        <Box style="padding:1rem;">
+            <p>{ "Hello from Yew + MUI!" }</p>
+        </Box>
+    }
+}
+
+fn main() {
+    // Mount the application to the document body.
+    yew::Renderer::<App>::new().render();
+}

--- a/scripts/build-rust-docs.sh
+++ b/scripts/build-rust-docs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Compile API docs and the mdBook guide in one step.
+# Usage: ./scripts/build-rust-docs.sh
+set -e
+
+cargo doc --no-deps --all
+mdbook build docs/rust-book


### PR DESCRIPTION
## Summary
- add `mdBook` powered Rust guide with JS→Wasm migration notes
- provide Yew example showcasing scalable deployment
- wire up CI job and script to publish `cargo doc` and guide to GitHub Pages

## Testing
- `mdbook build docs/rust-book`
- `cargo doc --no-deps -p mui-utils`
- `cargo doc --no-deps -p mui-system`
- `cargo test -p mui-utils`
- `cargo test -p mui-system`


------
https://chatgpt.com/codex/tasks/task_e_68c647199c78832eaf89daa88487c4d3