### PR TITLE
feat(joy): add card, chip, aspect-ratio and theme tokens

### DIFF
--- a/crates/mui-joy/README.md
+++ b/crates/mui-joy/README.md
@@ -5,16 +5,36 @@ Experimental Joy UI component library for Rust.
 This crate mirrors the `mui-material` crate but targets the Joy design
 language.  It showcases how additional design tokens such as `neutral` and
 `danger` palette colors or corner `radius` can be modeled in Rust.
+Shared enums and macros keep component props consistent and reduce manual
+boilerplate when authoring new widgets.
 
 ## Differences from Material
 
 * Extra palette colors: `neutral` and `danger`.
-* Joy specific tokens grouped under `Theme::joy` like `radius` for rounded
-  corners.
-* Component variants `solid`, `soft`, `outlined`, and `plain`.
+* Joy specific tokens grouped under `Theme::joy` such as `radius` and
+  `focus_thickness` which have no Material equivalents.
+* Component variants `solid`, `soft`, `outlined`, and `plain` shared across
+  multiple components via macros.
+
+## Usage
+
+```rust
+use mui_joy::{Button, Card, Chip, Color, Variant};
+
+let button = html! { <Button label="Save" color={Color::Primary} /> };
+```
+
+## Migration from Material
+
+Material components use `color`/`variant` patterns but the available values
+are different. Joy's `Color` adds `Neutral` and `Danger`, while `Variant`
+expands to `Soft` and `Plain`. When moving from Material simply switch to the
+`Color` and `Variant` enums exported by this crate and reference any Joy
+specific tokens through `Theme::joy`.
 
 ## Examples
 
 ```bash
 cargo run -p mui-joy --example button --features yew
+cargo run -p mui-joy --example card --features yew
 ```

--- a/crates/mui-joy/examples/button.rs
+++ b/crates/mui-joy/examples/button.rs
@@ -3,7 +3,7 @@
 //! Run with:
 //! `cargo run -p mui-joy --example button --features yew`
 
-use mui_joy::Button;
+use mui_joy::{Button, Color, Variant};
 use mui_system::theme_provider::ThemeProvider;
 use mui_system::Theme;
 use yew::prelude::*;
@@ -17,7 +17,7 @@ fn app() -> Html {
     };
     html! {
         <ThemeProvider theme={Theme::default()}>
-            <Button label="Add" {onclick} />
+            <Button label="Add" color={Color::Primary} variant={Variant::Solid} {onclick} />
             <p>{ format!("Clicks: {}", *count) }</p>
         </ThemeProvider>
     }

--- a/crates/mui-joy/examples/card.rs
+++ b/crates/mui-joy/examples/card.rs
@@ -1,0 +1,34 @@
+//! Demonstrates Card, Chip and AspectRatio components working together.
+//! Run with `cargo run -p mui-joy --example card --features yew`.
+
+use mui_joy::{AspectRatio, Card, Chip, Color, Variant};
+use mui_system::theme_provider::ThemeProvider;
+use mui_system::Theme;
+use yew::prelude::*;
+
+#[function_component(App)]
+fn app() -> Html {
+    let deleted = use_state(|| false);
+    let on_delete = {
+        let deleted = deleted.clone();
+        Callback::from(move |_| deleted.set(true))
+    };
+    html! {
+        <ThemeProvider theme={Theme::default()}>
+            <Card color={Color::Neutral} variant={Variant::Soft}>
+                <AspectRatio ratio={16.0 / 9.0}>
+                    <img src="https://via.placeholder.com/300" alt="placeholder" />
+                </AspectRatio>
+                { if !*deleted {
+                    html! { <Chip label="Deletable" on_delete={Some(on_delete)} /> }
+                } else {
+                    html! { <span>{"Deleted"}</span> }
+                }}
+            </Card>
+        </ThemeProvider>
+    }
+}
+
+fn main() {
+    yew::Renderer::<App>::new().render();
+}

