### PR TITLE
Enhance themed header adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "dioxus",
  "leptos",
  "mui-styled-engine-macros",
+ "mui-utils",
  "serde",
  "serde_json",
  "stylist",

--- a/crates/mui-system/Cargo.toml
+++ b/crates/mui-system/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 stylist = { version = "0.13", default-features = false, features = ["macros", "parser", "ssr"] }
 mui-styled-engine-macros = { path = "../mui-styled-engine-macros" }
+mui-utils = { path = "../mui-utils" }
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -42,15 +42,10 @@ pub use style::*;
 pub use stylist::{css, Style};
 pub use theme::{Breakpoints, Palette, Theme};
 extern crate self as mui_styled_engine;
-#[cfg(all(
-    any(feature = "dioxus", feature = "sycamore"),
-    not(any(feature = "yew", feature = "leptos"))
-))]
-pub use theme_provider::use_theme;
 #[cfg(feature = "yew")]
-pub use theme_provider::{use_theme, ThemeProvider};
+pub use theme_provider::ThemeProvider;
 #[cfg(all(feature = "leptos", not(feature = "yew")))]
-pub use theme_provider::{use_theme, ThemeProvider};
+pub use theme_provider::ThemeProvider;
 pub use themed_element::{ThemedProps, Variant};
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub use typography::{Typography, TypographyVariant};

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -129,7 +129,10 @@ mod yew_impl {
         // temporary style immediately to avoid side-effects while still
         // exercising the macro expansion.
         let sentinel = css_with_theme!(
-            r#".mui-reset-sentinel { color: ${theme.palette.text_primary.clone()}; }"#
+            r#"
+                color: ${text_color};
+            "#,
+            text_color = theme.palette.text_primary.clone()
         );
         sentinel.unregister();
 
@@ -143,7 +146,7 @@ mod yew_impl {
 
     /// Alias kept for API parity with the upstream JS packages where both
     /// `CssBaseline` and `GlobalStyles` exist.
-    pub type GlobalStyles = CssBaseline;
+    pub use CssBaseline as GlobalStyles;
 }
 
 #[cfg(feature = "yew")]
@@ -173,7 +176,10 @@ mod leptos_impl {
     #[component]
     pub fn CssBaseline(#[prop(optional)] additional_css: Option<String>) -> impl IntoView {
         let sentinel = css_with_theme!(
-            r#".mui-reset-sentinel { color: ${theme.palette.text_primary.clone()}; }"#
+            r#"
+                color: ${text_color};
+            "#,
+            text_color = theme.palette.text_primary.clone()
         );
         sentinel.unregister();
 
@@ -186,7 +192,7 @@ mod leptos_impl {
     }
 
     /// Alias kept for API parity between frameworks.
-    pub type GlobalStyles = CssBaseline;
+    pub use CssBaseline as GlobalStyles;
 }
 
 #[cfg(feature = "leptos")]

--- a/crates/mui-system/tests/framework.rs
+++ b/crates/mui-system/tests/framework.rs
@@ -10,8 +10,10 @@ fn leptos_adapter_renders() {
         ..Default::default()
     };
     let html = mui_system::themed_element::leptos::render(&props);
-    assert!(html.contains("mui-plain"));
+    assert!(html.contains("<style>"), "expected inlined stylesheet");
+    assert!(html.contains("mui-themed-header--plain"));
     assert!(html.contains("role=\"note\""));
+    assert!(html.contains("<header"));
 }
 
 #[cfg(feature = "dioxus")]
@@ -25,7 +27,8 @@ fn dioxus_adapter_renders() {
     props.role = Some("button".into());
     props.aria_label = Some("greet".into());
     let html = mui_system::themed_element::dioxus::render(&props);
-    assert!(html.contains("mui-outlined"));
+    assert!(html.contains("mui-themed-header--outlined"));
+    assert!(html.contains("style=\""));
     assert!(html.contains("aria-label=\"greet\""));
 }
 
@@ -40,4 +43,6 @@ fn sycamore_adapter_renders() {
     };
     let html = mui_system::themed_element::sycamore::render(&props);
     assert!(html.contains("role=\"note\""));
+    assert!(html.contains("mui-themed-header"));
+    assert!(html.contains("style=\""));
 }


### PR DESCRIPTION
## Summary
- add theme-aware helper logic for the SSR adapters and document the new `<header>` output
- render the Leptos adapter with `css_with_theme!` and inline the generated stylesheet for SSR
- update dioxus/sycamore renderers and tests to assert BEM classes and ARIA metadata while fixing theme provider utilities

## Testing
- `cargo test -p mui-system --no-default-features --features "dioxus sycamore"`
- `cargo test -p mui-system --no-default-features --features leptos`


------
https://chatgpt.com/codex/tasks/task_e_68c8c40409a8832ea0af0217be9fafe1