### PR TITLE
feat: theme derive improvements and css_with_theme macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
  "nom",
  "pathdiff",
  "serde",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -724,6 +724,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo"
@@ -1774,6 +1780,7 @@ dependencies = [
  "mui-system",
  "proptest",
  "stylist",
+ "trybuild",
  "wasm-bindgen",
  "yew",
 ]
@@ -2552,6 +2559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,6 +2800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "tempfile"
 version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2816,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2924,9 +2955,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -2939,13 +2985,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -2957,9 +3012,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow 0.7.13",
 ]
 
@@ -2968,6 +3032,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tracing"
@@ -2998,6 +3068,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ded9fdb81f30a5708920310bfcd9ea7482ff9cba5f54601f7a19a877d5c2392"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.5",
 ]
 
 [[package]]

--- a/crates/mui-styled-engine/Cargo.toml
+++ b/crates/mui-styled-engine/Cargo.toml
@@ -15,10 +15,14 @@ mui-styled-engine-macros = { path = "../mui-styled-engine-macros" }
 [features]
 default = []
 yew = ["mui-system/yew", "dep:yew", "dep:wasm-bindgen", "stylist/yew_integration"]
+leptos = ["mui-system/leptos"]
+dioxus = ["mui-system/dioxus"]
+sycamore = ["mui-system/sycamore"]
 
 [dev-dependencies]
 criterion = "0.5"
 proptest.workspace = true
+trybuild = "1.0"
 
 [[bench]]
 name = "style_bench"

--- a/crates/mui-styled-engine/tests/macro/expand_dioxus.rs
+++ b/crates/mui-styled-engine/tests/macro/expand_dioxus.rs
@@ -1,0 +1,6 @@
+use mui_styled_engine::css_with_theme;
+
+fn main() {
+    let style = css_with_theme!(r#"color: ${p};"#, p = theme.palette.primary.clone());
+    let _ = style.get_class_name();
+}

--- a/crates/mui-styled-engine/tests/macro/expand_leptos.rs
+++ b/crates/mui-styled-engine/tests/macro/expand_leptos.rs
@@ -1,0 +1,6 @@
+use mui_styled_engine::css_with_theme;
+
+fn main() {
+    let style = css_with_theme!(r#"color: ${p};"#, p = theme.palette.primary.clone());
+    let _ = style.get_class_name();
+}

--- a/crates/mui-styled-engine/tests/macro/expand_sycamore.rs
+++ b/crates/mui-styled-engine/tests/macro/expand_sycamore.rs
@@ -1,0 +1,6 @@
+use mui_styled_engine::css_with_theme;
+
+fn main() {
+    let style = css_with_theme!(r#"color: ${p};"#, p = theme.palette.primary.clone());
+    let _ = style.get_class_name();
+}

--- a/crates/mui-styled-engine/tests/macro/expand_yew.rs
+++ b/crates/mui-styled-engine/tests/macro/expand_yew.rs
@@ -1,0 +1,11 @@
+use mui_styled_engine::css_with_theme;
+use yew::prelude::*;
+
+#[function_component(Test)]
+fn test() -> Html {
+    // The macro still injects `use_theme` even if the theme isn't referenced.
+    let _style = css_with_theme!(r#"color: red;"#);
+    html! {}
+}
+
+fn main() {}

--- a/crates/mui-styled-engine/tests/macro_expansion.rs
+++ b/crates/mui-styled-engine/tests/macro_expansion.rs
@@ -1,0 +1,11 @@
+use trybuild::TestCases;
+
+#[test]
+fn css_with_theme_expands() {
+    let t = TestCases::new();
+    t.pass("tests/macro/expand_leptos.rs");
+    t.pass("tests/macro/expand_dioxus.rs");
+    t.pass("tests/macro/expand_sycamore.rs");
+    #[cfg(feature = "yew")]
+    t.pass("tests/macro/expand_yew.rs");
+}

--- a/crates/mui-system/Cargo.toml
+++ b/crates/mui-system/Cargo.toml
@@ -24,6 +24,8 @@ wasm-bindgen-test.workspace = true
 default = []
 yew = ["dep:yew", "dep:wasm-bindgen", "dep:web-sys"]
 leptos = ["dep:leptos", "dep:wasm-bindgen", "dep:web-sys"]
+dioxus = []
+sycamore = []
 
 [[example]]
 name = "basic"

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -21,7 +21,6 @@ pub mod container;
 pub mod grid;
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod stack;
-#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod theme_provider;
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod typography;
@@ -38,8 +37,12 @@ pub use stack::{Stack, StackDirection};
 #[allow(unused_imports)]
 pub use style::*;
 pub use theme::{Breakpoints, Palette, Theme};
-#[cfg(any(feature = "yew", feature = "leptos"))]
+#[cfg(feature = "yew")]
 pub use theme_provider::{use_theme, ThemeProvider};
+#[cfg(feature = "leptos")]
+pub use theme_provider::{use_theme, ThemeProvider};
+#[cfg(any(feature = "dioxus", feature = "sycamore"))]
+pub use theme_provider::use_theme;
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub use typography::{Typography, TypographyVariant};
 

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -53,3 +53,39 @@ mod leptos_impl {
 
 #[cfg(feature = "leptos")]
 pub use leptos_impl::{use_theme, ThemeProvider};
+
+#[cfg(feature = "dioxus")]
+mod dioxus_impl {
+    use super::*;
+
+    /// Placeholder theme hook for Dioxus backends. Currently just returns
+    /// [`Theme::default`] allowing compile-time integration tests to exercise
+    /// the styling macros without pulling in a full Dioxus dependency.
+    pub fn use_theme() -> Theme {
+        Theme::default()
+    }
+}
+
+#[cfg(feature = "dioxus")]
+pub use dioxus_impl::use_theme;
+
+#[cfg(feature = "sycamore")]
+mod sycamore_impl {
+    use super::*;
+
+    /// Placeholder theme hook for Sycamore backends mirroring the behaviour of
+    /// other frameworks. This keeps the API surface consistent while avoiding
+    /// heavyweight dependencies in tests.
+    pub fn use_theme() -> Theme {
+        Theme::default()
+    }
+}
+
+#[cfg(feature = "sycamore")]
+pub use sycamore_impl::use_theme;
+
+// Fallback implementation used when no front-end integration feature is enabled.
+#[cfg(not(any(feature = "yew", feature = "leptos", feature = "dioxus", feature = "sycamore")))]
+pub fn use_theme() -> Theme {
+    Theme::default()
+}


### PR DESCRIPTION
## Summary
- enhance `Theme` derive to merge nested structs and optional fields
- add `css_with_theme!` proc macro with auto `use_theme` and multi-framework support
- document macro migration and add compile-time UI tests across frameworks

## Testing
- `cargo test -p mui-styled-engine`
- `cargo test -p mui-styled-engine --features yew --test macro_expansion`
- `cargo test -p mui-styled-engine --features dioxus --test macro_expansion`
- `cargo test -p mui-styled-engine --features sycamore --test macro_expansion`
- `cargo test -p mui-styled-engine --features leptos --test macro_expansion` *(fails: proc macro panicked in mui-system typography)*


------
https://chatgpt.com/codex/tasks/task_e_68c73de7cc6c832e9973ba18b5088b12