--- a/crates/mui-joy/src/aspect_ratio.rs
+++ b/crates/mui-joy/src/aspect_ratio.rs
@@ -1,0 +1,29 @@
+use yew::prelude::*;
+
+use crate::joy_props;
+
+joy_props!(AspectRatioProps {
+    /// Desired width to height ratio (e.g. 16.0 / 9.0).
+    ratio: f32,
+    /// Child element rendered inside the constrained box.
+    children: Children,
+});
+
+/// Maintains a consistent width/height ratio for its child.
+///
+/// The component uses the classic padding-top hack so it works without any
+/// JavaScript and keeps layout calculations on the GPU.
+#[function_component(AspectRatio)]
+pub fn aspect_ratio(props: &AspectRatioProps) -> Html {
+    let padding = format!(
+        "padding-top:{}%;position:relative;width:100%;",
+        100.0 / props.ratio
+    );
+    html! {
+        <div style={padding}>
+            <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
+                { for props.children.iter() }
+            </div>
+        </div>
+    }
+}

--- a/crates/mui-joy/src/button.rs
+++ b/crates/mui-joy/src/button.rs
@@ -1,27 +1,12 @@
 use mui_system::theme_provider::use_theme;
 use yew::prelude::*;
 
-use crate::{joy_enum, joy_props};
+// Import shared enums and macros so all components stay aligned.
+use crate::{joy_component_props, Color, Variant};
 
