### PR TITLE
docs: add cargo feature guide and feature tables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Here are a few guidelines that will help you along the way.
 - [How can I use a change that hasn't been released yet?](#how-can-i-use-a-change-that-hasnt-been-released-yet)
 - [Roadmap](#roadmap)
 - [License](#license)
+- [Cargo feature guide](docs/cargo-features.md)
 
 ## Code of conduct
 
@@ -339,6 +340,9 @@ The `mui-lab` crate contains opt-in, unstable widgets. When proposing changes to
 Expect rapid iteration and potentially breaking changes as feedback is incorporated.
 
 ## Automated Rust workflow
+
+Cargo feature flags let developers compile only the crates and icons they need.
+Consult the [Cargo feature guide](docs/cargo-features.md) for usage examples.
 
 To keep development friction low, the Rust crates in this repository share a
 set of managed tasks exposed through [`cargo xtask`](https://github.com/matklad/cargo-xtask).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Run an example:
 cargo run --package mui-yew --example hello_world
 ```
 
+## Cargo features
+
+The workspace crates disable most features by default so applications pull in
+only the components or icons they use. Consult
+[docs/cargo-features.md](docs/cargo-features.md) for a breakdown of available
+flags and example `Cargo.toml` snippets.
+
 ## Workspace layout
 
 The workspace is organized under the `crates/` directory:

--- a/crates/mui-icons-material/README.md
+++ b/crates/mui-icons-material/README.md
@@ -12,6 +12,12 @@ names to these functions.
 
 ## Feature flags
 
+| Feature | Enables | Notes |
+|---------|---------|-------|
+| `all-icons` | every SVG icon | default; convenient for prototypes but slows compilation |
+| `icon-<name>` | a single icon | specify multiple entries for the icons your app uses |
+| `update-icons` | maintenance CLI | used only to refresh the icon list |
+
 Every SVG is gated behind an opt-in Cargo feature named `icon-<file name>`. An
 umbrella `all-icons` feature pulls in the full set and is enabled by default for
 ease of use. To keep compile times and binary sizes minimal in production,
@@ -21,6 +27,8 @@ disable the default and enable only the icons your application actually uses:
 [dependencies]
 mui-icons-material = { version = "0.1", default-features = false, features = ["icon-10k_24px"] }
 ```
+
+Additional examples live in the [Cargo feature guide](../../docs/cargo-features.md).
 
 The `update_icons` tool (see below) regenerates the `[features]` block in
 `Cargo.toml` so this list stays in sync with the available SVGs.

--- a/crates/mui-material/README.md
+++ b/crates/mui-material/README.md
@@ -13,8 +13,18 @@ text inputs debounced and style overrides merged via JSON using `deep_merge`.
 
 ## Feature Flags
 
-Components are gated behind framework features. Enable `yew`, `leptos`,
-`dioxus` or `sycamore` depending on the desired front-end backend.
+Select a single front-end framework to keep builds lean. All features are
+disabled by default so applications opt in explicitly:
+
+| Feature | Enables | Notes |
+|---------|---------|-------|
+| `yew` | Yew adapter | pulls in `yew`, `wasm-bindgen`, `web-sys` and `stylist` |
+| `leptos` | Leptos adapter | activates `wasm-bindgen` and `mui-system/leptos` |
+| `dioxus` | Dioxus adapter | compiles `mui-system/dioxus` and `mui-styled-engine/dioxus` |
+| `sycamore` | Sycamore adapter | hooks into `mui-system/sycamore` |
+
+See the [Cargo feature guide](../../docs/cargo-features.md) for examples of
+disabling defaults and enabling only the framework your application requires.
 
 ## Example
 

--- a/crates/mui-utils/README.md
+++ b/crates/mui-utils/README.md
@@ -1,0 +1,20 @@
+# mui-utils
+
+Utility helpers shared across the Material UI Rust ecosystem.
+
+## Feature flags
+
+| Feature | Enables | Notes |
+|---------|---------|-------|
+| `web` | WebAssembly helpers | pulls in `wasm-bindgen`, `js-sys` and `web-sys` for timer APIs |
+
+No features are enabled by default. Opt into `web` when compiling for the
+browser:
+
+```toml
+[dependencies]
+mui-utils = { version = "0.1", default-features = false, features = ["web"] }
+```
+
+See the [Cargo feature guide](../../docs/cargo-features.md) for additional
+examples.

--- a/docs/cargo-features.md
+++ b/docs/cargo-features.md
@@ -1,0 +1,45 @@
+# Cargo feature guide
+
+Material UI Rust crates expose fine‑grained Cargo features so applications compile only what they need. Disabling defaults and enabling a small feature set keeps builds fast and binaries lean.
+
+## Components
+
+`mui-material` gates each front‑end framework behind a feature flag. Start with no default features and opt into the one you use:
+
+```toml
+[dependencies]
+mui-material = { version = "0.1", default-features = false, features = ["leptos"] }
+```
+
+The table below lists available framework adapters:
+
+| Feature   | Enables | Notes |
+|-----------|---------|-------|
+| `yew`     | Yew components | pulls in `yew`, `wasm-bindgen`, `web-sys`, `stylist` |
+| `leptos`  | Leptos components | activates `wasm-bindgen` and `mui-system/leptos` |
+| `dioxus`  | Dioxus components | compiles `mui-system/dioxus` and `mui-styled-engine/dioxus` |
+| `sycamore`| Sycamore components | hooks into `mui-system/sycamore` |
+
+## Icons
+
+`mui-icons-material` ships thousands of SVGs, each behind its own feature. The crate enables `all-icons` by default for convenience. In production disable the default and cherry‑pick only the icons your UI references:
+
+```toml
+[dependencies]
+mui-icons-material = { version = "0.1", default-features = false, features = ["icon-10k_24px"] }
+```
+
+`update-icons` is a maintenance feature that exposes a CLI used by maintainers to refresh the icon list; end users rarely need it.
+
+## Utilities
+
+`mui-utils` contains helpers that are generic enough for server or client environments. Enable the optional `web` feature when targeting WebAssembly to pull in timer bindings:
+
+```toml
+[dependencies]
+mui-utils = { version = "0.1", default-features = false, features = ["web"] }
+```
+
+## Further reading
+
+Each crate's README documents its feature flags in more depth. For workspace‑wide automation and testing commands see [CONTRIBUTING.md](../CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- document cargo feature usage for components, icons, and utilities
- add feature tables to `mui-material`, `mui-icons-material`, and `mui-utils`
- link new guide from root README and CONTRIBUTING

## Testing
- `cargo test -p mui-material -p mui-icons-material -p mui-utils`


------
https://chatgpt.com/codex/tasks/task_e_68c759f04ad4832e817d466baddf44b7