### PR TITLE
feat(material): add leptos appbar and improve adapters

### DIFF
--- a/crates/mui-material/tests/app_bar_adapters.rs
+++ b/crates/mui-material/tests/app_bar_adapters.rs
@@ -1,0 +1,26 @@
+#![cfg(all(feature = "dioxus", feature = "sycamore"))]
+
+use mui_material::app_bar::{dioxus, sycamore};
+
+#[test]
+fn dioxus_and_sycamore_render_header() {
+    let props_dx = dioxus::AppBarProps {
+        title: "Dashboard".into(),
+        aria_label: "Application header".into(),
+        color: mui_material::app_bar::AppBarColor::Primary,
+        size: mui_material::app_bar::AppBarSize::Medium,
+    };
+    let dx = dioxus::render(&props_dx);
+    assert!(dx.starts_with("<header"));
+    assert!(dx.contains("aria-label=\"Application header\""));
+
+    let props_sy = sycamore::AppBarProps {
+        title: "Dashboard".into(),
+        aria_label: "Application header".into(),
+        color: mui_material::app_bar::AppBarColor::Primary,
+        size: mui_material::app_bar::AppBarSize::Medium,
+    };
+    let sy = sycamore::render(&props_sy);
+    assert!(sy.starts_with("<header"));
+    assert!(sy.contains("aria-label=\"Application header\""));
+}


### PR DESCRIPTION
## Summary
- add Leptos AppBar component using theme-aware styling
- render Dioxus and Sycamore AppBar adapters with ARIA metadata
- document theme resolution across framework modules

## Testing
- `cargo test -p mui-material --test button_adapters --no-default-features` *(fails: assertion mismatch in existing test)*
- `cargo test -p mui-material --features "dioxus sycamore leptos"` *(fails: unresolved import in dioxus-web crate)*

------
https://chatgpt.com/codex/tasks/task_e_68c7950d9d14832ea3d196120301c4a5