### PR TITLE
feat(styled-engine): add style registry and SSR provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,6 +1766,7 @@ dependencies = [
  "criterion",
  "mui-styled-engine-macros",
  "mui-system",
+ "proptest",
  "stylist",
  "wasm-bindgen",
  "yew",

--- a/crates/mui-styled-engine/Cargo.toml
+++ b/crates/mui-styled-engine/Cargo.toml
@@ -18,6 +18,7 @@ yew = ["mui-system/yew", "dep:yew", "dep:wasm-bindgen", "stylist/yew_integration
 
 [dev-dependencies]
 criterion = "0.5"
+proptest.workspace = true
 
 [[bench]]
 name = "style_bench"

--- a/crates/mui-styled-engine/src/context.rs
+++ b/crates/mui-styled-engine/src/context.rs
@@ -1,0 +1,81 @@
+//! Shared style registry used by Yew providers and SSR helpers.
+//!
+//! The registry owns both a [`Theme`] and an isolated [`StyleManager`]. The
+//! manager is backed by a writer/reader pair so that CSS rules generated during
+//! rendering can be flushed into `<style>` blocks.  Cloning the registry
+//! produces a shallow copy that shares the underlying manager allowing
+//! independent components to contribute styles while still aggregating them in a
+//! single place.
+//!
+//! The internal reader is protected by a [`Mutex`] to ensure thread-safety when
+//! style flushing happens concurrently (e.g. across async boundaries during
+//! server side rendering).  Each request should instantiate its own registry to
+//! avoid cross-request style leakage.  Once [`flush_styles`](StyleRegistry::flush_styles)
+//! is called, the accumulated style data is drained, making the type safe to
+//! reuse for subsequent renders.
+
+use std::sync::{Arc, Mutex};
+
+use stylist::manager::{render_static, StaticReader, StyleManager};
+
+use crate::Theme;
+
+/// Central style registry shared via Yew context.
+#[derive(Clone)]
+pub struct StyleRegistry {
+    /// Theme associated with this registry.  The theme is cloned for each
+    /// component render to prevent mutation across threads.
+    theme: Theme,
+    /// Manager that records all style rules.  [`StyleManager`] is internally
+    /// reference counted so cloning is cheap and thread-safe.
+    manager: StyleManager,
+    /// Reader side of the style channel.  Wrapped in a [`Mutex`] so multiple
+    /// threads can request style flushing concurrently without data races.
+    reader: Arc<Mutex<Option<StaticReader>>>, // when flushed styles are drained
+}
+
+impl PartialEq for StyleRegistry {
+    fn eq(&self, other: &Self) -> bool {
+        self.theme == other.theme
+    }
+}
+
+impl StyleRegistry {
+    /// Constructs a new registry with an isolated [`StyleManager`].
+    pub fn new(theme: Theme) -> Self {
+        let (writer, reader) = render_static();
+        let manager = StyleManager::builder()
+            .writer(writer)
+            .build()
+            .expect("create style manager");
+        Self {
+            theme,
+            manager,
+            reader: Arc::new(Mutex::new(Some(reader))),
+        }
+    }
+
+    /// Returns the [`Theme`] tied to this registry.
+    pub fn theme(&self) -> &Theme {
+        &self.theme
+    }
+
+    /// Provides a [`StyleManager`] clone for creating styles.
+    pub fn style_manager(&self) -> StyleManager {
+        self.manager.clone()
+    }
+
+    /// Drains all collected styles and returns them as `<style>` blocks suitable
+    /// for embedding into server rendered documents.
+    pub fn flush_styles(&self) -> String {
+        let mut out = String::new();
+        if let Ok(mut reader) = self.reader.lock() {
+            if let Some(r) = reader.take() {
+                r.read_style_data()
+                    .write_static_markup(&mut out)
+                    .expect("write styles");
+            }
+        }
+        out
+    }
+}

--- a/crates/mui-styled-engine/tests/registry_integration.rs
+++ b/crates/mui-styled-engine/tests/registry_integration.rs
@@ -1,0 +1,31 @@
+use mui_styled_engine::{StyleRegistry, Theme};
+use stylist::Style;
+
+/// Helper function simulating a nested component hierarchy where inner
+/// components also create styles.  All styles should end up in the same
+/// registry.
+fn inner_layer(registry: &StyleRegistry) {
+    Style::new_with_manager("background: blue;", registry.style_manager()).unwrap();
+}
+
+#[test]
+fn styles_are_scoped_per_registry() {
+    // First render with red + blue styles
+    let reg1 = StyleRegistry::new(Theme::default());
+    Style::new_with_manager("color: red;", reg1.style_manager()).unwrap();
+    inner_layer(&reg1);
+    let styles1 = reg1.flush_styles();
+    assert!(styles1.contains("color: red"));
+    assert!(styles1.contains("background: blue"));
+    assert!(
+        reg1.flush_styles().trim().is_empty(),
+        "styles leak after flush"
+    );
+
+    // Second render should not see previous styles
+    let reg2 = StyleRegistry::new(Theme::default());
+    Style::new_with_manager("color: green;", reg2.style_manager()).unwrap();
+    let styles2 = reg2.flush_styles();
+    assert!(styles2.contains("color: green"));
+    assert!(!styles2.contains("color: red"));
+}

--- a/crates/mui-styled-engine/tests/registry_prop.rs
+++ b/crates/mui-styled-engine/tests/registry_prop.rs
@@ -1,0 +1,19 @@
+use mui_styled_engine::{StyleRegistry, Theme};
+use proptest::prelude::*;
+use stylist::Style;
+
+proptest! {
+    /// Property-based test ensuring that arbitrary colors are flushed from the
+    /// registry and embedded into the resulting style blocks.  Randomized inputs
+    /// help catch any CSS escaping issues or stale cache references.
+    #[test]
+    fn collected_styles_contain_input(color in proptest::string::string_regex("#[0-9a-fA-F]{6}").unwrap()) {
+        let registry = StyleRegistry::new(Theme::default());
+        let css = format!("color: {color};");
+        Style::new_with_manager(css.clone(), registry.style_manager()).unwrap();
+        let out = registry.flush_styles();
+        prop_assert!(out.contains(&css));
+        // ensure flush drains accumulated styles
+        prop_assert!(registry.flush_styles().trim().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce StyleRegistry to hold Theme and StyleManager with safe flushing
- update StyledEngineProvider to share registry via context and expose flush_styles
- document SSR workflow and add tests for style collection isolation

## Testing
- `cargo test -p mui-styled-engine --features yew`

------
https://chatgpt.com/codex/tasks/task_e_68c6ee00eaf4832e850e9c98ee49d528