### PR TITLE
docs: add StyledEngineProvider automation guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,6 +358,8 @@ cargo xtask coverage     # Generate lcov.info via grcov
 cargo xtask bench        # Run Criterion benchmarks
 ```
 
+For automated style flushing, SSR rendering and variable auditing with `StyledEngineProvider`, see [docs/styled-engine/automation.md](docs/styled-engine/automation.md).
+
 The root `Makefile` delegates to these tasks (`make fmt`, `make test`, etc.)
 and the GitHub Actions workflow mirrors this setup. CI caches build artifacts
 and uploads coverage, documentation and benchmark reports as artifacts so that

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ make doc      # generate API docs
 
 These targets minimize manual steps and offer a single entry point for local development and CI.
 
+For end-to-end style orchestration that plays well with build pipelines and CI, see [docs/styled-engine/automation.md](docs/styled-engine/automation.md).
+
 ## Migrating from React/TypeScript
 
 Teams moving from React or TypeScript can leverage familiar patterns:

--- a/docs/styled-engine/automation.md
+++ b/docs/styled-engine/automation.md
@@ -1,0 +1,83 @@
+# Styled Engine Automation
+
+`StyledEngineProvider` orchestrates style injection for both client and server runtimes.  The snippets below show how to wire it into build pipelines, server‑side rendering (SSR) frameworks, and CI so that style generation, flushing, and auditing happen automatically with zero manual steps.
+
+## Build pipelines
+
+Automate style flushing and SSR output as part of the standard build.  Centralizing the logic in `cargo xtask` keeps the workflow reproducible for every contributor and for CI.
+
+```bash
+# Flush the style registry and write critical CSS to disk before packaging
+cargo xtask flush-styles
+
+# Pre-generate SSR HTML so deploys can ship static markup
+cargo xtask ssr-html --out dist/index.html
+```
+
+Example `xtask` implementation:
+
+```rust
+// crates/xtask/src/main.rs (excerpt)
+#[derive(Subcommand)]
+enum Commands {
+    /// Flush runtime style caches for deterministic builds.
+    FlushStyles,
+    /// Render the app to HTML using StyledEngineProvider and emit the file.
+    SsrHtml { out: PathBuf },
+    /// Scan compiled CSS variables to detect unused or missing entries.
+    AuditVars,
+}
+
+fn flush_styles() -> Result<()> {
+    // Execute the example that calls `StyledEngineProvider::flush_styles()`
+    run(Command::new("cargo").args(["run", "-p", "examples/mui-ssr-accessibility", "--example", "flush_styles"]))
+}
+
+fn ssr_html(out: PathBuf) -> Result<()> {
+    // Render to a file so both CI and local builds share identical HTML
+    run(Command::new("cargo").args(["run", "-p", "examples/mui-ssr-accessibility", "--release", "--", out.to_str().unwrap()]))
+}
+
+fn audit_vars() -> Result<()> {
+    // Placeholder: run a small binary that inspects generated CSS variables
+    run(Command::new("cargo").args(["run", "-p", "mui-styled-engine", "--example", "audit_vars"]))
+}
+```
+
+> **Note:** The commands above are deliberately thin wrappers so they can be reused in any build system.  They ensure a single source of truth for style artifacts and eliminate environment‑specific scripting.
+
+## SSR frameworks
+
+Frameworks like [Leptos](https://leptos.dev) or [Yew](https://yew.rs) can reuse the same tasks.  Wrap your root component with `StyledEngineProvider` and let the `ssr-html` subcommand produce deterministic markup.
+
+```rust
+use leptos::*;
+use mui_styled_engine::{StyleRegistry, StyledEngineProvider, Theme};
+
+pub fn app(cx: Scope) -> impl IntoView {
+    view! { cx,
+        <StyledEngineProvider theme=Theme::default()>/* app components */</StyledEngineProvider>
+    }
+}
+```
+
+Calling `cargo xtask ssr-html` now renders the snippet above to `dist/index.html` so the deployment step can publish it directly.
+
+## Continuous integration
+
+Include the automated tasks in your CI workflow to guarantee that every pull request produces vetted style artifacts.
+
+```yaml
+# .github/workflows/ci.yml
+steps:
+  - uses: actions/checkout@v4
+  - uses: actions-rs/toolchain@v1
+    with:
+      toolchain: stable
+  - run: cargo xtask fmt --check
+  - run: cargo xtask flush-styles
+  - run: cargo xtask ssr-html --out dist/index.html
+  - run: cargo xtask audit-vars
+```
+
+The CI configuration above executes the exact same commands contributors run locally, ensuring that style caches, SSR output, and variable audits remain consistent across environments without bespoke scripts.


### PR DESCRIPTION
## Summary
- document StyledEngineProvider automation for build pipelines, SSR and CI
- link guide from README and contributing docs to centralize workflow

## Testing
- `cargo xtask fmt --check` *(fails: command "cargo" "fmt" "--all" "--" "--check" failed)*
- `cargo xtask test` *(fails: doctest failed in crates/mui-system)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f6f46fec832e945438582e2b592a