### PR TITLE
Add cross-framework component rendering tests

### DIFF
--- a/crates/mui-material/tests/app_bar_adapters.rs
+++ b/crates/mui-material/tests/app_bar_adapters.rs
@@ -1,26 +1,46 @@
-#![cfg(all(feature = "dioxus", feature = "sycamore"))]
+#![cfg(any(feature = "dioxus", feature = "sycamore"))]
 
-use mui_material::app_bar::{dioxus, sycamore};
+/// Verify that each framework adapter for [`AppBar`] emits a `<header>` element
+/// with the generated class and required ARIA attributes. Tests are compiled
+/// per feature so frameworks can be exercised independently.
 
-#[test]
-fn dioxus_and_sycamore_render_header() {
-    let props_dx = dioxus::AppBarProps {
-        title: "Dashboard".into(),
-        aria_label: "Application header".into(),
-        color: mui_material::app_bar::AppBarColor::Primary,
-        size: mui_material::app_bar::AppBarSize::Medium,
-    };
-    let dx = dioxus::render(&props_dx);
-    assert!(dx.starts_with("<header"));
-    assert!(dx.contains("aria-label=\"Application header\""));
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use mui_material::app_bar::dioxus;
 
-    let props_sy = sycamore::AppBarProps {
-        title: "Dashboard".into(),
-        aria_label: "Application header".into(),
-        color: mui_material::app_bar::AppBarColor::Primary,
-        size: mui_material::app_bar::AppBarSize::Medium,
-    };
-    let sy = sycamore::render(&props_sy);
-    assert!(sy.starts_with("<header"));
-    assert!(sy.contains("aria-label=\"Application header\""));
+    #[test]
+    fn renders_header_with_aria() {
+        let props = dioxus::AppBarProps {
+            title: "Dashboard".into(),
+            aria_label: "Application header".into(),
+            color: mui_material::app_bar::AppBarColor::Primary,
+            size: mui_material::app_bar::AppBarSize::Medium,
+        };
+        let out = dioxus::render(&props);
+        assert!(out.starts_with("<header"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"banner\""));
+        assert!(out.contains("aria-label=\"Application header\""));
+    }
 }
+
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use mui_material::app_bar::sycamore;
+
+    #[test]
+    fn renders_header_with_aria() {
+        let props = sycamore::AppBarProps {
+            title: "Dashboard".into(),
+            aria_label: "Application header".into(),
+            color: mui_material::app_bar::AppBarColor::Primary,
+            size: mui_material::app_bar::AppBarSize::Medium,
+        };
+        let out = sycamore::render(&props);
+        assert!(out.starts_with("<header"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"banner\""));
+        assert!(out.contains("aria-label=\"Application header\""));
+    }
+}
+

--- a/crates/mui-material/tests/button_adapters.rs
+++ b/crates/mui-material/tests/button_adapters.rs
@@ -1,22 +1,84 @@
 use mui_headless::button::ButtonState;
 use mui_material::button::{self, ButtonProps};
 
