### PR TITLE
docs: expand utils and integrate in components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,9 +1756,12 @@ dependencies = [
  "leptos",
  "mui-styled-engine",
  "mui-system",
+ "mui-utils",
+ "serde_json",
  "stylist",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "web-sys",
  "yew",
 ]
 

--- a/crates/mui-material/Cargo.toml
+++ b/crates/mui-material/Cargo.toml
@@ -12,6 +12,9 @@ leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 stylist = { version = "0.13", optional = true }
+mui-utils = { path = "../mui-utils" }
+serde_json = { workspace = true }
+web-sys = { workspace = true, optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test.workspace = true
@@ -19,5 +22,5 @@ gloo-utils = "0.2"
 
 [features]
 default = []
-yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew", "mui-styled-engine/yew", "dep:stylist"]
+yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew", "mui-styled-engine/yew", "dep:stylist", "dep:web-sys"]
 leptos = ["dep:leptos", "dep:wasm-bindgen", "mui-system/leptos"]

--- a/crates/mui-material/README.md
+++ b/crates/mui-material/README.md
@@ -7,19 +7,33 @@ The crate exposes high level widgets like `Button`, `AppBar`, `TextField` and
 Common property boilerplate is generated through `material_component_props!`
 macro so adding new widgets requires minimal manual code.
 
+Utilities from [`mui-utils`](../mui-utils) are integrated to provide
+enterprise-friendly ergonomics: button callbacks can be throttled,
+text inputs debounced and style overrides merged via JSON using `deep_merge`.
+
 ## Example
 
 ```rust
-use mui_material::{Button, AppBar};
+use mui_material::{Button, AppBar, TextField};
 use mui_styled_engine::{ThemeProvider, Theme};
 use yew::prelude::*;
+use serde_json::json;
 
 #[function_component(App)]
 fn app() -> Html {
     html! {
         <ThemeProvider theme={Theme::default()}>
             <AppBar title="My App" aria_label="main navigation" />
-            <Button label="Press" />
+            // Throttle rapid clicks to once every 200ms
+            <Button label="Press" throttle_ms={200} />
+            // Debounced text input with custom background color
+            <TextField
+                value="".into()
+                placeholder="Search"
+                aria_label="search"
+                debounce_ms={300}
+                style_overrides={json!({"background": "#eee"})}
+            />
         </ThemeProvider>
     }
 }

--- a/crates/mui-material/src/button.rs
+++ b/crates/mui-material/src/button.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "leptos")]
+use mui_styled_engine::css_with_theme;
 #[cfg(any(feature = "yew", feature = "leptos"))]
-use mui_styled_engine::{css_with_theme, use_theme};
+use mui_styled_engine::use_theme;
 
 // Re-export shared enums under component specific names so the public API
 // remains ergonomic while the underlying definitions stay centralized.
@@ -8,6 +10,9 @@ pub use crate::macros::{Color as ButtonColor, Size as ButtonSize, Variant as But
 #[cfg(feature = "yew")]
 mod yew_impl {
     use super::*;
+    use mui_utils::{deep_merge, throttle};
+    use serde_json::{json, Value};
+    use std::time::Duration;
     use yew::prelude::*;
 
     crate::material_component_props!(ButtonProps {
@@ -17,6 +22,11 @@ mod yew_impl {
         disabled: bool,
         /// Callback invoked when the button is clicked.
         on_click: Option<Callback<MouseEvent>>,
+        /// Minimum number of milliseconds between invocations of `on_click`.
+        throttle_ms: u64,
+        /// Optional style overrides expressed as a JSON object.  Keys map to CSS
+        /// properties written in kebab-case.
+        style_overrides: Option<Value>,
     });
 
     /// Yew implementation of [`Button`].
@@ -41,28 +51,61 @@ mod yew_impl {
             ),
             ButtonVariant::Text => ("transparent".into(), palette.clone(), "none".into()),
         };
-        let style = css_with_theme!(
-            theme,
-            r#"
-            background: ${bg};
-            color: ${color};
-            border: ${border};
-            padding: ${padding};
-            cursor: ${cursor};
-            opacity: ${opacity};
-        "#,
-            bg = bg,
-            color = color,
-            border = border,
-            padding = padding,
-            cursor = if props.disabled { "default" } else { "pointer" },
-            opacity = if props.disabled { 0.5 } else { 1.0 },
-        );
-        let class = style.get_class_name().to_string();
-        let onclick = props.on_click.clone().unwrap_or_else(|| Callback::noop());
+        // Base styles derived from the theme. Represented as JSON so they can
+        // be merged with user provided overrides using `deep_merge` for a fully
+        // declarative styling pipeline.
+        let mut style = json!({
+            "background": bg,
+            "color": color,
+            "border": border,
+            "padding": padding,
+            "cursor": if props.disabled { "default" } else { "pointer" },
+            "opacity": if props.disabled { 0.5 } else { 1.0 },
+        });
+        if let Some(extra) = &props.style_overrides {
+            // Merge overrides deeply so callers can tweak any subset of
+            // properties without re-specifying the entire object.
+            deep_merge(&mut style, extra.clone());
+        }
+        let style_str = style
+            .as_object()
+            .map(|m| {
+                m.iter()
+                    .map(|(k, v)| {
+                        let val = v
+                            .as_str()
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|| v.to_string());
+                        format!("{k}: {val};")
+                    })
+                    .collect::<String>()
+            })
+            .unwrap_or_default();
+
+        let onclick_cb = props.on_click.clone().unwrap_or_else(|| Callback::noop());
+        let throttle_ms = props.throttle_ms;
+        // Store the throttled callback in `use_mut_ref` so the same closure is
+        // reused across renders – avoiding reallocation on every render cycle.
+        let throttled = use_mut_ref(move || {
+            let cb = onclick_cb.clone();
+            if throttle_ms > 0 {
+                Box::new(throttle(
+                    move |ev: MouseEvent| cb.emit(ev),
+                    Duration::from_millis(throttle_ms),
+                )) as Box<dyn FnMut(MouseEvent)>
+            } else {
+                Box::new(move |ev: MouseEvent| cb.emit(ev)) as Box<dyn FnMut(MouseEvent)>
+            }
+        });
+        let onclick = {
+            let throttled = throttled.clone();
+            Callback::from(move |ev: MouseEvent| {
+                (throttled.borrow_mut())(ev);
+            })
+        };
         html! {
             <button
-                class={class}
+                style={style_str}
                 type="button"
                 disabled={props.disabled}
                 onclick={onclick}

--- a/crates/mui-material/src/text_field.rs
+++ b/crates/mui-material/src/text_field.rs
@@ -1,4 +1,12 @@
-use mui_styled_engine::{css_with_theme, use_theme};
+use mui_styled_engine::use_theme;
+#[cfg(target_arch = "wasm32")]
+use mui_utils::debounce;
+use mui_utils::deep_merge;
+use serde_json::{json, Value};
+#[cfg(target_arch = "wasm32")]
+use std::time::Duration;
+use wasm_bindgen::JsCast;
+use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
 pub use crate::macros::{
@@ -12,6 +20,12 @@ crate::material_component_props!(TextFieldProps {
     placeholder: String,
     /// Accessibility label describing the purpose of the field.
     aria_label: String,
+    /// Delay in milliseconds before `on_input` is invoked.
+    debounce_ms: u64,
+    /// Callback emitting the latest value after debouncing.
+    on_input: Option<Callback<String>>,
+    /// Optional style overrides expressed as JSON.
+    style_overrides: Option<Value>,
 });
 
 /// Controlled text input field.
@@ -34,26 +48,77 @@ pub fn text_field(props: &TextFieldProps) -> Html {
         TextFieldVariant::Contained => format!("1px solid {}", color),
         TextFieldVariant::Text => "none".to_string(),
     };
-    let style = css_with_theme!(
-        theme,
-        r#"
-        color: ${color};
-        font-size: ${font_size};
-        border: ${border};
-        padding: 4px 8px;
-    "#,
-        color = color,
-        font_size = font_size,
-        border = border
-    );
-    let class = style.get_class_name().to_string();
+    // Construct base style object which mirrors the themed defaults.
+    // Representing style as JSON allows downstream consumers to declaratively
+    // merge modifications without rewriting the entire CSS string.
+    let mut style = json!({
+        "color": color,
+        "font-size": font_size,
+        "border": border,
+        "padding": "4px 8px",
+    });
+    if let Some(extra) = &props.style_overrides {
+        // Merge overrides deeply; this makes incremental styling trivial.
+        deep_merge(&mut style, extra.clone());
+    }
+    let style_str = style
+        .as_object()
+        .map(|m| {
+            m.iter()
+                .map(|(k, v)| {
+                    let val = v
+                        .as_str()
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| v.to_string());
+                    format!("{k}: {val};")
+                })
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+
+    let on_input_cb = props.on_input.clone().unwrap_or_else(|| Callback::noop());
+    let _debounce_ms = props.debounce_ms;
+    // Persist the debounced closure between renders to keep pending timers alive
+    // and avoid re-allocating the inner state machine.
+    #[cfg(target_arch = "wasm32")]
+    let debounced = {
+        let debounce_ms = _debounce_ms;
+        use_mut_ref(move || {
+            let cb = on_input_cb.clone();
+            if debounce_ms > 0 {
+                Box::new(debounce(
+                    move |v: String| cb.emit(v),
+                    Duration::from_millis(debounce_ms),
+                )) as Box<dyn FnMut(String)>
+            } else {
+                Box::new(move |v: String| cb.emit(v)) as Box<dyn FnMut(String)>
+            }
+        })
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let debounced = use_mut_ref(move || {
+        let cb = on_input_cb.clone();
+        Box::new(move |v: String| cb.emit(v)) as Box<dyn FnMut(String)>
+    });
+    let oninput = {
+        let debounced = debounced.clone();
+        Callback::from(move |e: InputEvent| {
+            let value = e
+                .target()
+                .and_then(|t| t.dyn_into::<HtmlInputElement>().ok())
+                .map(|el| el.value())
+                .unwrap_or_default();
+            (debounced.borrow_mut())(value);
+        })
+    };
 
     html! {
         <input
-            class={class}
+            style={style_str}
             value={props.value.clone()}
             placeholder={props.placeholder.clone()}
             aria-label={props.aria_label.clone()}
+            oninput={oninput}
         />
     }
 }

--- a/crates/mui-utils/src/compose_classes.rs
+++ b/crates/mui-utils/src/compose_classes.rs
@@ -1,10 +1,40 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Compose CSS class names for each slot from multiple sources.
 ///
 /// Slots map to arrays of optional class keys. For every defined key the
 /// `get_utility_class` function resolves the base utility class. If `classes`
-/// contains an entry for the same key its value is appended as well.
+/// contains an entry for the same key its value is appended as well. Empty
+/// strings are ignored and duplicate keys are de-duplicated to avoid bloated
+/// `class` attributes.
+///
+/// # Examples
+/// Basic composition with user provided overrides:
+/// ```
+/// use std::collections::HashMap;
+/// use mui_utils::compose_classes;
+///
+/// let slots = HashMap::from([
+///     ("root".to_string(), vec![Some("root".into()), Some("primary".into())])
+/// ]);
+/// let classes = HashMap::from([("root".to_string(), "custom".to_string())]);
+/// let get = |s: &str| format!("MuiButton-{s}");
+/// let out = compose_classes(&slots, get, Some(&classes));
+/// assert_eq!(out.get("root").unwrap(), "MuiButton-root custom MuiButton-primary");
+/// ```
+///
+/// Duplicate and empty entries are skipped automatically:
+/// ```
+/// use std::collections::HashMap;
+/// use mui_utils::compose_classes;
+///
+/// let slots = HashMap::from([
+///     ("root".to_string(), vec![Some("root".into()), Some("root".into()), Some("".into())])
+/// ]);
+/// // Identity resolver – returns the key verbatim
+/// let out = compose_classes(&slots, |s| s.to_string(), None);
+/// assert_eq!(out.get("root").unwrap(), "root");
+/// ```
 ///
 /// # Performance
 /// Each slot is processed in a single pass and output strings are built with
@@ -20,19 +50,27 @@ where
     let mut out = HashMap::with_capacity(slots.len());
     for (slot_name, slot_values) in slots {
         let mut buf = String::new();
-        let mut first = true;
+        let mut seen = HashSet::new();
         for opt in slot_values {
             if let Some(ref value) = opt {
-                if !first {
-                    buf.push(' ');
-                } else {
-                    first = false;
-                }
-                buf.push_str(&get_utility_class(value));
-                if let Some(class_map) = classes {
-                    if let Some(extra) = class_map.get(value) {
-                        buf.push(' ');
-                        buf.push_str(extra);
+                // Avoid repeating the same utility key
+                if seen.insert(value.clone()) {
+                    let util = get_utility_class(value);
+                    if !util.is_empty() {
+                        if !buf.is_empty() {
+                            buf.push(' ');
+                        }
+                        buf.push_str(&util);
+                    }
+                    if let Some(class_map) = classes {
+                        if let Some(extra) = class_map.get(value) {
+                            if !extra.is_empty() {
+                                if !buf.is_empty() {
+                                    buf.push(' ');
+                                }
+                                buf.push_str(extra);
+                            }
+                        }
                     }
                 }
             }

--- a/crates/mui-utils/src/debounce.rs
+++ b/crates/mui-utils/src/debounce.rs
@@ -13,14 +13,28 @@
 //!
 //! let counter = std::sync::Arc::new(std::sync::Mutex::new(0));
 //! let c = counter.clone();
-//! let mut debounced = debounce(move || {
+//! let mut debounced = debounce(move |_| {
 //!     *c.lock().unwrap() += 1;
 //! }, Duration::from_millis(50));
 //!
-//! debounced();
-//! debounced();
+//! debounced(());
+//! debounced(());
 //! std::thread::sleep(Duration::from_millis(60));
 //! assert_eq!(*counter.lock().unwrap(), 1);
+//! ```
+//!
+//! Supplying a zero delay forwards calls immediately:
+//! ```
+//! use mui_utils::debounce;
+//! use std::sync::{Arc, Mutex};
+//! use std::time::Duration;
+//!
+//! let called = Arc::new(Mutex::new(0));
+//! let c = called.clone();
+//! let mut d = debounce(move |_| *c.lock().unwrap() += 1, Duration::ZERO);
+//! d(());
+//! d(());
+//! assert_eq!(*called.lock().unwrap(), 2);
 //! ```
 
 use std::time::Duration;
@@ -37,25 +51,28 @@ use wasm_bindgen::JsCast;
 /// heap allocations for the happy path and leverages conditional compilation to
 /// integrate with `wasm-bindgen` timers when targeting WebAssembly.
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
-pub fn debounce<F>(func: F, delay: Duration) -> impl FnMut() + 'static
+pub fn debounce<T, F>(func: F, delay: Duration) -> impl FnMut(T) + 'static
 where
-    F: FnMut() + 'static,
+    F: FnMut(T) + 'static,
+    T: Clone + 'static,
 {
     debounce_impl(func, delay)
 }
 
 #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
-pub fn debounce<F>(func: F, delay: Duration) -> impl FnMut() + 'static
+pub fn debounce<T, F>(func: F, delay: Duration) -> impl FnMut(T) + 'static
 where
-    F: FnMut() + Send + 'static,
+    F: FnMut(T) + Send + 'static,
+    T: Send + Clone + 'static,
 {
     debounce_impl(func, delay)
 }
 
 #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
-fn debounce_impl<F>(func: F, delay: Duration) -> impl FnMut() + 'static
+fn debounce_impl<T, F>(func: F, delay: Duration) -> impl FnMut(T) + 'static
 where
-    F: FnMut() + Send + 'static,
+    F: FnMut(T) + Send + 'static,
+    T: Send + Clone + 'static,
 {
     use std::sync::{
         atomic::{AtomicBool, Ordering},
@@ -65,44 +82,63 @@ where
 
     let func = Arc::new(Mutex::new(func));
     let pending = Arc::new(Mutex::new(None::<Arc<AtomicBool>>));
+    let latest = Arc::new(Mutex::new(None::<T>));
 
-    move || {
+    move |arg: T| {
+        if delay.is_zero() {
+            (func.lock().unwrap())(arg);
+            return;
+        }
         if let Some(flag) = pending.lock().unwrap().take() {
             flag.store(true, Ordering::SeqCst);
         }
+        *latest.lock().unwrap() = Some(arg.clone());
         let func = func.clone();
         let flag = Arc::new(AtomicBool::new(false));
+        let latest_clone = latest.clone();
         *pending.lock().unwrap() = Some(flag.clone());
         thread::spawn(move || {
             thread::sleep(delay);
             if !flag.load(Ordering::SeqCst) {
-                (func.lock().unwrap())();
+                if let Some(val) = latest_clone.lock().unwrap().take() {
+                    (func.lock().unwrap())(val);
+                }
             }
         });
     }
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
-fn debounce_impl<F>(mut func: F, delay: Duration) -> impl FnMut() + 'static
+fn debounce_impl<T, F>(mut func: F, delay: Duration) -> impl FnMut(T) + 'static
 where
-    F: FnMut() + 'static,
+    F: FnMut(T) + 'static,
+    T: Clone + 'static,
 {
     use std::cell::{Cell, RefCell};
     use std::rc::Rc;
 
     let func = Rc::new(RefCell::new(func));
     let handle = Rc::new(Cell::new(None));
+    let latest = Rc::new(RefCell::new(None::<T>));
     let ms = delay.as_millis() as i32;
 
-    move || {
+    move |arg: T| {
+        if delay.is_zero() {
+            (func.borrow_mut())(arg);
+            return;
+        }
         let window = web_sys::window().expect("window available");
         if let Some(id) = handle.get() {
             window.clear_timeout_with_handle(id);
         }
+        *latest.borrow_mut() = Some(arg.clone());
         let func = func.clone();
+        let latest_clone = latest.clone();
         let handle_clone = handle.clone();
         let closure = Closure::once_into_js(move || {
-            (func.borrow_mut())();
+            if let Some(v) = latest_clone.borrow_mut().take() {
+                (func.borrow_mut())(v);
+            }
             handle_clone.set(None);
         });
         let id = window
@@ -113,43 +149,5 @@ where
             .expect("timeout set");
         closure.forget();
         handle.set(Some(id));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use proptest::prelude::*;
-
-    // Pure algorithm used for property based testing: given a list of event
-    // times (monotonic, milliseconds) return the times when the debounced
-    // function would actually execute. Each call schedules execution `wait`
-    // milliseconds after the last input in the burst.
-    fn simulated(times: &[u64], wait: u64) -> Vec<u64> {
-        if times.is_empty() {
-            return Vec::new();
-        }
-        let mut out = Vec::new();
-        let mut last = times[0];
-        for &t in &times[1..] {
-            if t - last >= wait {
-                out.push(last + wait);
-                last = t;
-            } else {
-                last = t;
-            }
-        }
-        out.push(last + wait);
-        out
-    }
-
-    proptest! {
-        #[test]
-        fn debounced_events_are_spaced(wait in 1u64..100u64, mut times in proptest::collection::vec(0u64..1000u64, 1..20)) {
-            times.sort_unstable();
-            let out = simulated(&times, wait);
-            for w in out.windows(2) {
-                prop_assert!(w[1] - w[0] >= wait);
-            }
-        }
     }
 }

--- a/crates/mui-utils/src/throttle.rs
+++ b/crates/mui-utils/src/throttle.rs
@@ -5,21 +5,39 @@
 //! hot paths lean and predictable.
 //!
 //! # Examples
+//! Throttling a counter using an explicit unit type. Passing `()` keeps the
+//! closure generic while allowing easy integration with event handlers that
+//! pass richer arguments:
 //! ```
 //! use mui_utils::throttle;
 //! use std::time::Duration;
 //!
 //! let counter = std::sync::Arc::new(std::sync::Mutex::new(0));
 //! let c = counter.clone();
-//! let mut throttled = throttle(move || {
+//! let mut throttled = throttle(move |_| {
 //!     *c.lock().unwrap() += 1;
 //! }, Duration::from_millis(50));
 //!
-//! throttled();
-//! throttled(); // ignored
+//! throttled(());
+//! throttled(()); // ignored
 //! std::thread::sleep(Duration::from_millis(60));
-//! throttled(); // runs again
+//! throttled(()); // runs again
 //! assert_eq!(*counter.lock().unwrap(), 2);
+//! ```
+//!
+//! Supplying a zero interval disables throttling and every invocation is
+//! forwarded:
+//! ```
+//! use mui_utils::throttle;
+//! use std::sync::{Arc, Mutex};
+//! use std::time::Duration;
+//!
+//! let called = Arc::new(Mutex::new(0));
+//! let c = called.clone();
+//! let mut t = throttle(move |_| *c.lock().unwrap() += 1, Duration::ZERO);
+//! t(());
+//! t(());
+//! assert_eq!(*called.lock().unwrap(), 2);
 //! ```
 
 use std::time::Duration;
@@ -31,80 +49,58 @@ use wasm_bindgen::prelude::*;
 ///
 /// Calls to the returned closure that occur more often than `interval` will be
 /// ignored. The implementation relies on the most efficient timing primitives
-/// available for the current target.
-pub fn throttle<F>(func: F, interval: Duration) -> impl FnMut() + 'static
+/// available for the current target. If `interval` is zero the original
+/// function is returned unchanged.
+pub fn throttle<T, F>(func: F, interval: Duration) -> impl FnMut(T) + 'static
 where
-    F: FnMut() + 'static,
+    F: FnMut(T) + 'static,
 {
     throttle_impl(func, interval)
 }
 
 #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
-fn throttle_impl<F>(mut func: F, interval: Duration) -> impl FnMut() + 'static
+fn throttle_impl<T, F>(mut func: F, interval: Duration) -> impl FnMut(T) + 'static
 where
-    F: FnMut() + 'static,
+    F: FnMut(T) + 'static,
 {
     use std::sync::{Arc, Mutex};
     use std::time::Instant;
 
     let last = Arc::new(Mutex::new(None::<Instant>));
-    move || {
+    move |arg: T| {
+        if interval.is_zero() {
+            func(arg);
+            return;
+        }
         let now = Instant::now();
         let mut last_lock = last.lock().unwrap();
         if last_lock.map_or(true, |l| now.duration_since(l) >= interval) {
             *last_lock = Some(now);
-            func();
+            func(arg);
         }
     }
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
-fn throttle_impl<F>(mut func: F, interval: Duration) -> impl FnMut() + 'static
+fn throttle_impl<T, F>(mut func: F, interval: Duration) -> impl FnMut(T) + 'static
 where
-    F: FnMut() + 'static,
+    F: FnMut(T) + 'static,
 {
     use std::cell::Cell;
     use std::rc::Rc;
 
     let last = Rc::new(Cell::new(0f64));
     let ms = interval.as_millis() as f64;
-    move || {
+    move |arg: T| {
+        if interval.is_zero() {
+            func(arg);
+            return;
+        }
         let now = js_sys::Date::now();
         let prev = last.get();
         if now - prev >= ms {
             last.set(now);
-            func();
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use proptest::prelude::*;
-
-    // Pure helper for property based tests. Given monotonically increasing
-    // event times it returns the subset that would trigger execution when
-    // throttled by `interval`.
-    pub(crate) fn simulated(times: &[u64], interval: u64) -> Vec<u64> {
-        let mut out = Vec::new();
-        let mut last = None;
-        for &t in times {
-            if last.map_or(true, |l| t - l >= interval) {
-                out.push(t);
-                last = Some(t);
-            }
-        }
-        out
-    }
-
-    proptest! {
-        #[test]
-        fn throttled_events_are_spaced(interval in 1u64..100u64, mut times in proptest::collection::vec(0u64..1000u64, 1..20)) {
-            times.sort_unstable();
-            let out = simulated(&times, interval);
-            for w in out.windows(2) {
-                prop_assert!(w[1] - w[0] >= interval);
-            }
+            func(arg);
         }
     }
 }

--- a/crates/mui-utils/tests/compose_classes_prop.rs
+++ b/crates/mui-utils/tests/compose_classes_prop.rs
@@ -24,14 +24,21 @@ proptest! {
             let mut out = HashMap::new();
             for (slot, values) in &slots {
                 let mut buf = String::new();
-                let mut first = true;
+                let mut seen = std::collections::HashSet::new();
                 for opt in values {
                     if let Some(v) = opt {
-                        if !first { buf.push(' '); } else { first = false; }
-                        buf.push_str(&get(v));
-                        if let Some(extra) = classes.get(v) {
-                            buf.push(' ');
-                            buf.push_str(extra);
+                        if seen.insert(v.clone()) {
+                            let util = get(v);
+                            if !util.is_empty() {
+                                if !buf.is_empty() { buf.push(' '); }
+                                buf.push_str(&util);
+                            }
+                            if let Some(extra) = classes.get(v) {
+                                if !extra.is_empty() {
+                                    if !buf.is_empty() { buf.push(' '); }
+                                    buf.push_str(extra);
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/mui-utils/tests/debounce_prop.rs
+++ b/crates/mui-utils/tests/debounce_prop.rs
@@ -1,0 +1,34 @@
+use proptest::prelude::*;
+
+// Pure algorithm used for property based testing: given a list of event
+// times (monotonic, milliseconds) return the times when the debounced
+// function would actually execute. Each call schedules execution `wait`
+// milliseconds after the last input in the burst.
+fn simulated(times: &[u64], wait: u64) -> Vec<u64> {
+    if times.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut last = times[0];
+    for &t in &times[1..] {
+        if t - last >= wait {
+            out.push(last + wait);
+            last = t;
+        } else {
+            last = t;
+        }
+    }
+    out.push(last + wait);
+    out
+}
+
+proptest! {
+    #[test]
+    fn debounced_events_are_spaced(wait in 1u64..100u64, mut times in proptest::collection::vec(0u64..1000u64, 1..20)) {
+        times.sort_unstable();
+        let out = simulated(&times, wait);
+        for w in out.windows(2) {
+            prop_assert!(w[1] - w[0] >= wait);
+        }
+    }
+}

--- a/crates/mui-utils/tests/throttle_prop.rs
+++ b/crates/mui-utils/tests/throttle_prop.rs
@@ -1,0 +1,27 @@
+use proptest::prelude::*;
+
+// Pure helper for property based tests. Given monotonically increasing
+// event times it returns the subset that would trigger execution when
+// throttled by `interval`.
+fn simulated(times: &[u64], interval: u64) -> Vec<u64> {
+    let mut out = Vec::new();
+    let mut last = None;
+    for &t in times {
+        if last.map_or(true, |l| t - l >= interval) {
+            out.push(t);
+            last = Some(t);
+        }
+    }
+    out
+}
+
+proptest! {
+    #[test]
+    fn throttled_events_are_spaced(interval in 1u64..100u64, mut times in proptest::collection::vec(0u64..1000u64, 1..20)) {
+        times.sort_unstable();
+        let out = simulated(&times, interval);
+        for w in out.windows(2) {
+            prop_assert!(w[1] - w[0] >= interval);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand util docs with edge-case handling and examples
- add property tests and integrate throttle/debounce helpers into material components
- document throttling/debouncing and style overrides in material README

## Testing
- `cargo test -p mui-utils`
- `cargo test -p mui-material --features yew`


------
https://chatgpt.com/codex/tasks/task_e_68c738bff5d8832ea985fc1f5ce3882c