### PR TITLE
Add responsive breakpoint handling to mui-system layouts

### DIFF
--- a/crates/mui-system/README.md
+++ b/crates/mui-system/README.md
@@ -30,6 +30,80 @@ mui-system = { version = "0.1", features = ["yew"] }
 
 Available features include `yew`, `leptos`, `dioxus` and `sycamore`.
 
+### Responsive props
+
+Every layout primitive understands breakpoint aware values through the
+`Responsive<T>` helper. Supply an `xs` baseline and optionally override any of
+the larger breakpoints (`sm`, `md`, `lg`, `xl`). The active viewport width is
+pulled from the current browser context and resolved automatically before the
+style string is emitted.
+
+```rust
+use mui_system::{
+    container::build_container_style,
+    grid::build_grid_style,
+    r#box::{build_box_style, BoxStyleInputs},
+    responsive::Responsive,
+    stack::{build_stack_style, StackDirection},
+    Theme,
+};
+
+let theme = Theme::default();
+let columns = Responsive { xs: 4, sm: Some(8), md: Some(12), lg: None, xl: Some(16) };
+let span = Responsive { xs: 4, sm: Some(6), md: Some(6), lg: Some(8), xl: Some(12) };
+let grid_styles = build_grid_style(900, &theme.breakpoints, Some(&columns), Some(&span), None, None, "");
+
+let max_width = Responsive { xs: "100%".into(), sm: Some("640px".into()), md: Some("960px".into()), lg: Some("1200px".into()), xl: Some("1440px".into()) };
+let container_styles = build_container_style(1280, &theme.breakpoints, Some(&max_width), "padding:24px;");
+
+let spacing = Responsive { xs: "4px".into(), sm: Some("8px".into()), md: Some("16px".into()), lg: None, xl: Some("32px".into()) };
+let stack_styles = build_stack_style(1000, &theme.breakpoints, Some(StackDirection::Row), Some(&spacing), None, Some("space-between"), "");
+
+let font_size = Responsive { xs: "14px".into(), sm: None, md: Some("16px".into()), lg: Some("18px".into()), xl: None };
+let margin = Responsive::from(String::from("8px"));
+let padding = Responsive::from(String::from("16px"));
+let width = Responsive::from(String::from("100%"));
+let box_styles = build_box_style(
+    1100,
+    &theme.breakpoints,
+    BoxStyleInputs {
+        margin: Some(&margin),
+        padding: Some(&padding),
+        font_size: Some(&font_size),
+        font_weight: None,
+        line_height: None,
+        letter_spacing: None,
+        color: None,
+        background_color: None,
+        width: Some(&width),
+        height: None,
+        min_width: None,
+        max_width: None,
+        min_height: None,
+        max_height: None,
+        position: None,
+        top: None,
+        right: None,
+        bottom: None,
+        left: None,
+        display: Some("flex"),
+        align_items: Some("center"),
+        justify_content: Some("space-between"),
+        sx: "border-radius:8px;",
+    },
+);
+
+assert!(grid_styles.contains("width:50%;"));
+assert!(container_styles.contains("max-width:1200px;"));
+assert!(stack_styles.contains("gap:16px;"));
+assert!(box_styles.contains("font-size:18px;"));
+```
+
+The helper builders above are available to integration tests as well, keeping
+the breakpoint logic centralised and encouraging automation over manual styling
+rules. Framework adapters (Yew, Leptos, etc.) invoke the same functions under
+the hood so behaviour is identical at runtime.
+
 ## Legacy JavaScript Package
 
 The original `packages/mui-system` directory from the upstream project has been

