### PR TITLE
Refactor TextField styling and expand framework support

### DIFF
--- a/crates/mui-material/Cargo.toml
+++ b/crates/mui-material/Cargo.toml
@@ -22,7 +22,6 @@ yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 stylist = { version = "0.13", default-features = false, features = ["macros", "parser"] }
 mui-utils = { path = "../mui-utils" }
-serde_json = { workspace = true }
 web-sys = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/mui-material/README.md
+++ b/crates/mui-material/README.md
@@ -15,7 +15,8 @@ accurately describe the UI without additional boilerplate.
 
 Utilities from [`mui-utils`](../mui-utils) are integrated to provide
 enterprise-friendly ergonomics: button callbacks can be throttled,
-text inputs debounced and style overrides merged via JSON using `deep_merge`.
+text inputs debounced and style overrides appended directly within
+`css_with_theme!` blocks.
 
 ## Feature Flags
 
@@ -38,7 +39,6 @@ disabling defaults and enabling only the framework your application requires.
 use mui_material::{Button, AppBar, TextField};
 use mui_styled_engine::{ThemeProvider, Theme};
 use yew::prelude::*;
-use serde_json::json;
 
 #[function_component(App)]
 fn app() -> Html {
@@ -53,7 +53,7 @@ fn app() -> Html {
                 placeholder="Search"
                 aria_label="search"
                 debounce_ms={300}
-                style_overrides={json!({"background": "#eee"})}
+                style_overrides={"background: #eee;"}
             />
         </ThemeProvider>
     }


### PR DESCRIPTION
## Summary
- replace JSON style assembly with `css_with_theme!` and merge optional overrides
- add Leptos adapter plus Dioxus/Sycamore render helpers for `TextField`
- document theme usage, debouncing, and accessibility in `mui-material`

## Testing
- `cargo test -p mui-material --no-default-features --features yew` *(fails: no field `palette` in `mui-system`)*
- `cargo test -p mui-material --no-default-features --features leptos` *(fails: compile errors in `mui-material`)*

------
https://chatgpt.com/codex/tasks/task_e_68c81696e8bc832eaee929ae6aa6ef16