-joy_enum!(ButtonColor {
-    Primary,
-    Neutral,
-    Danger
-});
-joy_enum!(ButtonVariant {
-    Solid,
-    Soft,
-    Outlined,
-    Plain
-});
-
-joy_props!(ButtonProps {
+joy_component_props!(ButtonProps {
     /// Text displayed inside the button.
     label: String,
-    /// Visual color scheme of the button.
-    color: ButtonColor,
-    /// Variant controlling the button's background and border.
-    variant: ButtonVariant,
     /// Click handler for interactive behavior.
     onclick: Callback<MouseEvent>,
 });
@@ -31,24 +16,24 @@ joy_props!(ButtonProps {
 pub fn button(props: &ButtonProps) -> Html {
     let theme = use_theme();
     let color = match props.color {
-        ButtonColor::Primary => theme.palette.primary.clone(),
-        ButtonColor::Neutral => theme.palette.neutral.clone(),
-        ButtonColor::Danger => theme.palette.danger.clone(),
+        Color::Primary => theme.palette.primary.clone(),
+        Color::Neutral => theme.palette.neutral.clone(),
+        Color::Danger => theme.palette.danger.clone(),
     };
     let style = match props.variant {
-        ButtonVariant::Solid => format!(
+        Variant::Solid => format!(
             "background:{};color:#fff;border-radius:{}px;",
             color, theme.joy.radius
         ),
-        ButtonVariant::Soft => format!(
+        Variant::Soft => format!(
             "background:{}33;color:{};border-radius:{}px;",
             color, color, theme.joy.radius
         ),
-        ButtonVariant::Outlined => format!(
+        Variant::Outlined => format!(
             "color:{};border:1px solid {};background:transparent;border-radius:{}px;",
             color, color, theme.joy.radius
         ),
-        ButtonVariant::Plain => format!(
+        Variant::Plain => format!(
             "color:{};background:transparent;border-radius:{}px;",
             color, theme.joy.radius
         ),

--- a/crates/mui-joy/src/card.rs
+++ b/crates/mui-joy/src/card.rs
@@ -1,0 +1,42 @@
+use mui_system::theme_provider::use_theme;
+use yew::prelude::*;
+
+use crate::{joy_component_props, Color, Variant};
+
+joy_component_props!(CardProps {
+    /// Nested content displayed within the card body.
+    children: Children,
+});
+
+/// Simple container mirroring Joy UI's Card component.
+///
+/// The implementation intentionally focuses on the core layout primitives
+/// so it can serve as a foundation for more advanced features such as
+/// headers, footers or media sections.
+#[function_component(Card)]
+pub fn card(props: &CardProps) -> Html {
+    let theme = use_theme();
+    // Resolve the color from the active theme's palette.
+    let color = match props.color {
+        Color::Primary => theme.palette.primary.clone(),
+        Color::Neutral => theme.palette.neutral.clone(),
+        Color::Danger => theme.palette.danger.clone(),
+    };
+    // Basic styling demonstrating Joy's variant system.
+    let style = match props.variant {
+        Variant::Solid => format!(
+            "background:{};padding:16px;border-radius:{}px;",
+            color, theme.joy.radius
+        ),
+        Variant::Soft => format!(
+            "background:{}33;padding:16px;border-radius:{}px;",
+            color, theme.joy.radius
+        ),
+        Variant::Outlined => format!(
+            "border:1px solid {};padding:16px;border-radius:{}px;",
+            color, theme.joy.radius
+        ),
+        Variant::Plain => format!("padding:16px;border-radius:{}px;", theme.joy.radius),
+    };
+    html! { <div style={style}>{ for props.children.iter() }</div> }
+}

--- a/crates/mui-joy/src/chip.rs
+++ b/crates/mui-joy/src/chip.rs
@@ -1,0 +1,44 @@
+use mui_system::theme_provider::use_theme;
+use yew::prelude::*;
+
+use crate::{joy_component_props, Color, Variant};
+
+joy_component_props!(ChipProps {
+    /// Text displayed within the chip.
+    label: String,
+    /// Optional handler invoked when the delete icon is clicked.
+    on_delete: Option<Callback<MouseEvent>>,
+});
+
+/// A small piece of information, often used as an input or tag.
+#[function_component(Chip)]
+pub fn chip(props: &ChipProps) -> Html {
+    let theme = use_theme();
+    let color = match props.color {
+        Color::Primary => theme.palette.primary.clone(),
+        Color::Neutral => theme.palette.neutral.clone(),
+        Color::Danger => theme.palette.danger.clone(),
+    };
+    let style = match props.variant {
+        Variant::Solid => format!(
+            "background:{};color:#fff;border-radius:{}px;padding:4px 8px;",
+            color, theme.joy.radius
+        ),
+        Variant::Soft => format!(
+            "background:{}33;color:{};border-radius:{}px;padding:4px 8px;",
+            color, color, theme.joy.radius
+        ),
+        Variant::Outlined => format!(
+            "border:1px solid {};color:{};border-radius:{}px;padding:4px 8px;",
+            color, color, theme.joy.radius
+        ),
+        Variant::Plain => format!(
+            "color:{};border-radius:{}px;padding:4px 8px;",
+            color, theme.joy.radius
+        ),
+    };
+    let delete_button = props.on_delete.as_ref().map(|cb| {
+        html! { <button style="margin-left:4px" onclick={cb.clone()}>{{"×"}}</button> }
+    });
+    html! { <span style={style}>{ &props.label }{ delete_button }</span> }
+}

--- a/crates/mui-joy/src/lib.rs
+++ b/crates/mui-joy/src/lib.rs
@@ -4,7 +4,14 @@
 //! components and tokens from the Joy design system. The goal is to provide
 //! a fully typed Rust API that can scale with additional components.
 
+pub mod aspect_ratio;
 pub mod button;
+pub mod card;
+pub mod chip;
 pub mod macros;
 
-pub use button::{Button, ButtonColor, ButtonProps, ButtonVariant};
+pub use aspect_ratio::{AspectRatio, AspectRatioProps};
+pub use button::{Button, ButtonProps};
+pub use card::{Card, CardProps};
+pub use chip::{Chip, ChipProps};
+pub use macros::{Color, Variant};

--- a/crates/mui-joy/src/macros.rs
+++ b/crates/mui-joy/src/macros.rs
@@ -27,3 +27,34 @@ macro_rules! joy_enum {
         }
     };
 }
+
+// Reusable enums shared across Joy components. Keeping them here ensures
+// a single source of truth so every component follows the same patterns.
+joy_enum!(Color {
+    Primary,
+    Neutral,
+    Danger
+});
+
+joy_enum!(Variant {
+    Solid,
+    Soft,
+    Outlined,
+    Plain
+});
+
+/// Helper macro building on [`joy_props!`] that pre-defines common `color`
+/// and `variant` fields shared by most Joy components. Additional fields can
+/// be supplied after these defaults.
+#[macro_export]
+macro_rules! joy_component_props {
+    ($name:ident { $( $(#[$meta:meta])* $field:ident : $ty:ty ),* $(,)? }) => {
+        crate::joy_props!($name {
+            /// Visual color scheme of the component.
+            color: Color,
+            /// Variant controlling background and border styles.
+            variant: Variant,
+            $( $(#[$meta])* $field : $ty, )*
+        });
+    };
+}

--- a/crates/mui-joy/tests/wasm.rs
+++ b/crates/mui-joy/tests/wasm.rs
@@ -1,4 +1,4 @@
-use mui_joy::Button;
+use mui_joy::{AspectRatio, Button, Chip, Color, Variant};
 use mui_system::theme_provider::ThemeProvider;
 use mui_system::Theme;
 use wasm_bindgen_test::*;
@@ -22,7 +22,7 @@ fn button_clicks_increment() {
         };
         html! {
             <ThemeProvider theme={Theme::default()}>
-                <Button label="Add" {onclick} />
+                <Button label="Add" color={Color::Primary} variant={Variant::Solid} {onclick} />
                 <div id="count">{*count}</div>
             </ThemeProvider>
         }
@@ -36,4 +36,57 @@ fn button_clicks_increment() {
 
     let count = mount.query_selector("#count").unwrap().unwrap();
     assert_eq!(count.text_content().unwrap(), "1");
+}
+
+#[wasm_bindgen_test]
+fn chip_delete_triggers_callback() {
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        let count = use_state(|| 0);
+        let on_delete = {
+            let count = count.clone();
+            Callback::from(move |_| count.set(*count + 1))
+        };
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <Chip label="Tag" on_delete={Some(on_delete)} />
+                <div id="count">{*count}</div>
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+
+    let btn = mount.query_selector("button").unwrap().unwrap();
+    let event = web_sys::Event::new("click").unwrap();
+    btn.dispatch_event(&event).unwrap();
+
+    let count = mount.query_selector("#count").unwrap().unwrap();
+    assert_eq!(count.text_content().unwrap(), "1");
+}
+
+#[wasm_bindgen_test]
+fn aspect_ratio_sets_padding() {
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <AspectRatio ratio={16.0 / 9.0}>
+                <img src="https://via.placeholder.com/160x90" alt="placeholder" />
+            </AspectRatio>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+
+    let outer = mount.first_element_child().unwrap();
+    let style = outer.get_attribute("style").unwrap();
+    assert!(style.contains("56.25%"));
 }

--- a/crates/mui-system/src/theme.rs
+++ b/crates/mui-system/src/theme.rs
@@ -15,7 +15,7 @@ pub struct Theme {
     pub breakpoints: Breakpoints,
     /// Primary, secondary and extended palette colors expressed as hex strings.
     pub palette: Palette,
-    /// Joy specific design tokens such as corner radius.
+    /// Joy specific design tokens such as corner radius and focus outlines.
     pub joy: JoyTokens,
 }
 
@@ -82,15 +82,23 @@ impl Default for Palette {
 }
 
 /// Joy specific design tokens that do not exist in the core Material theme.
+///
+/// They capture stylistic elements unique to Joy such as rounded corners and
+/// the thickness of focus indicators.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct JoyTokens {
     /// Default corner radius applied to Joy components.
     pub radius: u8,
+    /// Thickness in pixels of the default focus ring used for accessibility.
+    pub focus_thickness: u8,
 }
 
 impl Default for JoyTokens {
     fn default() -> Self {
-        Self { radius: 4 }
+        Self {
+            radius: 4,
+            focus_thickness: 2,
+        }
     }
 }
 
@@ -105,6 +113,7 @@ mod tests {
         assert_eq!(theme.spacing(2), 16);
         // Joy tokens available
         assert_eq!(theme.joy.radius, 4);
+        assert_eq!(theme.joy.focus_thickness, 2);
         assert_eq!(theme.palette.neutral, "#64748b");
 
         // Round trip through JSON to ensure `serde` wiring is correct


### PR DESCRIPTION
## Summary
- add Color/Variant enums and `joy_component_props!` macro for shared props
- implement `Card`, `Chip`, and `AspectRatio` components plus examples
- extend system theme with Joy-specific `focus_thickness` token

## Testing
- `cargo test -p mui-system`
- `cargo test -p mui-joy --features yew` *(no tests found)*
- `cargo test -p mui-joy --features yew --target wasm32-unknown-unknown` *(target missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d42c53e4832eb91fc0fa9bc24c3f