-#[test]
-fn all_adapters_render_consistently() {
-    let props = ButtonProps::new("Save");
-    let state = ButtonState::new(false, None);
-    let expected = "<button role=\"button\" aria-pressed=\"false\">Save</button>";
-    assert_eq!(button::yew::render(&props, &state), expected);
-    assert_eq!(button::leptos::render(&props, &state), expected);
-    assert_eq!(button::dioxus::render(&props, &state), expected);
-    assert_eq!(button::sycamore::render(&props, &state), expected);
+/// Each framework adapter should emit a `<button>` element with the generated
+/// class, `role="button"` and the current `aria-pressed` state.
+
+#[cfg(feature = "yew")]
+mod yew_tests {
+    use super::*;
+
+    #[test]
+    fn renders_with_aria() {
+        let props = ButtonProps::new("Save");
+        let state = ButtonState::new(false, None);
+        let out = button::yew::render(&props, &state);
+        assert!(out.starts_with("<button"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"button\""));
+        assert!(out.contains("aria-pressed=\"false\""));
+        assert!(out.ends_with(">Save</button>"));
+    }
+
+    #[test]
+    fn pressed_state_reflects_in_output() {
+        let props = ButtonProps::new("Toggle");
+        let mut state = ButtonState::new(false, None);
+        state.press(|_| {}); // toggle to pressed
+        let out = button::yew::render(&props, &state);
+        assert!(out.contains("class=\""));
+        assert!(out.contains("aria-pressed=\"true\""));
+    }
 }
 
-#[test]
-fn pressed_state_reflects_in_output() {
-    let props = ButtonProps::new("Toggle");
-    let mut state = ButtonState::new(false, None);
-    state.press(|_| {}); // toggle to pressed
-    let rendered = button::yew::render(&props, &state);
-    assert!(rendered.contains("aria-pressed=\"true\""));
+#[cfg(feature = "leptos")]
+mod leptos_tests {
+    use super::*;
+
+    #[test]
+    fn renders_with_aria() {
+        let props = ButtonProps::new("Save");
+        let state = ButtonState::new(false, None);
+        let out = button::leptos::render(&props, &state);
+        assert!(out.starts_with("<button"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"button\""));
+        assert!(out.contains("aria-pressed=\"false\""));
+        assert!(out.ends_with(">Save</button>"));
+    }
 }
+
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use super::*;
+
+    #[test]
+    fn renders_with_aria() {
+        let props = ButtonProps::new("Save");
+        let state = ButtonState::new(false, None);
+        let out = button::dioxus::render(&props, &state);
+        assert!(out.starts_with("<button"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"button\""));
+        assert!(out.contains("aria-pressed=\"false\""));
+        assert!(out.ends_with(">Save</button>"));
+    }
+}
+
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use super::*;
+
+    #[test]
+    fn renders_with_aria() {
+        let props = ButtonProps::new("Save");
+        let state = ButtonState::new(false, None);
+        let out = button::sycamore::render(&props, &state);
+        assert!(out.starts_with("<button"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"button\""));
+        assert!(out.contains("aria-pressed=\"false\""));
+        assert!(out.ends_with(">Save</button>"));
+    }
+}
+

--- a/crates/mui-material/tests/card_adapters.rs
+++ b/crates/mui-material/tests/card_adapters.rs
@@ -1,0 +1,38 @@
+#![cfg(any(feature = "dioxus", feature = "sycamore"))]
+
+/// Ensure the lightweight card adapters emit a themed class on the root `<div>`
+/// container. Cards do not expose additional ARIA metadata today so verifying
+/// the presence of the class guards against style regressions.
+
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use mui_material::card::dioxus;
+
+    #[test]
+    fn renders_div_with_class() {
+        let props = dioxus::CardProps {
+            children: "content".into(),
+        };
+        let out = dioxus::render(&props);
+        assert!(out.starts_with("<div"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains(">content</div>"));
+    }
+}
+
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use mui_material::card::sycamore;
+
+    #[test]
+    fn renders_div_with_class() {
+        let props = sycamore::CardProps {
+            children: "content".into(),
+        };
+        let out = sycamore::render(&props);
+        assert!(out.starts_with("<div"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains(">content</div>"));
+    }
+}
+

