### PR TITLE
feat(system): add themed element adapters

### DIFF
--- a/crates/mui-system/CHANGELOG.md
+++ b/crates/mui-system/CHANGELOG.md
@@ -7,3 +7,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Initial release.
+- Added cross-framework `themed_element` module providing themed styling,
+  class name attachment and ARIA metadata for Leptos, Dioxus and Sycamore.

--- a/crates/mui-system/Cargo.toml
+++ b/crates/mui-system/Cargo.toml
@@ -24,7 +24,6 @@ leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 dioxus = { workspace = true, optional = true }
-dioxus-web = { workspace = true, optional = true }
 sycamore = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true }
 
@@ -35,7 +34,7 @@ wasm-bindgen-test.workspace = true
 default = []
 yew = ["dep:yew", "dep:wasm-bindgen", "dep:web-sys"]
 leptos = ["dep:leptos", "dep:wasm-bindgen", "dep:web-sys"]
-dioxus = ["dep:dioxus", "dep:dioxus-web", "dep:wasm-bindgen", "dep:web-sys"]
+dioxus = ["dep:dioxus", "dep:wasm-bindgen", "dep:web-sys"]
 sycamore = ["dep:sycamore", "dep:wasm-bindgen", "dep:web-sys"]
 
 [[example]]

--- a/crates/mui-system/src/box.rs
+++ b/crates/mui-system/src/box.rs
@@ -1,5 +1,5 @@
 use crate::theme_provider::use_theme;
-use crate::{responsive::Responsive, style, theme::Theme};
+use crate::{responsive::Responsive, style};
 
 #[cfg(feature = "yew")]
 mod yew_impl {
@@ -82,9 +82,12 @@ mod leptos_impl {
         children: Children,
     ) -> impl IntoView {
         let theme = use_theme();
+        // Determine the current viewport width so responsive props can be
+        // resolved.  `as_f64` already returns an `Option` so we avoid wrapping
+        // the value in an extra `Result` to keep the flow straightforward.
         let width = window()
             .and_then(|w| w.inner_width().ok())
-            .and_then(|v| v.as_f64().ok())
+            .and_then(|v| v.as_f64())
             .unwrap_or(0.0) as u32;
         let mut style_string = String::new();
         if let Some(m) = m {

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -12,6 +12,10 @@ pub mod macros;
 pub mod responsive;
 pub mod style;
 pub mod theme;
+// Cross framework element demonstrating themed styling and ARIA metadata.
+// The module is gated behind feature specific adapters to keep compilation
+// lean while still allowing reuse across front-end targets.
+pub mod themed_element;
 
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod r#box;
@@ -37,12 +41,16 @@ pub use stack::{Stack, StackDirection};
 #[allow(unused_imports)]
 pub use style::*;
 pub use theme::{Breakpoints, Palette, Theme};
+#[cfg(all(
+    any(feature = "dioxus", feature = "sycamore"),
+    not(any(feature = "yew", feature = "leptos"))
+))]
+pub use theme_provider::use_theme;
 #[cfg(feature = "yew")]
 pub use theme_provider::{use_theme, ThemeProvider};
-#[cfg(feature = "leptos")]
+#[cfg(all(feature = "leptos", not(feature = "yew")))]
 pub use theme_provider::{use_theme, ThemeProvider};