--- a/crates/mui-system/src/box.rs
+++ b/crates/mui-system/src/box.rs
@@ -1,13 +1,222 @@
-use crate::theme_provider::use_theme;
-use crate::{responsive::Responsive, style};
+use crate::{responsive::Responsive, style, theme::Breakpoints};
+
+/// Lightweight descriptor passed into [`build_box_style`].  The struct keeps the
+/// rendering code terse because the framework adapters can forward borrowed
+/// references rather than cloning every [`Responsive`] value.
+pub struct BoxStyleInputs<'a> {
+    pub margin: Option<&'a Responsive<String>>,
+    pub padding: Option<&'a Responsive<String>>,
+    pub font_size: Option<&'a Responsive<String>>,
+    pub font_weight: Option<&'a Responsive<String>>,
+    pub line_height: Option<&'a Responsive<String>>,
+    pub letter_spacing: Option<&'a Responsive<String>>,
+    pub color: Option<&'a Responsive<String>>,
+    pub background_color: Option<&'a Responsive<String>>,
+    pub width: Option<&'a Responsive<String>>,
+    pub height: Option<&'a Responsive<String>>,
+    pub min_width: Option<&'a Responsive<String>>,
+    pub max_width: Option<&'a Responsive<String>>,
+    pub min_height: Option<&'a Responsive<String>>,
+    pub max_height: Option<&'a Responsive<String>>,
+    pub position: Option<&'a Responsive<String>>,
+    pub top: Option<&'a Responsive<String>>,
+    pub right: Option<&'a Responsive<String>>,
+    pub bottom: Option<&'a Responsive<String>>,
+    pub left: Option<&'a Responsive<String>>,
+    pub display: Option<&'a str>,
+    pub align_items: Option<&'a str>,
+    pub justify_content: Option<&'a str>,
+    pub sx: &'a str,
+}
+
+fn apply_responsive_style<F>(
+    style: &mut String,
+    width: u32,
+    breakpoints: &Breakpoints,
+    value: Option<&Responsive<String>>,
+    mut renderer: F,
+) where
+    F: FnMut(String) -> String,
+{
+    if let Some(responsive) = value {
+        let resolved = responsive.resolve(width, breakpoints);
+        style.push_str(&renderer(resolved));
+    }
+}
+
+/// Assembles the inline CSS string for [`Box`] based on the supplied responsive
+/// props. Centralising the resolver keeps behaviour identical across the Yew
+/// and Leptos adapters and gives the integration tests something deterministic
+/// to exercise.
+#[doc(hidden)]
+pub fn build_box_style(
+    width: u32,
+    breakpoints: &Breakpoints,
+    inputs: BoxStyleInputs<'_>,
+) -> String {
+    let mut style_string = String::new();
+
+    // Spacing ----------------------------------------------------------------
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.margin,
+        |value| style::margin(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.padding,
+        |value| style::padding(value),
+    );
+
+    // Typography -------------------------------------------------------------
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.font_size,
+        |value| style::font_size(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.font_weight,
+        |value| style::font_weight(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.line_height,
+        |value| style::line_height(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.letter_spacing,
+        |value| style::letter_spacing(value),
+    );
+
+    // Sizing -----------------------------------------------------------------
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.width,
+        |value| style::width(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.height,
+        |value| style::height(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.min_width,
+        |value| style::min_width(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.max_width,
+        |value| style::max_width(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.min_height,
+        |value| style::min_height(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.max_height,
+        |value| style::max_height(value),
+    );
+
+    // Color ------------------------------------------------------------------
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.color,
+        |value| style::color(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.background_color,
+        |value| style::background_color(value),
+    );
+
+    // Positioning ------------------------------------------------------------
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.position,
+        |value| style::position(value),
+    );
+    apply_responsive_style(&mut style_string, width, breakpoints, inputs.top, |value| {
+        style::top(value)
+    });
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.right,
+        |value| style::right(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.bottom,
+        |value| style::bottom(value),
+    );
+    apply_responsive_style(
+        &mut style_string,
+        width,
+        breakpoints,
+        inputs.left,
+        |value| style::left(value),
+    );
+
+    // Layout toggles that remain non-responsive for now ----------------------
+    if let Some(display) = inputs.display {
+        style_string.push_str(&style::display(display));
+    }
+    if let Some(ai) = inputs.align_items {
+        style_string.push_str(&style::align_items(ai));
+    }
+    if let Some(jc) = inputs.justify_content {
+        style_string.push_str(&style::justify_content(jc));
+    }
+
+    style_string.push_str(inputs.sx);
+    style_string
+}
 
 #[cfg(feature = "yew")]
 mod yew_impl {
     use super::*;
-    use web_sys::window;
+    use crate::theme_provider::use_theme;
     use yew::prelude::*;
 
-    /// Lightweight wrapper around a `div` that accepts system style properties.
+    /// Properties for the [`Box`] component when targeting Yew.
     #[derive(Properties, PartialEq)]
     pub struct BoxProps {
         /// Responsive margin shorthand. Values cascade from `xs` upwards.
@@ -16,6 +225,57 @@ mod yew_impl {
         /// Responsive padding shorthand.
         #[prop_or_default]
         pub p: Option<Responsive<String>>,
+        /// Responsive font size declarations covering the Issue 13 typography additions.
+        #[prop_or_default]
+        pub font_size: Option<Responsive<String>>,
+        /// Font weight responsive overrides.
+        #[prop_or_default]
+        pub font_weight: Option<Responsive<String>>,
+        /// Responsive line height adjustments.
+        #[prop_or_default]
+        pub line_height: Option<Responsive<String>>,
+        /// Responsive letter spacing adjustments.
+        #[prop_or_default]
+        pub letter_spacing: Option<Responsive<String>>,
+        /// Responsive foreground color configuration.
+        #[prop_or_default]
+        pub color: Option<Responsive<String>>,
+        /// Responsive background color configuration.
+        #[prop_or_default]
+        pub background_color: Option<Responsive<String>>,
+        /// Responsive width declarations.
+        #[prop_or_default]
+        pub width: Option<Responsive<String>>,
+        /// Responsive height declarations.
+        #[prop_or_default]
+        pub height: Option<Responsive<String>>,
+        /// Minimum width per breakpoint.
+        #[prop_or_default]
+        pub min_width: Option<Responsive<String>>,
+        /// Maximum width per breakpoint.
+        #[prop_or_default]
+        pub max_width: Option<Responsive<String>>,
+        /// Minimum height per breakpoint.
+        #[prop_or_default]
+        pub min_height: Option<Responsive<String>>,
+        /// Maximum height per breakpoint.
+        #[prop_or_default]
+        pub max_height: Option<Responsive<String>>,
+        /// Responsive position mode (`static`, `absolute`, ...).
+        #[prop_or_default]
+        pub position: Option<Responsive<String>>,
+        /// Top offset for positioned layouts.
+        #[prop_or_default]
+        pub top: Option<Responsive<String>>,
+        /// Right offset for positioned layouts.
+        #[prop_or_default]
+        pub right: Option<Responsive<String>>,
+        /// Bottom offset for positioned layouts.
+        #[prop_or_default]
+        pub bottom: Option<Responsive<String>>,
+        /// Left offset for positioned layouts.
+        #[prop_or_default]
+        pub left: Option<Responsive<String>>,
         /// Optional `display` style.
         #[prop_or_default]
         pub display: Option<String>,
@@ -36,27 +296,36 @@ mod yew_impl {
     #[function_component(Box)]
     pub fn box_component(props: &BoxProps) -> Html {
         let theme = use_theme();
-        let width = window()
-            .and_then(|w| w.inner_width().ok())
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0) as u32;
-        let mut style_string = String::new();
-        if let Some(m) = &props.m {
-            style_string.push_str(&style::margin(m.resolve(width, &theme.breakpoints)));
-        }
-        if let Some(p) = &props.p {
-            style_string.push_str(&style::padding(p.resolve(width, &theme.breakpoints)));
-        }
-        if let Some(d) = &props.display {
-            style_string.push_str(&style::display(d.clone()));
-        }
-        if let Some(ai) = &props.align_items {
-            style_string.push_str(&style::align_items(ai.clone()));
-        }
-        if let Some(jc) = &props.justify_content {
-            style_string.push_str(&style::justify_content(jc.clone()));
-        }
-        style_string.push_str(&props.sx);
+        let viewport = crate::responsive::viewport_width();
+        let style_string = build_box_style(
+            viewport,
+            &theme.breakpoints,
+            BoxStyleInputs {
+                margin: props.m.as_ref(),
+                padding: props.p.as_ref(),
+                font_size: props.font_size.as_ref(),
+                font_weight: props.font_weight.as_ref(),
+                line_height: props.line_height.as_ref(),
+                letter_spacing: props.letter_spacing.as_ref(),
+                color: props.color.as_ref(),
+                background_color: props.background_color.as_ref(),
+                width: props.width.as_ref(),
+                height: props.height.as_ref(),
+                min_width: props.min_width.as_ref(),
+                max_width: props.max_width.as_ref(),
+                min_height: props.min_height.as_ref(),
+                max_height: props.max_height.as_ref(),
+                position: props.position.as_ref(),
+                top: props.top.as_ref(),
+                right: props.right.as_ref(),
+                bottom: props.bottom.as_ref(),
+                left: props.left.as_ref(),
+                display: props.display.as_deref(),
+                align_items: props.align_items.as_deref(),
+                justify_content: props.justify_content.as_deref(),
+                sx: &props.sx,
+            },
+        );
         html! { <div style={style_string}>{ for props.children.iter() }</div> }
     }
 }
@@ -67,14 +336,31 @@ pub use yew_impl::{Box, BoxProps};
 #[cfg(feature = "leptos")]
 mod leptos_impl {
     use super::*;
+    use crate::theme_provider::use_theme;
     use leptos::*;
-    use web_sys::window;
 
-    /// Leptos version of [`Box`] sharing the same props as the Yew variant.
+    /// Leptos version of [`Box`] sharing the same responsive props as the Yew variant.
     #[component]
     pub fn Box(
         #[prop(optional)] m: Option<Responsive<String>>,
         #[prop(optional)] p: Option<Responsive<String>>,
+        #[prop(optional)] font_size: Option<Responsive<String>>,
+        #[prop(optional)] font_weight: Option<Responsive<String>>,
+        #[prop(optional)] line_height: Option<Responsive<String>>,
+        #[prop(optional)] letter_spacing: Option<Responsive<String>>,
+        #[prop(optional)] color: Option<Responsive<String>>,
+        #[prop(optional)] background_color: Option<Responsive<String>>,
+        #[prop(optional)] width: Option<Responsive<String>>,
+        #[prop(optional)] height: Option<Responsive<String>>,
+        #[prop(optional)] min_width: Option<Responsive<String>>,
+        #[prop(optional)] max_width: Option<Responsive<String>>,
+        #[prop(optional)] min_height: Option<Responsive<String>>,
+        #[prop(optional)] max_height: Option<Responsive<String>>,
+        #[prop(optional)] position: Option<Responsive<String>>,
+        #[prop(optional)] top: Option<Responsive<String>>,
+        #[prop(optional)] right: Option<Responsive<String>>,
+        #[prop(optional)] bottom: Option<Responsive<String>>,
+        #[prop(optional)] left: Option<Responsive<String>>,
         #[prop(optional, into)] display: Option<String>,
         #[prop(optional, into)] align_items: Option<String>,
         #[prop(optional, into)] justify_content: Option<String>,
@@ -82,30 +368,36 @@ mod leptos_impl {
         children: Children,
     ) -> impl IntoView {
         let theme = use_theme();
-        // Determine the current viewport width so responsive props can be
-        // resolved.  `as_f64` already returns an `Option` so we avoid wrapping
-        // the value in an extra `Result` to keep the flow straightforward.
-        let width = window()
-            .and_then(|w| w.inner_width().ok())
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0) as u32;
-        let mut style_string = String::new();
-        if let Some(m) = m {
-            style_string.push_str(&style::margin(m.resolve(width, &theme.breakpoints)));
-        }
-        if let Some(p) = p {
-            style_string.push_str(&style::padding(p.resolve(width, &theme.breakpoints)));
-        }
-        if let Some(d) = display {
-            style_string.push_str(&style::display(d));
-        }
-        if let Some(ai) = align_items {
-            style_string.push_str(&style::align_items(ai));
-        }
-        if let Some(jc) = justify_content {
-            style_string.push_str(&style::justify_content(jc));
-        }
-        style_string.push_str(&sx);
+        let viewport = crate::responsive::viewport_width();
+        let style_string = build_box_style(
+            viewport,
+            &theme.breakpoints,
+            BoxStyleInputs {
+                margin: m.as_ref(),
+                padding: p.as_ref(),
+                font_size: font_size.as_ref(),
+                font_weight: font_weight.as_ref(),
+                line_height: line_height.as_ref(),
+                letter_spacing: letter_spacing.as_ref(),
+                color: color.as_ref(),
+                background_color: background_color.as_ref(),
+                width: width.as_ref(),
+                height: height.as_ref(),
+                min_width: min_width.as_ref(),
+                max_width: max_width.as_ref(),
+                min_height: min_height.as_ref(),
+                max_height: max_height.as_ref(),
+                position: position.as_ref(),
+                top: top.as_ref(),
+                right: right.as_ref(),
+                bottom: bottom.as_ref(),
+                left: left.as_ref(),
+                display: display.as_deref(),
+                align_items: align_items.as_deref(),
+                justify_content: justify_content.as_deref(),
+                sx: &sx,
+            },
+        );
         view! { <div style=style_string>{children()}</div> }
     }
 }

--- a/crates/mui-system/src/container.rs
+++ b/crates/mui-system/src/container.rs
@@ -1,4 +1,26 @@
-use crate::style_props;
+use crate::{responsive::Responsive, style, style_props, theme::Breakpoints};
+
+/// Builds the inline style string for the container based on the current
+/// viewport width. The helper is used by all framework adapters and ensures the
+/// integration tests exercise the exact same resolution logic.
+#[doc(hidden)]
+pub fn build_container_style(
+    width: u32,
+    breakpoints: &Breakpoints,
+    max_width: Option<&Responsive<String>>,
+    sx: &str,
+) -> String {
+    let mut style = if let Some(mw) = max_width {
+        let resolved = mw.resolve(width, breakpoints);
+        let mut base = style_props! { margin_left: "auto", margin_right: "auto", width: "100%" };
+        base.push_str(&style::max_width(resolved));
+        base
+    } else {
+        style_props! { width: "100%" }
+    };
+    style.push_str(sx);
+    style
+}
 
 #[cfg(feature = "yew")]
 mod yew_impl {
@@ -10,7 +32,7 @@ mod yew_impl {
     pub struct ContainerProps {
         /// Optional maximum width of the container (e.g. `"1200px"`).
         #[prop_or_default]
-        pub max_width: Option<String>,
+        pub max_width: Option<Responsive<String>>,
         /// Additional style string to merge, following the MUI `sx` syntax.
         #[prop_or_default]
         pub sx: String,
@@ -22,13 +44,14 @@ mod yew_impl {
     /// Centers content with an optional maximum width.
     #[function_component(Container)]
     pub fn container(props: &ContainerProps) -> Html {
-        let mut style = String::new();
-        if let Some(mw) = &props.max_width {
-            style.push_str(&style_props! { margin_left: "auto", margin_right: "auto", max_width: mw.clone(), width: "100%" });
-        } else {
-            style.push_str(&style_props! { width: "100%" });
-        }
-        style.push_str(&props.sx);
+        let theme = crate::theme_provider::use_theme();
+        let width = crate::responsive::viewport_width();
+        let style = build_container_style(
+            width,
+            &theme.breakpoints,
+            props.max_width.as_ref(),
+            &props.sx,
+        );
         html! { <div style={style}>{ for props.children.iter() }</div> }
     }
 }
@@ -44,17 +67,13 @@ mod leptos_impl {
     /// Leptos variant of [`Container`].
     #[component]
     pub fn Container(
-        #[prop(optional, into)] max_width: Option<String>,
+        #[prop(optional)] max_width: Option<Responsive<String>>,
         #[prop(optional, into)] sx: String,
         children: Children,
     ) -> impl IntoView {
-        let mut style = String::new();
-        if let Some(mw) = max_width {
-            style.push_str(&style_props! { margin_left: "auto", margin_right: "auto", max_width: mw, width: "100%" });
-        } else {
-            style.push_str(&style_props! { width: "100%" });
-        }
-        style.push_str(&sx);
+        let theme = crate::theme_provider::use_theme();
+        let width = crate::responsive::viewport_width();
+        let style = build_container_style(width, &theme.breakpoints, max_width.as_ref(), &sx);
         view! { <div style=style>{children()}</div> }
     }
 }

--- a/crates/mui-system/src/grid.rs
+++ b/crates/mui-system/src/grid.rs
@@ -1,4 +1,48 @@
-use crate::{responsive::grid_span_to_percent, style};
+use crate::{
+    responsive::{grid_span_to_percent, Responsive},
+    style,
+    theme::Breakpoints,
+};
+
+/// Shared styling routine leveraged by every framework specific grid
+/// implementation and the integration tests.  Centralising the logic keeps the
+/// breakpoint cascade identical regardless of whether the consumer renders via
+/// Yew, Leptos or a headless test harness.
+#[doc(hidden)]
+pub fn build_grid_style(
+    width: u32,
+    breakpoints: &Breakpoints,
+    columns: Option<&Responsive<u16>>,
+    span: Option<&Responsive<u16>>,
+    justify_content: Option<&str>,
+    align_items: Option<&str>,
+    sx: &str,
+) -> String {
+    // Compute the active column model for the current viewport.  We lean on the
+    // `Responsive::constant` helper so callers can omit props entirely and
+    // still reuse the same resolution pipeline used for explicit overrides.
+    let default_columns = Responsive::constant(12);
+    let resolved_columns = columns
+        .map(|value| value.resolve(width, breakpoints))
+        .unwrap_or_else(|| default_columns.resolve(width, breakpoints));
+    let default_span = Responsive::constant(12);
+    let resolved_span = span
+        .map(|value| value.resolve(width, breakpoints))
+        .unwrap_or_else(|| default_span.resolve(width, breakpoints));
+    let width_percent = grid_span_to_percent(resolved_span, resolved_columns);
+
+    let mut style_string = String::from(sx);
+    style_string.push_str(&format!("width:{}%;", width_percent));
+
+    if let Some(jc) = justify_content {
+        style_string.push_str(&style::justify_content(jc));
+    }
+    if let Some(ai) = align_items {
+        style_string.push_str(&style::align_items(ai));
+    }
+
+    style_string
+}
 
 #[cfg(feature = "yew")]
 mod yew_impl {
@@ -8,12 +52,13 @@ mod yew_impl {
     /// Simple grid item that computes its own width based on `span` and `columns`.
     #[derive(Properties, PartialEq)]
     pub struct GridProps {
-        /// Total number of columns in the grid container.
-        #[prop_or(12)]
-        pub columns: u16,
-        /// Number of columns this item should span.
-        #[prop_or(12)]
-        pub span: u16,
+        /// Total number of columns in the grid container. `None` defaults to 12
+        /// so existing layouts continue to render exactly as before.
+        #[prop_or_default]
+        pub columns: Option<Responsive<u16>>,
+        /// Number of columns this item should span at each breakpoint.
+        #[prop_or_default]
+        pub span: Option<Responsive<u16>>,
         /// Flexbox alignment on the main axis when using a flex container.
         #[prop_or_default]
         pub justify_content: Option<String>,
@@ -31,14 +76,17 @@ mod yew_impl {
     /// Render a grid item as a `<div>` with a calculated percentage width.
     #[function_component(Grid)]
     pub fn grid(props: &GridProps) -> Html {
-        let width = grid_span_to_percent(props.span, props.columns);
-        let mut style_string = format!("{}width:{}%;", props.sx, width);
-        if let Some(jc) = &props.justify_content {
-            style_string.push_str(&style::justify_content(jc.clone()));
-        }
-        if let Some(ai) = &props.align_items {
-            style_string.push_str(&style::align_items(ai.clone()));
-        }
+        let theme = crate::theme_provider::use_theme();
+        let width = crate::responsive::viewport_width();
+        let style_string = build_grid_style(
+            width,
+            &theme.breakpoints,
+            props.columns.as_ref(),
+            props.span.as_ref(),
+            props.justify_content.as_deref(),
+            props.align_items.as_deref(),
+            &props.sx,
+        );
         html! { <div style={style_string}>{ for props.children.iter() }</div> }
     }
 }
@@ -54,23 +102,24 @@ mod leptos_impl {
     /// Leptos implementation of [`Grid`].
     #[component]
     pub fn Grid(
-        #[prop(optional)] columns: Option<u16>,
-        #[prop(optional)] span: Option<u16>,
+        #[prop(optional)] columns: Option<Responsive<u16>>,
+        #[prop(optional)] span: Option<Responsive<u16>>,
         #[prop(optional, into)] justify_content: Option<String>,
         #[prop(optional, into)] align_items: Option<String>,
         #[prop(optional, into)] sx: String,
         children: Children,
     ) -> impl IntoView {
-        let columns = columns.unwrap_or(12);
-        let span = span.unwrap_or(12);
-        let width = grid_span_to_percent(span, columns);
-        let mut style_string = format!("{}width:{}%;", sx, width);
-        if let Some(jc) = justify_content {
-            style_string.push_str(&style::justify_content(jc));
-        }
-        if let Some(ai) = align_items {
-            style_string.push_str(&style::align_items(ai));
-        }
+        let theme = crate::theme_provider::use_theme();
+        let width_px = crate::responsive::viewport_width();
+        let style_string = build_grid_style(
+            width_px,
+            &theme.breakpoints,
+            columns.as_ref(),
+            span.as_ref(),
+            justify_content.as_deref(),
+            align_items.as_deref(),
+            &sx,
+        );
         view! { <div style=style_string>{children()}</div> }
     }
 }

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -17,13 +17,9 @@ pub mod theme;
 // lean while still allowing reuse across front-end targets.
 pub mod themed_element;
 
-#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod r#box;
-#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod container;
-#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod grid;
-#[cfg(any(feature = "yew", feature = "leptos"))]
 pub mod stack;
 pub mod theme_provider;
 #[cfg(any(feature = "yew", feature = "leptos"))]

--- a/crates/mui-system/src/style.rs
+++ b/crates/mui-system/src/style.rs
@@ -33,6 +33,27 @@ define_style_props! {
     flex_wrap => "flex-wrap",
     align_items => "align-items",
     justify_content => "justify-content",
+    width => "width",
+    height => "height",
+    min_width => "min-width",
+    max_width => "max-width",
+    min_height => "min-height",
+    max_height => "max-height",
+    position => "position",
+    top => "top",
+    right => "right",
+    bottom => "bottom",
+    left => "left",
+
+    // Typography -------------------------------------------------------------
+    font_size => "font-size",
+    font_weight => "font-weight",
+    line_height => "line-height",
+    letter_spacing => "letter-spacing",
+
+    // Colors -----------------------------------------------------------------
+    color => "color",
+    background_color => "background-color",
 }
 
 // The module intentionally re-exports all generated helpers so callers can do

--- a/crates/mui-system/src/theme.rs
+++ b/crates/mui-system/src/theme.rs
@@ -42,6 +42,7 @@ impl Theme {
 /// struct if additional breakpoints are required.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Breakpoints {
+    pub xs: u32,
     pub sm: u32,
     pub md: u32,
     pub lg: u32,
@@ -51,6 +52,7 @@ pub struct Breakpoints {
 impl Default for Breakpoints {
     fn default() -> Self {
         Self {
+            xs: 0,
             sm: 600,
             md: 900,
             lg: 1200,
@@ -115,6 +117,7 @@ mod tests {
         assert_eq!(theme.joy.radius, 4);
         assert_eq!(theme.joy.focus_thickness, 2);
         assert_eq!(theme.palette.neutral, "#64748b");
+        assert_eq!(theme.breakpoints.xs, 0);
 
         // Round trip through JSON to ensure `serde` wiring is correct
         let json = serde_json::to_string(&theme).expect("serialize");

--- a/crates/mui-system/tests/responsive_box.rs
+++ b/crates/mui-system/tests/responsive_box.rs
@@ -1,0 +1,216 @@
+use mui_system::{
+    r#box::{build_box_style, BoxStyleInputs},
+    responsive::Responsive,
+    Theme,
+};
+
+#[test]
+fn box_resolves_all_responsive_groups() {
+    let theme = Theme::default();
+    let margin = Responsive {
+        xs: "2px".into(),
+        sm: Some("4px".into()),
+        md: Some("8px".into()),
+        lg: Some("16px".into()),
+        xl: None,
+    };
+    let padding = Responsive {
+        xs: "1rem".into(),
+        sm: Some("1.5rem".into()),
+        md: Some("2rem".into()),
+        lg: None,
+        xl: Some("3rem".into()),
+    };
+    let font_size = Responsive {
+        xs: "12px".into(),
+        sm: None,
+        md: Some("16px".into()),
+        lg: Some("18px".into()),
+        xl: Some("20px".into()),
+    };
+    let font_weight = Responsive {
+        xs: "400".into(),
+        sm: None,
+        md: Some("500".into()),
+        lg: Some("600".into()),
+        xl: None,
+    };
+    let line_height = Responsive {
+        xs: "20px".into(),
+        sm: None,
+        md: Some("24px".into()),
+        lg: Some("28px".into()),
+        xl: None,
+    };
+    let letter_spacing = Responsive {
+        xs: "0px".into(),
+        sm: Some("0.5px".into()),
+        md: Some("1px".into()),
+        lg: None,
+        xl: Some("1.5px".into()),
+    };
+    let color = Responsive {
+        xs: "#111111".into(),
+        sm: None,
+        md: Some("#222222".into()),
+        lg: Some("#333333".into()),
+        xl: None,
+    };
+    let background = Responsive {
+        xs: "#ffffff".into(),
+        sm: None,
+        md: Some("#f0f0f0".into()),
+        lg: Some("#e0e0e0".into()),
+        xl: Some("#d0d0d0".into()),
+    };
+    let width = Responsive {
+        xs: "100%".into(),
+        sm: None,
+        md: Some("75%".into()),
+        lg: Some("50%".into()),
+        xl: None,
+    };
+    let height = Responsive {
+        xs: "auto".into(),
+        sm: None,
+        md: Some("320px".into()),
+        lg: Some("400px".into()),
+        xl: None,
+    };
+    let min_width = Responsive {
+        xs: "240px".into(),
+        sm: None,
+        md: Some("320px".into()),
+        lg: Some("360px".into()),
+        xl: None,
+    };
+    let max_width = Responsive {
+        xs: "480px".into(),
+        sm: None,
+        md: Some("640px".into()),
+        lg: Some("720px".into()),
+        xl: None,
+    };
+    let min_height = Responsive {
+        xs: "120px".into(),
+        sm: None,
+        md: Some("160px".into()),
+        lg: Some("180px".into()),
+        xl: None,
+    };
+    let max_height = Responsive {
+        xs: "260px".into(),
+        sm: None,
+        md: Some("320px".into()),
+        lg: Some("360px".into()),
+        xl: None,
+    };
+    let position = Responsive {
+        xs: "relative".into(),
+        sm: None,
+        md: Some("relative".into()),
+        lg: Some("absolute".into()),
+        xl: None,
+    };
+    let offsets = Responsive {
+        xs: "0".into(),
+        sm: None,
+        md: Some("4px".into()),
+        lg: Some("8px".into()),
+        xl: None,
+    };
+
+    let base = build_box_style(
+        500,
+        &theme.breakpoints,
+        BoxStyleInputs {
+            margin: Some(&margin),
+            padding: Some(&padding),
+            font_size: Some(&font_size),
+            font_weight: Some(&font_weight),
+            line_height: Some(&line_height),
+            letter_spacing: Some(&letter_spacing),
+            color: Some(&color),
+            background_color: Some(&background),
+            width: Some(&width),
+            height: Some(&height),
+            min_width: Some(&min_width),
+            max_width: Some(&max_width),
+            min_height: Some(&min_height),
+            max_height: Some(&max_height),
+            position: Some(&position),
+            top: Some(&offsets),
+            right: Some(&offsets),
+            bottom: Some(&offsets),
+            left: Some(&offsets),
+            display: Some("flex"),
+            align_items: Some("center"),
+            justify_content: Some("flex-start"),
+            sx: "border-radius:4px;",
+        },
+    );
+    assert!(base.contains("margin:2px;"));
+    assert!(base.contains("padding:1rem;"));
+    assert!(base.contains("font-size:12px;"));
+    assert!(base.contains("font-weight:400;"));
+    assert!(base.contains("line-height:20px;"));
+    assert!(base.contains("letter-spacing:0px;"));
+    assert!(base.contains("color:#111111;"));
+    assert!(base.contains("background-color:#ffffff;"));
+    assert!(base.contains("width:100%;"));
+    assert!(base.contains("height:auto;"));
+    assert!(base.contains("min-width:240px;"));
+    assert!(base.contains("max-width:480px;"));
+    assert!(base.contains("min-height:120px;"));
+    assert!(base.contains("max-height:260px;"));
+    assert!(base.contains("position:relative;"));
+    assert!(base.contains("top:0;"));
+    assert!(base.contains("display:flex;"));
+    assert!(base.ends_with("border-radius:4px;"));
+
+    let large = build_box_style(
+        1400,
+        &theme.breakpoints,
+        BoxStyleInputs {
+            margin: Some(&margin),
+            padding: Some(&padding),
+            font_size: Some(&font_size),
+            font_weight: Some(&font_weight),
+            line_height: Some(&line_height),
+            letter_spacing: Some(&letter_spacing),
+            color: Some(&color),
+            background_color: Some(&background),
+            width: Some(&width),
+            height: Some(&height),
+            min_width: Some(&min_width),
+            max_width: Some(&max_width),
+            min_height: Some(&min_height),
+            max_height: Some(&max_height),
+            position: Some(&position),
+            top: Some(&offsets),
+            right: Some(&offsets),
+            bottom: Some(&offsets),
+            left: Some(&offsets),
+            display: Some("flex"),
+            align_items: Some("center"),
+            justify_content: Some("flex-start"),
+            sx: "border-radius:4px;",
+        },
+    );
+    assert!(large.contains("margin:16px;"));
+    assert!(large.contains("padding:2rem;"));
+    assert!(large.contains("font-size:18px;"));
+    assert!(large.contains("font-weight:600;"));
+    assert!(large.contains("line-height:28px;"));
+    assert!(large.contains("letter-spacing:1px;"));
+    assert!(large.contains("color:#333333;"));
+    assert!(large.contains("background-color:#e0e0e0;"));
+    assert!(large.contains("width:50%;"));
+    assert!(large.contains("height:400px;"));
+    assert!(large.contains("min-width:360px;"));
+    assert!(large.contains("max-width:720px;"));
+    assert!(large.contains("min-height:180px;"));
+    assert!(large.contains("max-height:360px;"));
+    assert!(large.contains("position:absolute;"));
+    assert!(large.contains("top:8px;"));
+}

--- a/crates/mui-system/tests/responsive_container.rs
+++ b/crates/mui-system/tests/responsive_container.rs
@@ -1,0 +1,23 @@
+use mui_system::{container::build_container_style, responsive::Responsive, Theme};
+
+#[test]
+fn container_applies_responsive_max_width() {
+    let theme = Theme::default();
+    let max_width = Responsive {
+        xs: "100%".into(),
+        sm: Some("640px".into()),
+        md: Some("960px".into()),
+        lg: Some("1200px".into()),
+        xl: Some("1440px".into()),
+    };
+
+    let mobile = build_container_style(400, &theme.breakpoints, Some(&max_width), "");
+    assert!(mobile.contains("width:100%;"));
+    assert!(mobile.contains("max-width:100%;"));
+
+    let desktop =
+        build_container_style(1280, &theme.breakpoints, Some(&max_width), "padding:24px;");
+    assert!(desktop.contains("max-width:1200px;"));
+    assert!(desktop.starts_with("margin-left:auto;margin-right:auto;width:100%;"));
+    assert!(desktop.ends_with("padding:24px;"));
+}

--- a/crates/mui-system/tests/responsive_grid.rs
+++ b/crates/mui-system/tests/responsive_grid.rs
@@ -1,0 +1,56 @@
+use mui_system::{grid::build_grid_style, responsive::Responsive, Theme};
+
+#[test]
+fn grid_breakpoints_resolve_width_and_alignment() {
+    let theme = Theme::default();
+    let columns = Responsive {
+        xs: 4,
+        sm: Some(8),
+        md: Some(12),
+        lg: None,
+        xl: Some(16),
+    };
+    let span = Responsive {
+        xs: 4,
+        sm: Some(4),
+        md: Some(6),
+        lg: Some(8),
+        xl: Some(12),
+    };
+
+    let base = build_grid_style(
+        500,
+        &theme.breakpoints,
+        Some(&columns),
+        Some(&span),
+        Some("center"),
+        None,
+        "border:1px solid red;",
+    );
+    assert!(base.contains("border:1px solid red;"));
+    assert!(base.contains("width:100%;"));
+    assert!(base.contains("justify-content:center;"));
+
+    let medium = build_grid_style(
+        950,
+        &theme.breakpoints,
+        Some(&columns),
+        Some(&span),
+        None,
+        Some("flex-end"),
+        "",
+    );
+    assert!(medium.contains("width:50%;"));
+    assert!(medium.contains("align-items:flex-end;"));
+
+    let extra_large = build_grid_style(
+        1600,
+        &theme.breakpoints,
+        Some(&columns),
+        Some(&span),
+        None,
+        None,
+        "",
+    );
+    assert!(extra_large.contains("width:75%;"));
+}

--- a/crates/mui-system/tests/responsive_stack.rs
+++ b/crates/mui-system/tests/responsive_stack.rs
@@ -1,0 +1,45 @@
+use mui_system::{
+    responsive::Responsive,
+    stack::{build_stack_style, StackDirection},
+    Theme,
+};
+
+#[test]
+fn stack_spacing_scales_with_breakpoints() {
+    let theme = Theme::default();
+    let spacing = Responsive {
+        xs: "4px".into(),
+        sm: Some("8px".into()),
+        md: Some("16px".into()),
+        lg: None,
+        xl: Some("32px".into()),
+    };
+
+    let column = build_stack_style(
+        480,
+        &theme.breakpoints,
+        None,
+        Some(&spacing),
+        Some("center"),
+        None,
+        "",
+    );
+    assert!(column.contains("display:flex;"));
+    assert!(column.contains("flex-direction:column;"));
+    assert!(column.contains("gap:4px;"));
+    assert!(column.contains("align-items:center;"));
+
+    let row = build_stack_style(
+        1000,
+        &theme.breakpoints,
+        Some(StackDirection::Row),
+        Some(&spacing),
+        None,
+        Some("space-between"),
+        "background:blue;",
+    );
+    assert!(row.contains("flex-direction:row;"));
+    assert!(row.contains("gap:16px;"));
+    assert!(row.contains("justify-content:space-between;"));
+    assert!(row.ends_with("background:blue;"));
+}


### PR DESCRIPTION
## Summary
- add a shared viewport helper and convenience constructors for `Responsive<T>` values
- update Grid, Container, Stack, and Box to resolve responsive props via centralized style builders and support additional responsive fields
- document responsive usage patterns and add integration tests that verify breakpoint resolution across components

## Testing
- cargo test -p mui-system

------
https://chatgpt.com/codex/tasks/task_e_68c868cef3e4832eb5866f380ead893d