--- a/crates/mui-material/tests/dialog_adapters.rs
+++ b/crates/mui-material/tests/dialog_adapters.rs
@@ -1,0 +1,51 @@
+#![cfg(any(feature = "dioxus", feature = "sycamore"))]
+
+/// Validate that dialog adapters attach the generated class and ARIA metadata
+/// when open while emitting no markup when closed.
+
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use mui_material::dialog::dioxus;
+
+    #[test]
+    fn open_and_closed_states() {
+        let props = dioxus::DialogProps {
+            open: true,
+            children: "body".into(),
+            aria_label: "Settings".into(),
+        };
+        let out = dioxus::render(&props);
+        assert!(out.starts_with("<div"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"dialog\""));
+        assert!(out.contains("aria-modal=\"true\""));
+        assert!(out.contains("aria-label=\"Settings\""));
+
+        let closed = dioxus::render(&dioxus::DialogProps { open: false, ..Default::default() });
+        assert!(closed.is_empty());
+    }
+}
+
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use mui_material::dialog::sycamore;
+
+    #[test]
+    fn open_and_closed_states() {
+        let props = sycamore::DialogProps {
+            open: true,
+            children: "body".into(),
+            aria_label: "Settings".into(),
+        };
+        let out = sycamore::render(&props);
+        assert!(out.starts_with("<div"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("role=\"dialog\""));
+        assert!(out.contains("aria-modal=\"true\""));
+        assert!(out.contains("aria-label=\"Settings\""));
+
+        let closed = sycamore::render(&sycamore::DialogProps { open: false, ..Default::default() });
+        assert!(closed.is_empty());
+    }
+}
+

--- a/crates/mui-material/tests/text_field_adapters.rs
+++ b/crates/mui-material/tests/text_field_adapters.rs
@@ -1,0 +1,54 @@
+#![cfg(any(feature = "dioxus", feature = "sycamore"))]
+
+use mui_material::text_field::{TextFieldColor, TextFieldSize, TextFieldVariant};
+
+/// The text field adapters render an `<input>` element with a themed class and
+/// accessible `aria-label`. Assertions are performed per framework so that each
+/// adapter can be compiled independently.
+
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use super::*;
+    use mui_material::text_field::dioxus;
+
+    #[test]
+    fn renders_input_with_class_and_label() {
+        let props = dioxus::TextFieldProps {
+            value: "v".into(),
+            placeholder: "p".into(),
+            aria_label: "Email".into(),
+            color: TextFieldColor::Primary,
+            size: TextFieldSize::Medium,
+            variant: TextFieldVariant::Outlined,
+            style_overrides: None,
+        };
+        let out = dioxus::render(&props);
+        assert!(out.starts_with("<input"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("aria-label=\"Email\""));
+    }
+}
+
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use super::*;
+    use mui_material::text_field::sycamore;
+
+    #[test]
+    fn renders_input_with_class_and_label() {
+        let props = sycamore::TextFieldProps {
+            value: "v".into(),
+            placeholder: "p".into(),
+            aria_label: "Email".into(),
+            color: TextFieldColor::Primary,
+            size: TextFieldSize::Medium,
+            variant: TextFieldVariant::Outlined,
+            style_overrides: None,
+        };
+        let out = sycamore::render(&props);
+        assert!(out.starts_with("<input"));
+        assert!(out.contains("class=\""), "missing class attribute: {}", out);
+        assert!(out.contains("aria-label=\"Email\""));
+    }
+}
+

--- a/docs/rust-ci.md
+++ b/docs/rust-ci.md
@@ -47,6 +47,13 @@ validate ARIA roles, keyboard navigation and overall accessibility. Tests fail
 if any violation is detected, making a11y compliance part of the standard CI
 pipeline.
 
+### Component Rendering Assertions
+
+Cross-framework unit tests in `mui-material` render each component and verify
+that the generated HTML includes the hashed CSS class and expected ARIA
+metadata. These structured assertions guard against regressions in both styling
+and accessibility across adapters.
+
 ### Documentation and Benchmarks
 ```bash
 cargo doc --no-deps --workspace


### PR DESCRIPTION
## Summary
- add per-framework adapter tests ensuring generated class names and ARIA roles/labels for AppBar, Button, Card, Dialog, and TextField
- document new rendering assertions in rust CI guide

## Testing
- `cargo test -p mui-material --no-default-features --features "dioxus sycamore"` *(fails: the name `Snackbar` is defined multiple times)*
- `cargo test -p mui-material --no-default-features --features yew` *(fails: no field `palette` on type `impl yew::Hook<...>`)*

------
https://chatgpt.com/codex/tasks/task_e_68c8270ad230832e8f1a65f4bf6cb6d1