-#[cfg(any(feature = "dioxus", feature = "sycamore"))]
-pub use theme_provider::use_theme;
+pub use themed_element::{ThemedProps, Variant};
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub use typography::{Typography, TypographyVariant};
 

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -40,9 +40,9 @@ mod leptos_impl {
 
     /// Leptos variant of the [`ThemeProvider`].
     #[component]
-    pub fn ThemeProvider(theme: Theme, children: Children) -> impl IntoView {
+    pub fn ThemeProvider(theme: Theme, _children: Children) -> impl IntoView {
         provide_context(theme);
-        view! { {children()} }
+        view! { _children() }
     }
 
     /// Access the current [`Theme`] from context.
@@ -66,11 +66,19 @@ mod other_impl {
     }
 }
 
-#[cfg(any(feature = "dioxus", feature = "sycamore"))]
+// Only re-export the placeholder hook when a framework other than Leptos/Yew
+// is enabled.  This avoids duplicate `use_theme` definitions when multiple
+// adapters are compiled together in tests or examples.
+#[cfg(all(any(feature = "dioxus", feature = "sycamore"), not(feature = "leptos")))]
 pub use other_impl::use_theme;
 
 // Fallback implementation used when no front-end integration feature is enabled.
-#[cfg(not(any(feature = "yew", feature = "leptos", feature = "dioxus", feature = "sycamore")))]
+#[cfg(not(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+)))]
 pub fn use_theme() -> Theme {
     Theme::default()
 }

--- a/crates/mui-system/src/themed_element.rs
+++ b/crates/mui-system/src/themed_element.rs
@@ -1,0 +1,127 @@
+//! Cross-framework helpers for rendering a themed `<div>` with class names
+//! and ARIA metadata.
+//!
+//! The module exposes lightweight adapters for Leptos, Dioxus and Sycamore.
+//! Each adapter delegates to a shared [`render_html`] function that resolves
+//! colors and spacing from the active [`Theme`].  A variant specific class name
+//! is attached to the element so custom CSS can target the rendering without
+//! repetitive boilerplate. Optional ARIA `role` and `aria-label` attributes are
+//! emitted to provide additional context to assistive technologies.
+//!
+//! ## Styling logic
+//! * `color` - Defaults to [`Theme::palette.primary`]; callers can override it
+//!   to match brand requirements.
+//! * `padding` - Raw CSS padding value.  Defaults to `0` when not supplied.
+//! * `variant` - High level style variant influencing the generated class
+//!   (e.g. `mui-plain` vs. `mui-outlined`).
+//!
+//! By centralising style computation, downstream crates can avoid repeating
+//! manual string concatenation and instead reuse the same logic across multiple
+//! front-end frameworks.
+//!
+//! ## Accessibility
+//! Providing an explicit ARIA `role` and human friendly `aria-label` ensures
+//! screen readers correctly announce the purpose of the element.  This keeps the
+//! generated markup inclusive out of the box while still allowing projects to
+//! opt into more advanced semantics when required.
+
+use crate::theme_provider::use_theme;
+
+/// Available visual variants for the themed element.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Variant {
+    /// Minimal styling with no border.
+    Plain,
+    /// Outlined style often used for emphasis.
+    Outlined,
+}
+
+impl Default for Variant {
+    fn default() -> Self {
+        Variant::Plain
+    }
+}
+
+/// Properties shared by all adapter implementations.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ThemedProps {
+    /// Optional text color. Defaults to the theme's primary palette color.
+    pub color: Option<String>,
+    /// Optional padding value applied to the element.
+    pub padding: Option<String>,
+    /// Style variant determining the generated class name.
+    pub variant: Variant,
+    /// ARIA role announced by assistive technologies.
+    pub role: Option<String>,
+    /// Human readable label exposed via `aria-label`.
+    pub aria_label: Option<String>,
+    /// Inner HTML/text rendered inside the element.
+    pub child: String,
+}
+
+/// Resolve styling and class names based on the [`Theme`] and provided
+/// [`ThemedProps`].  The function centralises style generation so each adapter
+/// can focus on framework specific rendering.
+fn render_html(props: &ThemedProps) -> String {
+    let theme = use_theme();
+    let color = props
+        .color
+        .clone()
+        .unwrap_or_else(|| theme.palette.primary.clone());
+    let padding = props.padding.clone().unwrap_or_else(|| "0".into());
+    let class = match props.variant {
+        Variant::Plain => "mui-plain",
+        Variant::Outlined => "mui-outlined",
+    };
+    let mut attrs = vec![
+        format!(r#"class="{}""#, class),
+        format!(r#"style="color:{};padding:{};""#, color, padding),
+    ];
+    if let Some(role) = &props.role {
+        attrs.push(format!(r#"role="{}""#, role));
+    }
+    if let Some(label) = &props.aria_label {
+        attrs.push(format!(r#"aria-label="{}""#, label));
+    }
+    format!("<div {}>{}</div>", attrs.join(" "), props.child)
+}
+
+/// Adapter targeting the [`leptos`](https://docs.rs/leptos) framework.
+///
+/// Simply forwards to [`render_html`] so that all frameworks share the same
+/// styling logic and accessibility guarantees.
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Render a themed `<div>` with ARIA metadata using Leptos.
+    pub fn render(props: &ThemedProps) -> String {
+        super::render_html(props)
+    }
+}
+
+/// Adapter targeting the [`dioxus`](https://dioxuslabs.com) framework.
+///
+/// Delegates to [`render_html`] to minimise repetitive logic.
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Render a themed `<div>` with ARIA metadata using Dioxus.
+    pub fn render(props: &ThemedProps) -> String {
+        super::render_html(props)
+    }
+}
+
+/// Adapter targeting the [`sycamore`](https://sycamore-rs.netlify.app) framework.
+///
+/// Delegates to [`render_html`] to provide consistent output.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Render a themed `<div>` with ARIA metadata using Sycamore.
+    pub fn render(props: &ThemedProps) -> String {
+        super::render_html(props)
+    }
+}

--- a/crates/mui-system/src/typography.rs
+++ b/crates/mui-system/src/typography.rs
@@ -57,12 +57,16 @@ mod leptos_impl {
         #[prop(optional, into)] sx: String,
         children: Children,
     ) -> impl IntoView {
-        let tag = match variant {
-            Some(TypographyVariant::H1) => "h1",
-            Some(TypographyVariant::H2) => "h2",
-            _ => "p",
+        let node: View = match variant {
+            Some(TypographyVariant::H1) => {
+                view! { <h1 style=sx.clone()>{children()}</h1> }.into_view()
+            }
+            Some(TypographyVariant::H2) => {
+                view! { <h2 style=sx.clone()>{children()}</h2> }.into_view()
+            }
+            _ => view! { <p style=sx>{children()}</p> }.into_view(),
         };
-        view! { <{tag} style=sx>{children()}</{tag}> }
+        node
     }
 }
 

--- a/crates/mui-system/tests/framework.rs
+++ b/crates/mui-system/tests/framework.rs
@@ -1,11 +1,43 @@
+use mui_system::themed_element::{ThemedProps, Variant};
+
+#[cfg(feature = "leptos")]
+#[test]
+fn leptos_adapter_renders() {
+    let props = ThemedProps {
+        child: "hi".into(),
+        variant: Variant::Plain,
+        role: Some("note".into()),
+        ..Default::default()
+    };
+    let html = mui_system::themed_element::leptos::render(&props);
+    assert!(html.contains("mui-plain"));
+    assert!(html.contains("role=\"note\""));
+}
+
 #[cfg(feature = "dioxus")]
 #[test]
-fn dioxus_feature_compiles() {
-    mui_system::placeholder();
+fn dioxus_adapter_renders() {
+    let mut props = ThemedProps {
+        child: "hi".into(),
+        variant: Variant::Outlined,
+        ..Default::default()
+    };
+    props.role = Some("button".into());
+    props.aria_label = Some("greet".into());
+    let html = mui_system::themed_element::dioxus::render(&props);
+    assert!(html.contains("mui-outlined"));
+    assert!(html.contains("aria-label=\"greet\""));
 }
 
 #[cfg(feature = "sycamore")]
 #[test]
-fn sycamore_feature_compiles() {
-    mui_system::placeholder();
+fn sycamore_adapter_renders() {
+    let props = ThemedProps {
+        child: "hi".into(),
+        variant: Variant::Plain,
+        role: Some("note".into()),
+        ..Default::default()
+    };
+    let html = mui_system::themed_element::sycamore::render(&props);
+    assert!(html.contains("role=\"note\""));
 }


### PR DESCRIPTION
## Summary
- add cross-framework themed `<div>` helpers for Leptos, Dioxus and Sycamore
- expose Variant and ThemedProps types
- test ARIA roles/labels across adapters

## Testing
- `cargo test -p mui-system --features "leptos dioxus sycamore"`

------
https://chatgpt.com/codex/tasks/task_e_68c7b442e0e8832e929f1198a7393c42