### PR TITLE
feat(lab): add experimental components

### DIFF
--- a/crates/mui-lab/Cargo.toml
+++ b/crates/mui-lab/Cargo.toml
@@ -16,9 +16,13 @@ time = { workspace = true, optional = true }
 [features]
 default = []
 # Enable experimental widgets individually to keep compile times lean.
+autocomplete = []
 date-picker = []
+data-grid = []
 time-picker = []
 masonry = []
+tree-view = []
+timeline = []
 localization = ["dep:serde", "dep:once_cell"]
 # Features toggling which date library backing to use.
 chrono = ["dep:chrono"]

--- a/crates/mui-lab/README.md
+++ b/crates/mui-lab/README.md
@@ -15,10 +15,14 @@ at your own risk and pin versions accordingly.
 Each preview widget lives behind a Cargo feature so consumers only compile
 what they need:
 
+- `autocomplete` – lightweight string matcher for building suggestion UIs.
 - `date-picker` – opt-in to the minimal date picker demonstrating the
   `DateAdapter` abstraction.
+- `data-grid` – in-memory tabular data manipulation.
 - `time-picker` – enables the time picker powered by `TimeAdapter`.
 - `masonry` – experimental Masonry layout algorithm.
+- `tree-view` – hierarchical tree structure with expand/collapse state.
+- `timeline` – ordered collection of timestamped events.
 - `localization` – runtime `LocalizationProvider` and built-in `en-US`
   locale pack (requires `serde`).
 

