### PR TITLE
feat(button): theme-aware rendering via css_with_theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,18 +1497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,10 +2940,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684929eeaa18b44296533430c1453f6ea0ebff8cc7182185657fc7887ad5b9d4"
 dependencies = [
- "fastrand",
  "gloo-events 0.2.0",
  "html-escape",
- "instant",
  "once_cell",
  "serde",
  "stylist-core",

--- a/crates/mui-material/Cargo.toml
+++ b/crates/mui-material/Cargo.toml
@@ -20,7 +20,7 @@ mui-headless = { path = "../mui-headless" }
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-stylist = { version = "0.13", optional = true }
+stylist = { version = "0.13", default-features = false, features = ["macros", "parser"] }
 mui-utils = { path = "../mui-utils" }
 serde_json = { workspace = true }
 web-sys = { workspace = true, optional = true }
@@ -31,7 +31,7 @@ gloo-utils = "0.2"
 
 [features]
 default = []
-yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew", "mui-styled-engine/yew", "dep:stylist", "dep:web-sys"]
+yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew", "mui-styled-engine/yew", "dep:web-sys"]
 leptos = ["dep:leptos", "dep:wasm-bindgen", "mui-system/leptos"]
 dioxus = ["mui-system/dioxus", "mui-styled-engine/dioxus"]
 sycamore = ["mui-system/sycamore", "mui-styled-engine/sycamore"]


### PR DESCRIPTION
## Summary
- render Material button with css_with_theme-derived class
- merge ButtonState ARIA attributes and centralize renderer
- document theme styling and accessibility rationale

## Testing
- `cargo test -p mui-material --quiet` *(fails: use of unresolved module or unlinked crate `wasm_bindgen`)*
- `cargo check -p mui-material --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68c7899c4d88832e950a34513813ccec