### PR TITLE
docs: prepare release automation

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -147,3 +147,21 @@ jobs:
       - run: cargo xtask accessibility-audit
       # Build the JavaScript documentation site for validation
       - run: cargo xtask build-docs
+
+  publish-check:
+    name: Publish Dry Run
+    runs-on: ubuntu-latest
+    steps:
+      # Validate that each crate is ready for publication by running a dry run
+      # `cargo publish`. This catches missing metadata or ignored files early.
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          for crate in crates/*; do
+            if [ -f "$crate/Cargo.toml" ]; then
+              (cd "$crate" && cargo publish --dry-run)
+            fi
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,6 +369,37 @@ and the GitHub Actions workflow mirrors this setup. CI caches build artifacts
 and uploads coverage, documentation and benchmark reports as artifacts so that
 contributors can focus on writing code rather than on bespoke scripting.
 
+## Release workflow
+
+Versioning for the Rust crates is automated with
+[`cargo release`](https://github.com/crate-ci/cargo-release). This utility
+reads the root `release.toml` and keeps versions, tags and changelog entries in
+sync across the workspace.
+
+1. Document user visible changes in each crate's `CHANGELOG.md`.
+2. Verify everything builds and is publishable:
+
+   ```bash
+   cargo xtask test
+   cargo publish --dry-run -p <crate>
+   ```
+
+3. Bump the version and create a signed tag:
+
+   ```bash
+   cargo release <patch|minor|major> -p <crate> --execute
+   ```
+
+4. Push the commit and tag, then publish to crates.io:
+
+   ```bash
+   git push --follow-tags
+   cargo publish -p <crate>
+   ```
+
+Automating releases this way keeps the process repeatable and avoids manual
+version mismatches between crates.
+
 ## How can I use a change that hasn't been released yet?
 
 We use [pkg.pr.new](https://pkg.pr.new) to publish a working version of the packages for each pull request as a "preview."

--- a/crates/mui-headless/CHANGELOG.md
+++ b/crates/mui-headless/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-headless/Cargo.toml
+++ b/crates/mui-headless/Cargo.toml
@@ -3,6 +3,16 @@ name = "mui-headless"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
+# Standardized metadata keeps each crate aligned and enables automated tooling
+# to reason about the entire workspace without manual per-crate overrides.
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-headless"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 # Use std only; no external dependencies beyond std.

--- a/crates/mui-icons-material/CHANGELOG.md
+++ b/crates/mui-icons-material/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-icons-material/Cargo.toml
+++ b/crates/mui-icons-material/Cargo.toml
@@ -7,6 +7,18 @@ license = "MIT OR Apache-2.0"
 
 # Build script performs SVG -> Rust conversion.
 build = "build.rs"
+# Expose rich metadata so tooling and crates.io users can easily discover the
+# crate. Centralizing the repository links streamlines issue tracking and
+# reduces manual curation across multiple crates.
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-icons-material"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+# Flag the crate as experimental to set contributor expectations.
+maintenance = { status = "experimental" }
 
 [features]
 # By default include all icons so downstream users get a drop-in experience.
@@ -21,9 +33,9 @@ icon-10k_24px = []
 icon-10mp_24px = []
 # END ICON FEATURES
 
-# Internal feature used only for the maintenance CLI. Keeping it optional
-# prevents heavy HTTP/ZIP dependencies from impacting normal builds.
-update-icons = ["ureq", "zip"]
+# Internal feature used only for the maintenance CLI. `dep:` ensures the
+# optional network/ZIP dependencies stay isolated until explicitly requested.
+update-icons = ["dep:ureq", "dep:zip"]
 
 [dependencies]
 once_cell.workspace = true

--- a/crates/mui-icons/CHANGELOG.md
+++ b/crates/mui-icons/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-icons/Cargo.toml
+++ b/crates/mui-icons/Cargo.toml
@@ -6,6 +6,19 @@ description = "Bindings to Material UI's SVG icon set for Rust front-end framewo
 license = "MIT OR Apache-2.0"
 # Build script converts SVGs into memoized Rust functions.
 build = "build.rs"
+# Rich metadata surfaces crate intent on crates.io and enables automated
+# publishing workflows. The repository/homepage links funnel users to the
+# centralized documentation and issue tracker to reduce fragmentation.
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-icons"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+# Mark the crate as experimental so downstream consumers understand the API
+# surface is still evolving.
+maintenance = { status = "experimental" }
 
 [features]
 # Enable all icons by default for ease of use.
@@ -16,8 +29,9 @@ set-material = ["icon-material-10k_24px", "icon-material-10mp_24px"]
 # Individual icon features.
 icon-material-10k_24px = []
 icon-material-10mp_24px = []
-# Internal feature for the icon update utility.
-update-icons = ["ureq", "zip"]
+# Internal feature for the icon update utility. Using `dep:` ensures the
+# optional HTTP/ZIP dependencies only activate when explicitly requested.
+update-icons = ["dep:ureq", "dep:zip"]
 
 [dependencies]
 once_cell.workspace = true

--- a/crates/mui-joy/CHANGELOG.md
+++ b/crates/mui-joy/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-joy/Cargo.toml
+++ b/crates/mui-joy/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = "2021"
 description = "Joy UI components implemented in Rust leveraging mui-system."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-joy"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 mui-system = { path = "../mui-system" }

--- a/crates/mui-lab/CHANGELOG.md
+++ b/crates/mui-lab/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-lab/Cargo.toml
+++ b/crates/mui-lab/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = "2021"
 description = "Experimental widgets for MUI Rust. These APIs are unstable and subject to change."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-lab"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 once_cell = { workspace = true, optional = true }

--- a/crates/mui-material/CHANGELOG.md
+++ b/crates/mui-material/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-material/Cargo.toml
+++ b/crates/mui-material/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = "2021"
 description = "Material Design components implemented in Rust leveraging mui-system."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-material"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 mui-styled-engine = { path = "../mui-styled-engine" }

--- a/crates/mui-styled-engine-macros/CHANGELOG.md
+++ b/crates/mui-styled-engine-macros/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-styled-engine-macros/Cargo.toml
+++ b/crates/mui-styled-engine-macros/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = "2021"
 description = "Procedural macros for mui-styled-engine"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-styled-engine-macros"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [lib]
 proc-macro = true

--- a/crates/mui-styled-engine/CHANGELOG.md
+++ b/crates/mui-styled-engine/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-styled-engine/Cargo.toml
+++ b/crates/mui-styled-engine/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = "2021"
 description = "Styling engine for Material UI Rust components providing theme primitives."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-styled-engine"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 mui-system = { path = "../mui-system" }

--- a/crates/mui-system/CHANGELOG.md
+++ b/crates/mui-system/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-system/Cargo.toml
+++ b/crates/mui-system/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 edition = "2021"
 description = "Foundational styling primitives for the Material UI Rust ecosystem."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-system"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 # Use shared versions from the workspace. These dependencies are optional

--- a/crates/mui-utils/CHANGELOG.md
+++ b/crates/mui-utils/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- Initial release.

--- a/crates/mui-utils/Cargo.toml
+++ b/crates/mui-utils/Cargo.toml
@@ -2,8 +2,16 @@
 name = "mui-utils"
 version = "0.1.0"
 edition = "2021"
-description = "Utility helpers for the Material UI Rust ecosystem." 
+description = "Utility helpers for the Material UI Rust ecosystem."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/mui/mui-rust"
+homepage = "https://github.com/mui/mui-rust"
+documentation = "https://docs.rs/mui-utils"
+keywords = ["material", "ui", "web"]
+categories = ["gui"]
+
+[badges]
+maintenance = { status = "experimental" }
 
 [dependencies]
 wasm-bindgen = { workspace = true, optional = true }

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -1,0 +1,104 @@
+# Release guide
+
+This guide walks maintainers through publishing the workspace crates to
+[crates.io](https://crates.io). The process favors automation so releases are
+repeatable and low-friction.
+
+## Pre-flight checklist
+
+1. Update each crate's `CHANGELOG.md` with the upcoming changes.
+2. Ensure the repository is clean and tests pass:
+
+   ```bash
+   cargo xtask test
+   ```
+
+3. Validate the package manifests via dry run:
+
+   ```bash
+   cargo publish --dry-run -p <crate>
+   ```
+
+## Publishing steps
+
+Use [`cargo release`](https://github.com/crate-ci/cargo-release) to bump
+versions and tag commits. Release crates independently as they become ready.
+
+### mui-system
+
+```bash
+cargo release minor -p mui-system --execute
+cargo publish -p mui-system --features "yew leptos dioxus sycamore" --no-default-features
+```
+
+### mui-styled-engine
+
+```bash
+cargo release minor -p mui-styled-engine --execute
+cargo publish -p mui-styled-engine --features "yew leptos dioxus sycamore" --no-default-features
+```
+
+### mui-styled-engine-macros
+
+```bash
+cargo release minor -p mui-styled-engine-macros --execute
+cargo publish -p mui-styled-engine-macros
+```
+
+### mui-headless
+
+```bash
+cargo release minor -p mui-headless --execute
+cargo publish -p mui-headless
+```
+
+### mui-material
+
+```bash
+cargo release minor -p mui-material --execute
+cargo publish -p mui-material --features "yew leptos dioxus sycamore" --no-default-features
+```
+
+### mui-icons
+
+```bash
+cargo release minor -p mui-icons --execute
+cargo publish -p mui-icons
+```
+
+### mui-icons-material
+
+```bash
+cargo release minor -p mui-icons-material --execute
+cargo publish -p mui-icons-material
+```
+
+### mui-joy
+
+```bash
+cargo release minor -p mui-joy --execute
+cargo publish -p mui-joy --features "yew leptos" --no-default-features
+```
+
+### mui-lab
+
+```bash
+cargo release minor -p mui-lab --execute
+cargo publish -p mui-lab
+```
+
+### mui-utils
+
+```bash
+cargo release minor -p mui-utils --execute
+cargo publish -p mui-utils --features web --no-default-features
+```
+
+After publishing, push the commit and tag to the repository:
+
+```bash
+git push --follow-tags
+```
+
+This centralized approach minimizes repetitive manual work and ensures each
+crate advertises the proper feature coverage on crates.io.

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,12 @@
+# Central configuration for `cargo release`.
+# This keeps version management and tagging consistent across all crates while
+# avoiding manual repetitive steps.
+
+sign-commit = true
+push = false
+
+[workspace]
+# Manage versions for each crate independently so releases can happen as
+# components mature. The main branch is the default release target.
+independent = true
+allow-branch = ["main"]


### PR DESCRIPTION
## Summary
- document cargo-release workflow and add release guide
- add metadata and changelogs for all crates
- verify crates publish cleanly in CI

## Testing
- `cargo publish --dry-run -p mui-utils --allow-dirty`
- `cargo check --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c77289f914832eabae22ac653be315