--- a/crates/mui-lab/src/autocomplete.rs
+++ b/crates/mui-lab/src/autocomplete.rs
@@ -1,0 +1,45 @@
+//! Experimental string-based autocomplete.
+//!
+//! This tiny component is intentionally minimal. It focuses on the core
+//! suggestion logic so that downstream crates can wrap it with any
+//! rendering technology they prefer. The module is gate kept behind the
+//! `autocomplete` Cargo feature to signal its unstable status and keep
+//! compile times low for consumers who do not need it.
+//!
+//! The implementation favors pure functions and small data structures to
+//! keep the API easy to reason about and friendly for automated testing
+//! and future code generation.
+
+/// Simple autocomplete that matches the beginning of options.
+#[derive(Debug, Clone)]
+pub struct Autocomplete {
+    /// List of candidate options provided by the application.
+    options: Vec<String>,
+}
+
+impl Autocomplete {
+    /// Creates a new autocomplete with the given options.
+    pub fn new(options: Vec<String>) -> Self {
+        Self { options }
+    }
+
+    /// Returns all options that start with the provided input.
+    pub fn suggestions(&self, input: &str) -> Vec<String> {
+        self.options
+            .iter()
+            .filter(|opt| opt.to_lowercase().starts_with(&input.to_lowercase()))
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suggestions_filter_by_prefix() {
+        let ac = Autocomplete::new(vec!["alpha".into(), "beta".into()]);
+        assert_eq!(ac.suggestions("a"), vec!["alpha"]);
+    }
+}

--- a/crates/mui-lab/src/data_grid.rs
+++ b/crates/mui-lab/src/data_grid.rs
@@ -1,0 +1,44 @@
+//! Minimal in-memory data grid.
+//!
+//! The goal of this experimental API is to provide a small, easily testable
+//! abstraction for manipulating tabular data. Rendering and virtualization are
+//! intentionally left to higher level crates so that this module can be reused
+//! across different UI frameworks or even server-side processing tools.
+//!
+//! The component is feature gated behind `data-grid` to avoid pulling it into
+//! applications that don't need it.
+
+/// Generic grid storing rows of data.
+#[derive(Debug, Clone)]
+pub struct DataGrid<T> {
+    /// Rows backing the grid. In a real widget this would likely be a more
+    /// complex structure supporting pagination or virtualization.
+    pub rows: Vec<T>,
+}
+
+impl<T> DataGrid<T> {
+    /// Creates a new grid from a set of rows.
+    pub fn new(rows: Vec<T>) -> Self {
+        Self { rows }
+    }
+
+    /// Sorts the rows in place using the provided comparator.
+    pub fn sort_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&T, &T) -> std::cmp::Ordering,
+    {
+        self.rows.sort_by(compare);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sort_by_orders_rows() {
+        let mut grid = DataGrid::new(vec![3, 1, 2]);
+        grid.sort_by(|a, b| a.cmp(b));
+        assert_eq!(grid.rows, vec![1, 2, 3]);
+    }
+}

--- a/crates/mui-lab/src/lib.rs
+++ b/crates/mui-lab/src/lib.rs
@@ -9,19 +9,32 @@
 //! downstream applications can swap implementations without touching
 //! widget logic.  This is intended to scale to enterprise grade usage
 //! where different teams may standardize on different date/time crates. Each
-//! widget lives behind a feature flag (`date-picker`, `time-picker`,
-//! `masonry`, `localization`) to minimize compile times and manual toggling.
+//! widget lives behind a feature flag (`autocomplete`, `date-picker`,
+//! `data-grid`, `tree-view`, `timeline`, `time-picker`, `masonry`,
+//! `localization`) to minimize compile times and manual toggling.
 
 pub mod adapters;
 
 #[cfg(feature = "localization")]
 pub mod localization;
 
+#[cfg(feature = "autocomplete")]
+pub mod autocomplete;
+
 #[cfg(feature = "date-picker")]
 pub mod date_picker;
+
+#[cfg(feature = "data-grid")]
+pub mod data_grid;
 
 #[cfg(feature = "time-picker")]
 pub mod time_picker;
 
 #[cfg(feature = "masonry")]
 pub mod masonry;
+
+#[cfg(feature = "tree-view")]
+pub mod tree_view;
+
+#[cfg(feature = "timeline")]
+pub mod timeline;

--- a/crates/mui-lab/src/timeline.rs
+++ b/crates/mui-lab/src/timeline.rs
@@ -1,0 +1,52 @@
+//! Lightweight event timeline.
+//!
+//! `Timeline` stores events in chronological order. It is intentionally kept
+//! simple so that applications can build richer visualizations or persistence
+//! layers on top. The component is hidden behind the `timeline` feature gate.
+
+/// Event with an associated timestamp.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimelineEvent<T> {
+    /// Milliseconds since UNIX epoch.
+    pub at: u64,
+    /// Arbitrary payload for the event.
+    pub data: T,
+}
+
+/// In-memory ordered collection of [`TimelineEvent`]s.
+#[derive(Debug, Default, Clone)]
+pub struct Timeline<T> {
+    events: Vec<TimelineEvent<T>>,
+}
+
+impl<T> Timeline<T> {
+    /// Creates an empty timeline.
+    pub fn new() -> Self {
+        Self { events: Vec::new() }
+    }
+
+    /// Inserts an event and keeps the internal vector ordered by timestamp.
+    pub fn push(&mut self, event: TimelineEvent<T>) {
+        self.events.push(event);
+        self.events.sort_by_key(|e| e.at);
+    }
+
+    /// Returns the events in chronological order.
+    pub fn events(&self) -> &[TimelineEvent<T>] {
+        &self.events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeline_keeps_events_sorted() {
+        let mut tl = Timeline::new();
+        tl.push(TimelineEvent { at: 2, data: "b" });
+        tl.push(TimelineEvent { at: 1, data: "a" });
+        let events: Vec<_> = tl.events().iter().map(|e| e.data).collect();
+        assert_eq!(events, vec!["a", "b"]);
+    }
+}

--- a/crates/mui-lab/src/tree_view.rs
+++ b/crates/mui-lab/src/tree_view.rs
@@ -1,0 +1,62 @@
+//! Simple hierarchical tree structure.
+//!
+//! The `TreeView` type models expansion state and is intended as a foundation
+//! for richer UI representations. Rendering is not handled here so that
+//! alternative front ends (e.g. Yew, Leptos) can build on top without pulling in
+//! extra dependencies. The API is intentionally tiny to keep tests fast and the
+//! mental model small.
+
+/// Node within a tree.
+#[derive(Debug, Clone)]
+pub struct TreeNode<T> {
+    /// Value stored at this node.
+    pub value: T,
+    /// Child nodes in insertion order.
+    pub children: Vec<TreeNode<T>>,
+    /// Whether this node's children are visible. Defaults to `false`.
+    pub expanded: bool,
+}
+
+impl<T> TreeNode<T> {
+    /// Creates a new leaf node with the given value.
+    pub fn new(value: T) -> Self {
+        Self {
+            value,
+            children: Vec::new(),
+            expanded: false,
+        }
+    }
+
+    /// Toggles the node's expansion state.
+    pub fn toggle(&mut self) {
+        self.expanded = !self.expanded;
+    }
+}
+
+/// Convenience wrapper representing a full tree.
+#[derive(Debug, Clone)]
+pub struct TreeView<T> {
+    /// Root node of the tree. Applications can traverse and mutate this
+    /// directly for more complex scenarios.
+    pub root: TreeNode<T>,
+}
+
+impl<T> TreeView<T> {
+    /// Creates a new tree from a root node.
+    pub fn new(root: TreeNode<T>) -> Self {
+        Self { root }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toggle_flips_expanded_state() {
+        let mut node = TreeNode::new(1);
+        assert!(!node.expanded);
+        node.toggle();
+        assert!(node.expanded);
+    }
+}

--- a/crates/mui-lab/tests/lab.rs
+++ b/crates/mui-lab/tests/lab.rs
@@ -1,10 +1,14 @@
 use mui_lab::adapters::{AdapterChrono, AdapterTime, DateAdapter, TimeAdapter};
+use mui_lab::autocomplete::Autocomplete;
+use mui_lab::data_grid::DataGrid;
 use mui_lab::date_picker::{DatePicker, Key};
 use mui_lab::localization::{
     init_default_locales, register_locale, LocalePack, LocalizationProvider,
 };
 use mui_lab::masonry::Masonry;
 use mui_lab::time_picker::TimePicker;
+use mui_lab::timeline::{Timeline, TimelineEvent};
+use mui_lab::tree_view::TreeNode;
 
 /// Custom locale used to prove that the provider can be extended at
 /// runtime by the community.
@@ -80,4 +84,34 @@ fn time_adapter_from_time_crate_roundtrip() {
     let now = adapter.now();
     let later = adapter.add_minutes(&now, 30);
     assert_eq!(adapter.add_minutes(&later, -30), now);
+}
+
+#[test]
+fn autocomplete_returns_matching_options() {
+    let ac = Autocomplete::new(vec!["apple".into(), "banana".into()]);
+    assert_eq!(ac.suggestions("ba"), vec!["banana"]);
+}
+
+#[test]
+fn data_grid_sorts_rows_ascending() {
+    let mut grid = DataGrid::new(vec![3, 1, 2]);
+    grid.sort_by(|a, b| a.cmp(b));
+    assert_eq!(grid.rows, vec![1, 2, 3]);
+}
+
+#[test]
+fn tree_node_toggle_expands() {
+    let mut node = TreeNode::new("root");
+    assert!(!node.expanded);
+    node.toggle();
+    assert!(node.expanded);
+}
+
+#[test]
+fn timeline_orders_pushed_events() {
+    let mut tl = Timeline::new();
+    tl.push(TimelineEvent { at: 2, data: "b" });
+    tl.push(TimelineEvent { at: 1, data: "a" });
+    let events: Vec<_> = tl.events().iter().map(|e| e.data).collect();
+    assert_eq!(events, vec!["a", "b"]);
 }

--- a/crates/mui-material/src/button.rs
+++ b/crates/mui-material/src/button.rs
@@ -34,7 +34,11 @@ mod yew_impl {
         };
         let (bg, color, border) = match props.variant {
             ButtonVariant::Contained => (palette.clone(), "#fff".to_string(), "none".to_string()),
-            ButtonVariant::Outlined => ("transparent".into(), palette.clone(), format!("1px solid {}", palette)),
+            ButtonVariant::Outlined => (
+                "transparent".into(),
+                palette.clone(),
+                format!("1px solid {}", palette),
+            ),
             ButtonVariant::Text => ("transparent".into(), palette.clone(), "none".into()),
         };
         let style = css_with_theme!(
@@ -106,7 +110,11 @@ mod leptos_impl {
         };
         let (bg, color, border) = match props.variant {
             ButtonVariant::Contained => (palette.clone(), "#fff".to_string(), "none".to_string()),
-            ButtonVariant::Outlined => ("transparent".into(), palette.clone(), format!("1px solid {}", palette)),
+            ButtonVariant::Outlined => (
+                "transparent".into(),
+                palette.clone(),
+                format!("1px solid {}", palette),
+            ),
             ButtonVariant::Text => ("transparent".into(), palette.clone(), "none".into()),
         };
         let style = css_with_theme!(

--- a/crates/mui-material/src/card.rs
+++ b/crates/mui-material/src/card.rs
@@ -1,5 +1,5 @@
-use yew::prelude::*;
 use mui_styled_engine::use_theme;
+use yew::prelude::*;
 
 use crate::material_props;
 

--- a/crates/mui-material/src/dialog.rs
+++ b/crates/mui-material/src/dialog.rs
@@ -1,5 +1,5 @@
-use yew::prelude::*;
 use mui_styled_engine::use_theme;
+use yew::prelude::*;
 
 use crate::material_props;
 

--- a/crates/mui-styled-engine-macros/src/lib.rs
+++ b/crates/mui-styled-engine-macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, ItemFn, Fields};
+use syn::{parse_macro_input, DeriveInput, Fields, ItemFn};
 
 /// Derive macro generating an `into_theme` helper for custom theme structs.
 ///

--- a/crates/mui-styled-engine/benches/style_bench.rs
+++ b/crates/mui-styled-engine/benches/style_bench.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use mui_styled_engine::{Style, css};
+use mui_styled_engine::{css, Style};
 
 fn rust_style() {
-    Style::new(css!("color: red;" )).unwrap();
+    Style::new(css!("color: red;")).unwrap();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/crates/mui-system/src/box.rs
+++ b/crates/mui-system/src/box.rs
@@ -1,5 +1,5 @@
-use crate::{responsive::Responsive, style, theme::Theme};
 use crate::theme_provider::use_theme;
+use crate::{responsive::Responsive, style, theme::Theme};
 
 #[cfg(feature = "yew")]
 mod yew_impl {
@@ -38,9 +38,7 @@ mod yew_impl {
         let theme = use_theme();
         let width = window()
             .and_then(|w| w.inner_width().ok())
-
             .and_then(|v| v.as_f64())
-
             .unwrap_or(0.0) as u32;
         let mut style_string = String::new();
         if let Some(m) = &props.m {

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -10,8 +10,8 @@
 
 pub mod macros;
 pub mod responsive;
-pub mod theme;
 pub mod style;
+pub mod theme;
 
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod r#box;
@@ -33,10 +33,10 @@ pub use grid::Grid;
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub use r#box::Box;
 pub use responsive::{grid_span_to_percent, Responsive};
-#[allow(unused_imports)]
-pub use style::*;
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub use stack::{Stack, StackDirection};
+#[allow(unused_imports)]
+pub use style::*;
 pub use theme::{Breakpoints, Palette, Theme};
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub use theme_provider::{use_theme, ThemeProvider};

--- a/crates/mui-system/src/responsive.rs
+++ b/crates/mui-system/src/responsive.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use crate::theme::Breakpoints;
+use serde::{Deserialize, Serialize};
 
 /// Helper structure representing values that change across breakpoints.
 /// Missing values fall back to the next smallest defined one, mirroring
@@ -17,20 +17,23 @@ impl<T: Clone> Responsive<T> {
     /// Resolves the appropriate value for a given viewport width.
     pub fn resolve(&self, width: u32, bp: &Breakpoints) -> T {
         if width >= bp.xl {
-            self.xl.as_ref()
+            self.xl
+                .as_ref()
                 .or(self.lg.as_ref())
                 .or(self.md.as_ref())
                 .or(self.sm.as_ref())
                 .unwrap_or(&self.xs)
                 .clone()
         } else if width >= bp.lg {
-            self.lg.as_ref()
+            self.lg
+                .as_ref()
                 .or(self.md.as_ref())
                 .or(self.sm.as_ref())
                 .unwrap_or(&self.xs)
                 .clone()
         } else if width >= bp.md {
-            self.md.as_ref()
+            self.md
+                .as_ref()
                 .or(self.sm.as_ref())
                 .unwrap_or(&self.xs)
                 .clone()

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -31,7 +31,7 @@ mod yew_impl {
 }
 
 #[cfg(feature = "yew")]
-pub use yew_impl::{ThemeProvider, ThemeProviderProps, use_theme};
+pub use yew_impl::{use_theme, ThemeProvider, ThemeProviderProps};
 
 #[cfg(feature = "leptos")]
 mod leptos_impl {
@@ -52,4 +52,4 @@ mod leptos_impl {
 }
 
 #[cfg(feature = "leptos")]
-pub use leptos_impl::{ThemeProvider, use_theme};
+pub use leptos_impl::{use_theme, ThemeProvider};

--- a/crates/mui-system/src/typography.rs
+++ b/crates/mui-system/src/typography.rs
@@ -1,4 +1,3 @@
-
 /// Typography variants represented as semantic HTML tags.
 #[derive(Clone, PartialEq)]
 pub enum TypographyVariant {


### PR DESCRIPTION
## Summary
- add feature-gated Autocomplete, DataGrid, TreeView, and Timeline primitives to `mui-lab`
- document new preview features and wiring in `lib.rs`

## Testing
- `cargo test -p mui-lab --all-features`
- `cargo test -p mui-joy --features yew`

------
https://chatgpt.com/codex/tasks/task_e_68c70da1505c832e8ede5a9970eaf9ed