### PR TITLE
feat(mui-system): typed style helpers and cross-framework primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "web-sys",
  "yew",
 ]
 

--- a/crates/mui-system/Cargo.toml
+++ b/crates/mui-system/Cargo.toml
@@ -15,14 +15,15 @@ serde_json.workspace = true
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+web-sys = { workspace = true, optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test.workspace = true
 
 [features]
 default = []
-yew = ["dep:yew", "dep:wasm-bindgen"]
-leptos = ["dep:leptos", "dep:wasm-bindgen"]
+yew = ["dep:yew", "dep:wasm-bindgen", "dep:web-sys"]
+leptos = ["dep:leptos", "dep:wasm-bindgen", "dep:web-sys"]
 
 [[example]]
 name = "basic"

--- a/crates/mui-system/README.md
+++ b/crates/mui-system/README.md
@@ -8,13 +8,16 @@ runtime configuration.
 ## Usage
 
 ```rust
-use mui_system::{Box, Stack, style_props};
+use mui_system::{Box, Stack, style_props, ThemeProvider, Theme};
 # #[cfg(feature = "yew")]
 # fn render() -> yew::Html {
+let theme = Theme::default();
 html! {
-    <Stack spacing={Some("8px".into())}>
-        <Box style={style_props!{ padding: "4px" }}>{"Item"}</Box>
-    </Stack>
+    <ThemeProvider theme={theme}>
+        <Stack spacing={Some("8px".into())} justify_content={Some("center".into())}>
+            <Box sx={style_props!{ padding: "4px" }}>{"Item"}</Box>
+        </Stack>
+    </ThemeProvider>
 }
 # }
 ```

--- a/crates/mui-system/src/box.rs
+++ b/crates/mui-system/src/box.rs
@@ -1,23 +1,111 @@
-#![cfg(feature = "yew")]
-use yew::prelude::*;
+use crate::{responsive::Responsive, style, theme::Theme};
+use crate::theme_provider::use_theme;
 
-/// Lightweight wrapper around a `div` that accepts style properties.
-///
-/// Combine with the [`style_props!`](crate::style_props) macro to build the
-/// `style` string in a concise and type‑checked manner.
-#[derive(Properties, PartialEq)]
-pub struct BoxProps {
-    /// Inline CSS style string typically generated via the `style_props!` macro.
-    #[prop_or_default]
-    pub style: String,
-    /// Child elements to render inside the container.
-    #[prop_or_default]
-    pub children: Children,
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use web_sys::window;
+    use yew::prelude::*;
+
+    /// Lightweight wrapper around a `div` that accepts system style properties.
+    #[derive(Properties, PartialEq)]
+    pub struct BoxProps {
+        /// Responsive margin shorthand. Values cascade from `xs` upwards.
+        #[prop_or_default]
+        pub m: Option<Responsive<String>>,
+        /// Responsive padding shorthand.
+        #[prop_or_default]
+        pub p: Option<Responsive<String>>,
+        /// Optional `display` style.
+        #[prop_or_default]
+        pub display: Option<String>,
+        /// Flexbox alignment of children on the cross axis.
+        #[prop_or_default]
+        pub align_items: Option<String>,
+        /// Flexbox alignment of children on the main axis.
+        #[prop_or_default]
+        pub justify_content: Option<String>,
+        /// Raw style string allowing arbitrary `sx` values.
+        #[prop_or_default]
+        pub sx: String,
+        /// Elements to render inside the box.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    #[function_component(Box)]
+    pub fn box_component(props: &BoxProps) -> Html {
+        let theme = use_theme();
+        let width = window()
+            .and_then(|w| w.inner_width().ok())
+            .and_then(|v| v.as_f64().ok())
+            .unwrap_or(0.0) as u32;
+        let mut style_string = String::new();
+        if let Some(m) = &props.m {
+            style_string.push_str(&style::margin(m.resolve(width, &theme.breakpoints)));
+        }
+        if let Some(p) = &props.p {
+            style_string.push_str(&style::padding(p.resolve(width, &theme.breakpoints)));
+        }
+        if let Some(d) = &props.display {
+            style_string.push_str(&style::display(d.clone()));
+        }
+        if let Some(ai) = &props.align_items {
+            style_string.push_str(&style::align_items(ai.clone()));
+        }
+        if let Some(jc) = &props.justify_content {
+            style_string.push_str(&style::justify_content(jc.clone()));
+        }
+        style_string.push_str(&props.sx);
+        html! { <div style={style_string}>{ for props.children.iter() }</div> }
+    }
 }
 
-/// Basic building block analogous to the `Box` component from MUI's JS
-/// ecosystem. Additional props and behaviors can be layered on over time.
-#[function_component(Box)]
-pub fn box_component(props: &BoxProps) -> Html {
-    html! { <div style={props.style.clone()}>{ for props.children.iter() }</div> }
+#[cfg(feature = "yew")]
+pub use yew_impl::{Box, BoxProps};
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::*;
+    use web_sys::window;
+
+    /// Leptos version of [`Box`] sharing the same props as the Yew variant.
+    #[component]
+    pub fn Box(
+        #[prop(optional)] m: Option<Responsive<String>>,
+        #[prop(optional)] p: Option<Responsive<String>>,
+        #[prop(optional, into)] display: Option<String>,
+        #[prop(optional, into)] align_items: Option<String>,
+        #[prop(optional, into)] justify_content: Option<String>,
+        #[prop(optional, into)] sx: String,
+        children: Children,
+    ) -> impl IntoView {
+        let theme = use_theme();
+        let width = window()
+            .and_then(|w| w.inner_width().ok())
+            .and_then(|v| v.as_f64().ok())
+            .unwrap_or(0.0) as u32;
+        let mut style_string = String::new();
+        if let Some(m) = m {
+            style_string.push_str(&style::margin(m.resolve(width, &theme.breakpoints)));
+        }
+        if let Some(p) = p {
+            style_string.push_str(&style::padding(p.resolve(width, &theme.breakpoints)));
+        }
+        if let Some(d) = display {
+            style_string.push_str(&style::display(d));
+        }
+        if let Some(ai) = align_items {
+            style_string.push_str(&style::align_items(ai));
+        }
+        if let Some(jc) = justify_content {
+            style_string.push_str(&style::justify_content(jc));
+        }
+        style_string.push_str(&sx);
+        view! { <div style=style_string>{children()}</div> }
+    }
 }
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::Box;

--- a/crates/mui-system/src/container.rs
+++ b/crates/mui-system/src/container.rs
@@ -1,30 +1,63 @@
-#![cfg(feature = "yew")]
 use crate::style_props;
-use yew::prelude::*;
 
-/// Properties for the [`Container`] component.
-#[derive(Properties, PartialEq)]
-pub struct ContainerProps {
-    /// Optional maximum width of the container (e.g. `"1200px"`).
-    #[prop_or_default]
-    pub max_width: Option<String>,
-    /// Additional style string to merge.
-    #[prop_or_default]
-    pub style: String,
-    /// Child elements to display inside the container.
-    #[prop_or_default]
-    pub children: Children,
-}
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use yew::prelude::*;
 
-/// Centers content with an optional maximum width.
-#[function_component(Container)]
-pub fn container(props: &ContainerProps) -> Html {
-    let mut style = String::new();
-    if let Some(mw) = &props.max_width {
-        style.push_str(&style_props! { margin_left: "auto", margin_right: "auto", max_width: mw.clone(), width: "100%" });
-    } else {
-        style.push_str(&style_props! { width: "100%" });
+    /// Properties for the [`Container`] component.
+    #[derive(Properties, PartialEq)]
+    pub struct ContainerProps {
+        /// Optional maximum width of the container (e.g. `"1200px"`).
+        #[prop_or_default]
+        pub max_width: Option<String>,
+        /// Additional style string to merge, following the MUI `sx` syntax.
+        #[prop_or_default]
+        pub sx: String,
+        /// Child elements to display inside the container.
+        #[prop_or_default]
+        pub children: Children,
     }
-    style.push_str(&props.style);
-    html! { <div style={style}>{ for props.children.iter() }</div> }
+
+    /// Centers content with an optional maximum width.
+    #[function_component(Container)]
+    pub fn container(props: &ContainerProps) -> Html {
+        let mut style = String::new();
+        if let Some(mw) = &props.max_width {
+            style.push_str(&style_props! { margin_left: "auto", margin_right: "auto", max_width: mw.clone(), width: "100%" });
+        } else {
+            style.push_str(&style_props! { width: "100%" });
+        }
+        style.push_str(&props.sx);
+        html! { <div style={style}>{ for props.children.iter() }</div> }
+    }
 }
+
+#[cfg(feature = "yew")]
+pub use yew_impl::{Container, ContainerProps};
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::*;
+
+    /// Leptos variant of [`Container`].
+    #[component]
+    pub fn Container(
+        #[prop(optional, into)] max_width: Option<String>,
+        #[prop(optional, into)] sx: String,
+        children: Children,
+    ) -> impl IntoView {
+        let mut style = String::new();
+        if let Some(mw) = max_width {
+            style.push_str(&style_props! { margin_left: "auto", margin_right: "auto", max_width: mw, width: "100%" });
+        } else {
+            style.push_str(&style_props! { width: "100%" });
+        }
+        style.push_str(&sx);
+        view! { <div style=style>{children()}</div> }
+    }
+}
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::Container;

--- a/crates/mui-system/src/grid.rs
+++ b/crates/mui-system/src/grid.rs
@@ -1,34 +1,79 @@
-#![cfg(feature = "yew")]
-use yew::prelude::*;
-use crate::responsive::grid_span_to_percent;
+use crate::{responsive::grid_span_to_percent, style};
 
-/// Simple grid item that computes its own width based on `span` and `columns`.
-#[derive(Properties, PartialEq)]
-pub struct GridProps {
-    /// Total number of columns in the grid container.
-    #[prop_or(12)]
-    pub columns: u16,
-    /// Number of columns this item should span.
-    #[prop_or(12)]
-    pub span: u16,
-    /// Additional inline styles merged with the computed width.
-    #[prop_or_default]
-    pub style: String,
-    /// Child elements of the grid item.
-    #[prop_or_default]
-    pub children: Children,
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use yew::prelude::*;
+
+    /// Simple grid item that computes its own width based on `span` and `columns`.
+    #[derive(Properties, PartialEq)]
+    pub struct GridProps {
+        /// Total number of columns in the grid container.
+        #[prop_or(12)]
+        pub columns: u16,
+        /// Number of columns this item should span.
+        #[prop_or(12)]
+        pub span: u16,
+        /// Flexbox alignment on the main axis when using a flex container.
+        #[prop_or_default]
+        pub justify_content: Option<String>,
+        /// Flexbox alignment on the cross axis.
+        #[prop_or_default]
+        pub align_items: Option<String>,
+        /// Additional inline styles merged with the computed width.
+        #[prop_or_default]
+        pub sx: String,
+        /// Child elements of the grid item.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    /// Render a grid item as a `<div>` with a calculated percentage width.
+    #[function_component(Grid)]
+    pub fn grid(props: &GridProps) -> Html {
+        let width = grid_span_to_percent(props.span, props.columns);
+        let mut style_string = format!("{}width:{}%;", props.sx, width);
+        if let Some(jc) = &props.justify_content {
+            style_string.push_str(&style::justify_content(jc.clone()));
+        }
+        if let Some(ai) = &props.align_items {
+            style_string.push_str(&style::align_items(ai.clone()));
+        }
+        html! { <div style={style_string}>{ for props.children.iter() }</div> }
+    }
 }
 
-/// Render a grid item as a `<div>` with a calculated percentage width.
-///
-/// Using percentages keeps the layout responsive without forcing the browser
-/// to recalculate layout on every resize event.  The function component keeps
-/// the render path simple and therefore easy to inline by the optimizer.
-#[function_component(Grid)]
-pub fn grid(props: &GridProps) -> Html {
-    // Convert the span to a percentage so it scales with the parent container.
-    let width = grid_span_to_percent(props.span, props.columns);
-    // Merge caller supplied styles with the computed width.
-    let style = format!("{}width:{}%;", props.style, width);
-    html! { <div style={style}>{ for props.children.iter() }</div> }
+#[cfg(feature = "yew")]
+pub use yew_impl::{Grid, GridProps};
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::*;
+
+    /// Leptos implementation of [`Grid`].
+    #[component]
+    pub fn Grid(
+        #[prop(optional)] columns: Option<u16>,
+        #[prop(optional)] span: Option<u16>,
+        #[prop(optional, into)] justify_content: Option<String>,
+        #[prop(optional, into)] align_items: Option<String>,
+        #[prop(optional, into)] sx: String,
+        children: Children,
+    ) -> impl IntoView {
+        let columns = columns.unwrap_or(12);
+        let span = span.unwrap_or(12);
+        let width = grid_span_to_percent(span, columns);
+        let mut style_string = format!("{}width:{}%;", sx, width);
+        if let Some(jc) = justify_content {
+            style_string.push_str(&style::justify_content(jc));
+        }
+        if let Some(ai) = align_items {
+            style_string.push_str(&style::align_items(ai));
+        }
+        view! { <div style=style_string>{children()}</div> }
+    }
 }
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::Grid;

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -11,33 +11,36 @@
 pub mod macros;
 pub mod responsive;
 pub mod theme;
+pub mod style;
 
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod r#box;
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod container;
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod grid;
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod stack;
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod theme_provider;
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod typography;
 
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub use container::Container;
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub use grid::Grid;
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub use r#box::Box;
 pub use responsive::{grid_span_to_percent, Responsive};
-#[cfg(feature = "yew")]
+#[allow(unused_imports)]
+pub use style::*;
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub use stack::{Stack, StackDirection};
 pub use theme::{Breakpoints, Palette, Theme};
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub use theme_provider::{use_theme, ThemeProvider};
-#[cfg(feature = "yew")]
+#[cfg(any(feature = "yew", feature = "leptos"))]
 pub use typography::{Typography, TypographyVariant};
 
 /// Legacy no-op function retained to keep dependent crates compiling while

--- a/crates/mui-system/src/stack.rs
+++ b/crates/mui-system/src/stack.rs
@@ -1,6 +1,4 @@
-#![cfg(feature = "yew")]
-use crate::style_props;
-use yew::prelude::*;
+use crate::{style, style_props};
 
 /// Direction of children placement inside [`Stack`].
 #[derive(Clone, PartialEq)]
@@ -9,43 +7,92 @@ pub enum StackDirection {
     Column,
 }
 
-/// Properties for the [`Stack`] component.
-#[derive(Properties, PartialEq)]
-pub struct StackProps {
-    /// Orientation of the stack. Defaults to vertical column layout.
-    #[prop_or_default]
-    pub direction: Option<StackDirection>,
-    /// Gap between children. Accepts any CSS length value.
-    #[prop_or_default]
-    pub spacing: Option<String>,
-    /// Additional arbitrary style string merged into the generated CSS.
-    #[prop_or_default]
-    pub style: String,
-    /// Child elements to render.
-    #[prop_or_default]
-    pub children: Children,
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use yew::prelude::*;
+
+    /// Properties for the [`Stack`] component.
+    #[derive(Properties, PartialEq)]
+    pub struct StackProps {
+        /// Orientation of the stack. Defaults to vertical column layout.
+        #[prop_or_default]
+        pub direction: Option<StackDirection>,
+        /// Gap between children. Accepts any CSS length value.
+        #[prop_or_default]
+        pub spacing: Option<String>,
+        /// Align items on the cross axis.
+        #[prop_or_default]
+        pub align_items: Option<String>,
+        /// Align items on the main axis.
+        #[prop_or_default]
+        pub justify_content: Option<String>,
+        /// Additional arbitrary style string merged into the generated CSS.
+        #[prop_or_default]
+        pub sx: String,
+        /// Child elements to render.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    /// Minimal flexbox based stack layout.
+    #[function_component(Stack)]
+    pub fn stack(props: &StackProps) -> Html {
+        let direction = match props.direction {
+            Some(StackDirection::Row) => "row",
+            _ => "column",
+        };
+        let mut style = style_props! { display: "flex", flex_direction: direction };
+        if let Some(spacing) = &props.spacing {
+            style.push_str(&style_props! { gap: spacing.clone() });
+        }
+        if let Some(ai) = &props.align_items {
+            style.push_str(&style::align_items(ai.clone()));
+        }
+        if let Some(jc) = &props.justify_content {
+            style.push_str(&style::justify_content(jc.clone()));
+        }
+        style.push_str(&props.sx);
+        html! { <div style={style}>{ for props.children.iter() }</div> }
+    }
 }
 
-/// Minimal flexbox based stack layout.
-///
-/// ```rust
-/// use mui_system::Stack;
-/// use mui_system::style_props;
-/// # #[cfg(feature = "yew")]
-/// # fn render() -> yew::Html {
-/// html! {<Stack spacing={Some("8px".into())}>{"item"}</Stack>}
-/// # }
-/// ```
-#[function_component(Stack)]
-pub fn stack(props: &StackProps) -> Html {
-    let direction = match props.direction {
-        Some(StackDirection::Row) => "row",
-        _ => "column",
-    };
-    let mut style = style_props! { display: "flex", flex_direction: direction };
-    if let Some(spacing) = &props.spacing {
-        style.push_str(&style_props! { gap: spacing.clone() });
+#[cfg(feature = "yew")]
+pub use yew_impl::{Stack, StackProps};
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::*;
+
+    /// Leptos implementation of [`Stack`].
+    #[component]
+    pub fn Stack(
+        #[prop(optional)] direction: Option<StackDirection>,
+        #[prop(optional, into)] spacing: Option<String>,
+        #[prop(optional, into)] align_items: Option<String>,
+        #[prop(optional, into)] justify_content: Option<String>,
+        #[prop(optional, into)] sx: String,
+        children: Children,
+    ) -> impl IntoView {
+        let direction = match direction {
+            Some(StackDirection::Row) => "row",
+            _ => "column",
+        };
+        let mut style = style_props! { display: "flex", flex_direction: direction };
+        if let Some(sp) = spacing {
+            style.push_str(&style_props! { gap: sp });
+        }
+        if let Some(ai) = align_items {
+            style.push_str(&style::align_items(ai));
+        }
+        if let Some(jc) = justify_content {
+            style.push_str(&style::justify_content(jc));
+        }
+        style.push_str(&sx);
+        view! { <div style=style>{children()}</div> }
     }
-    style.push_str(&props.style);
-    html! { <div style={style}>{ for props.children.iter() }</div> }
 }
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::Stack;

--- a/crates/mui-system/src/style.rs
+++ b/crates/mui-system/src/style.rs
@@ -1,0 +1,40 @@
+//! Typed helper functions for common CSS properties.
+//!
+//! These helpers are generated via macros to keep the source lightweight while
+//! still exposing strongly typed builders. Each function returns a CSS style
+//! string of the form `name:value;` and can be freely composed using the
+//! [`style_props!`](crate::style_props) macro.
+//!
+//! The goal is to minimise repetitive manual mapping of Rust fields to CSS
+//! strings and instead centralise the mapping in a declarative list. New style
+//! properties can be added by appending a line to the macro invocation below.
+
+use crate::define_style_props;
+
+// Generate a suite of style property builders. These mirror a subset of the
+// most commonly used system props from MUI. The list can easily be extended as
+// additional style shortcuts are required.
+define_style_props! {
+    // Spacing ---------------------------------------------------------------
+    margin => "margin",
+    padding => "padding",
+    margin_top => "margin-top",
+    margin_bottom => "margin-bottom",
+    margin_left => "margin-left",
+    margin_right => "margin-right",
+    padding_top => "padding-top",
+    padding_bottom => "padding-bottom",
+    padding_left => "padding-left",
+    padding_right => "padding-right",
+
+    // Layout ----------------------------------------------------------------
+    display => "display",
+    flex_direction => "flex-direction",
+    flex_wrap => "flex-wrap",
+    align_items => "align-items",
+    justify_content => "justify-content",
+}
+
+// The module intentionally re-exports all generated helpers so callers can do
+// `use mui_system::style::*` or simply `use mui_system::*` when `lib.rs`
+// re-exports this module.

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -1,30 +1,55 @@
-#![cfg(feature = "yew")]
-use yew::prelude::*;
 use crate::theme::Theme;
 
-/// Provides the current [`Theme`] to descendant components via Yew's
-/// `ContextProvider` mechanism.
-#[derive(Properties, PartialEq)]
-pub struct ThemeProviderProps {
-    pub theme: Theme,
-    #[prop_or_default]
-    pub children: Children,
-}
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use yew::prelude::*;
 
-#[function_component(ThemeProvider)]
-pub fn theme_provider(props: &ThemeProviderProps) -> Html {
-    html! {
-        <ContextProvider<Theme> context={props.theme.clone()}>
-            { for props.children.iter() }
-        </ContextProvider<Theme>>
+    /// Provides the current [`Theme`] to descendant components via Yew's context system.
+    #[derive(Properties, PartialEq)]
+    pub struct ThemeProviderProps {
+        pub theme: Theme,
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    #[function_component(ThemeProvider)]
+    pub fn theme_provider(props: &ThemeProviderProps) -> Html {
+        html! {
+            <ContextProvider<Theme> context={props.theme.clone()}>
+                { for props.children.iter() }
+            </ContextProvider<Theme>>
+        }
+    }
+
+    /// Retrieves the current theme from context. Components can call this helper
+    /// instead of dealing with `use_context` directly which keeps the call sites concise.
+    #[hook]
+    pub fn use_theme() -> Theme {
+        use_context::<Theme>().unwrap_or_default()
     }
 }
 
-/// Retrieves the current theme from context. Components can call this helper
-/// instead of dealing with `use_context` directly which keeps the call sites
-/// concise.
 #[cfg(feature = "yew")]
-#[hook]
-pub fn use_theme() -> Theme {
-    use_context::<Theme>().unwrap_or_default()
+pub use yew_impl::{ThemeProvider, ThemeProviderProps, use_theme};
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::*;
+
+    /// Leptos variant of the [`ThemeProvider`].
+    #[component]
+    pub fn ThemeProvider(theme: Theme, children: Children) -> impl IntoView {
+        provide_context(theme);
+        view! { {children()} }
+    }
+
+    /// Access the current [`Theme`] from context.
+    pub fn use_theme() -> Theme {
+        use_context::<Theme>().unwrap_or_default()
+    }
 }
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::{ThemeProvider, use_theme};

--- a/crates/mui-system/src/typography.rs
+++ b/crates/mui-system/src/typography.rs
@@ -1,6 +1,3 @@
-#![cfg(feature = "yew")]
-use crate::style_props;
-use yew::prelude::*;
 
 /// Typography variants represented as semantic HTML tags.
 #[derive(Clone, PartialEq)]
@@ -10,35 +7,65 @@ pub enum TypographyVariant {
     Body1,
 }
 
-/// Properties for the [`Typography`] component.
-#[derive(Properties, PartialEq)]
-pub struct TypographyProps {
-    /// Which typography style to apply. Defaults to [`TypographyVariant::Body1`].
-    #[prop_or_default]
-    pub variant: Option<TypographyVariant>,
-    /// Inline style string built with the [`style_props!`] macro.
-    #[prop_or_default]
-    pub style: String,
-    /// Text or elements to render.
-    #[prop_or_default]
-    pub children: Children,
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use yew::prelude::*;
+
+    /// Properties for the [`Typography`] component.
+    #[derive(Properties, PartialEq)]
+    pub struct TypographyProps {
+        /// Which typography style to apply. Defaults to [`TypographyVariant::Body1`].
+        #[prop_or_default]
+        pub variant: Option<TypographyVariant>,
+        /// Inline style string built with the `sx` helpers.
+        #[prop_or_default]
+        pub sx: String,
+        /// Text or elements to render.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    /// Displays text with semantic HTML tags and optional styling.
+    #[function_component(Typography)]
+    pub fn typography(props: &TypographyProps) -> Html {
+        let tag = match props.variant {
+            Some(TypographyVariant::H1) => "h1",
+            Some(TypographyVariant::H2) => "h2",
+            _ => "p",
+        };
+        let mut node = yew::virtual_dom::VTag::new(tag);
+        if !props.sx.is_empty() {
+            node.add_attribute("style", props.sx.clone());
+        }
+        node.add_children(props.children.iter());
+        Html::VTag(Box::new(node))
+    }
 }
 
-/// Displays text with semantic HTML tags and optional styling.
-#[function_component(Typography)]
-pub fn typography(props: &TypographyProps) -> Html {
-    let tag = match props.variant {
-        Some(TypographyVariant::H1) => "h1",
-        Some(TypographyVariant::H2) => "h2",
-        _ => "p",
-    };
-    let mut node = yew::virtual_dom::VTag::new(tag);
-    if !props.style.is_empty() {
-        node.add_attribute("style", props.style.clone());
+#[cfg(feature = "yew")]
+pub use yew_impl::{Typography, TypographyProps};
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::*;
+
+    /// Leptos variant of [`Typography`].
+    #[component]
+    pub fn Typography(
+        #[prop(optional)] variant: Option<TypographyVariant>,
+        #[prop(optional, into)] sx: String,
+        children: Children,
+    ) -> impl IntoView {
+        let tag = match variant {
+            Some(TypographyVariant::H1) => "h1",
+            Some(TypographyVariant::H2) => "h2",
+            _ => "p",
+        };
+        view! { <{tag} style=sx>{children()}</{tag}> }
     }
-    node.add_children(props.children.iter());
-    // `Html::VTag` expects the element to be heap allocated so it can be
-    // shared across render passes.  Boxing here keeps the API ergonomic for
-    // callers while satisfying the enum's requirements.
-    Html::VTag(Box::new(node))
 }
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::Typography;

--- a/crates/mui-system/tests/style.rs
+++ b/crates/mui-system/tests/style.rs
@@ -1,0 +1,8 @@
+use mui_system::{margin, padding};
+
+/// Ensure macro generated helpers emit valid CSS strings.
+#[test]
+fn spacing_helpers_work() {
+    assert_eq!(margin("4px"), "margin:4px;");
+    assert_eq!(padding("2px"), "padding:2px;");
+}


### PR DESCRIPTION
## Summary
- add macro-generated style property builders for spacing and flexbox
- implement responsive Box, Grid, Stack, Container, Typography with Yew and Leptos support
- expose cross-framework ThemeProvider/use_theme and document `sx` usage

## Testing
- `cargo test -p mui-system`


------
https://chatgpt.com/codex/tasks/task_e_68c5b76e226c832e9f3592e57445bf19