### PR TITLE
test: add accessibility wasm tests

### DIFF
--- a/crates/mui-material/tests/axe.js
+++ b/crates/mui-material/tests/axe.js
@@ -1,0 +1,9 @@
+import axe from 'axe-core';
+
+// Wrapper function exposed to wasm tests.
+// It runs axe-core against the provided DOM node and returns the violations.
+export async function runAxe(node) {
+  const results = await axe.run(node);
+  // Only return violations to keep payload small for wasm.
+  return { violations: results.violations };
+}

--- a/crates/mui-material/tests/axe.rs
+++ b/crates/mui-material/tests/axe.rs
@@ -1,0 +1,31 @@
+//! Simple bridge to the `axe-core` accessibility engine.
+//!
+//! The JS implementation lives alongside this file in `axe.js` and is imported
+//! via `wasm-bindgen`.  By centralizing the wrapper we keep individual tests
+//! focused on assertions rather than boilerplate interop code.
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+#[wasm_bindgen(module = "/tests/axe.js")]
+extern "C" {
+    #[wasm_bindgen(catch)]
+    async fn runAxe(node: JsValue) -> Result<JsValue, JsValue>;
+}
+
+/// Execute an axe-core audit against the provided DOM node.
+///
+/// The function panics if any accessibility violations are reported, causing
+/// the enclosing test to fail.  This gives us a CI gate that enforces a11y
+/// compliance for all interactive components.
+pub async fn axe_check(node: &web_sys::Element) {
+    // Invoke the JS bridge and unwrap the resulting Promise.
+    let result = runAxe(node.clone().into())
+        .await
+        .expect("axe-core execution failed");
+    // Extract the `violations` array and assert it is empty.
+    let violations = js_sys::Reflect::get(&result, &JsValue::from_str("violations"))
+        .expect("missing violations field");
+    let arr = js_sys::Array::from(&violations);
+    assert_eq!(arr.length(), 0, "Accessibility violations: {:?}", arr);
+}

--- a/crates/mui-material/tests/wasm.rs
+++ b/crates/mui-material/tests/wasm.rs
@@ -2,9 +2,16 @@
 
 use mui_material::{AppBar, Button, Snackbar, TextField};
 use mui_styled_engine::{Theme, ThemeProvider};
+use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_test::*;
 use yew::prelude::*;
 use yew::Renderer;
+
+// Expose the axe-core helper so each test can easily perform an
+// accessibility audit.  Centralizing the logic keeps individual tests
+// focused on asserting behavior rather than plumbing.
+mod axe;
+use axe::axe_check;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -105,4 +112,122 @@ fn snackbar_announces_message() {
         .unwrap()
         .expect("snackbar rendered");
     assert_eq!(div.text_content().unwrap(), "Saved");
+}
+
+// ---------------------------------------------------------------------------
+// Additional interactive component tests exercising styles and accessibility.
+// ---------------------------------------------------------------------------
+
+/// Ensure that the AppBar injects themed styles and passes an axe-core audit.
+#[wasm_bindgen_test(async)]
+async fn app_bar_style_and_accessibility() {
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <AppBar title="Dashboard" aria_label="main navigation" />
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+
+    // The styled engine injects a <style> tag into <head>. Verify the expected
+    // background color from the default theme is present so visual styling is
+    // preserved across refactors.
+    let head_html = document.head().unwrap().inner_html();
+    assert!(head_html.contains("background: #1976d2"));
+
+    axe_check(&mount).await;
+}
+
+/// Verify that buttons respond to keyboard interaction and are free of
+/// accessibility violations.
+#[wasm_bindgen_test(async)]
+async fn button_keyboard_navigation() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <Button label="Submit" />
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+
+    let button: web_sys::HtmlElement = mount
+        .query_selector("button")
+        .unwrap()
+        .unwrap()
+        .dyn_into()
+        .unwrap();
+
+    // Track click invocation so we can assert keyboard activation works.
+    let clicked = Rc::new(Cell::new(false));
+    {
+        let clicked = clicked.clone();
+        let cb = Closure::<dyn FnMut(_)>::new(move |_e: web_sys::Event| {
+            clicked.set(true);
+        });
+        button
+            .add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+            .unwrap();
+        cb.forget();
+    }
+
+    button.focus().unwrap();
+    let event = web_sys::KeyboardEvent::new_with_keyboard_event_init_dict(
+        "keydown",
+        web_sys::KeyboardEventInit::new().key("Enter"),
+    )
+    .unwrap();
+    button.dispatch_event(&event).unwrap();
+
+    assert!(clicked.get(), "Enter key should trigger click");
+    axe_check(&mount).await;
+}
+
+/// Confirm that the TextField computes inline styles based on theme tokens and
+/// remains accessible.
+#[wasm_bindgen_test(async)]
+async fn text_field_styles_and_accessibility() {
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <TextField value="" placeholder="Name" aria_label="name" />
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+
+    let input = mount
+        .query_selector("input")
+        .unwrap()
+        .expect("input rendered")
+        .dyn_into::<web_sys::HtmlInputElement>()
+        .unwrap();
+    // The component builds an inline style string. Validate that the default
+    // primary color is present which proves theme integration works.
+    let style = input.get_attribute("style").unwrap();
+    assert!(style.contains("#1976d2"));
+
+    axe_check(&mount).await;
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -135,6 +135,11 @@ fn wasm_test() -> Result<()> {
         cmd.arg("test")
             .arg("--headless")
             .arg("--chrome")
+            // All interactive components currently rely on the `yew` feature for
+            // rendering. By enabling it here we exercise the same code paths in
+            // CI and local development.
+            .arg("--features")
+            .arg("yew")
             .current_dir(krate);
         run(cmd)?;
     }

--- a/docs/rust-ci.md
+++ b/docs/rust-ci.md
@@ -32,12 +32,20 @@ grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existin
 ```
 
 ### WebAssembly Tests
-Only crates with `wasm-bindgen-test` are executed.
+Only crates with `wasm-bindgen-test` are executed. Interactive components rely
+on the `yew` feature and are automatically audited for accessibility using
+[`axe-core`](https://github.com/dequelabs/axe-core).
 ```bash
 for crate in crates/mui-joy crates/mui-material; do
-  (cd "$crate" && wasm-pack test --headless --chrome)
+  (cd "$crate" && wasm-pack test --headless --chrome --features yew)
 done
 ```
+
+### Accessibility Audits
+The `mui-material` test suite integrates `axe-core` via `wasm-bindgen` to
+validate ARIA roles, keyboard navigation and overall accessibility. Tests fail
+if any violation is detected, making a11y compliance part of the standard CI
+pipeline.
 
 ### Documentation and Benchmarks
 ```bash


### PR DESCRIPTION
## Summary
- add wasm-bindgen tests for style verification and accessibility checks via axe-core
- run wasm-pack tests with yew feature via xtask
- document wasm testing and accessibility guidance in CI docs

## Testing
- `cargo test -p xtask`
- `cargo test -p mui-material --features yew` *(fails: unexpected end of input in css_with_theme macro)*

------
https://chatgpt.com/codex/tasks/task_e_68c768e95214832e8c8b20ab8cf5efd1