### PR TITLE
Refactor themed element adapters to use scoped theme classes

### DIFF
--- a/crates/mui-system/tests/framework.rs
+++ b/crates/mui-system/tests/framework.rs
@@ -13,7 +13,12 @@ fn leptos_adapter_renders() {
     assert!(html.contains("<style>"), "expected inlined stylesheet");
     assert!(html.contains("mui-themed-header--plain"));
     assert!(html.contains("role=\"note\""));
-    assert!(html.contains("<header"));
+    assert!(html.contains("<div"));
+    assert!(html.contains("class=\""));
+    assert!(
+        !html.contains("style=\""),
+        "inline styles should be replaced with generated classes"
+    );
 }
 
 #[cfg(feature = "dioxus")]
@@ -28,7 +33,12 @@ fn dioxus_adapter_renders() {
     props.aria_label = Some("greet".into());
     let html = mui_system::themed_element::dioxus::render(&props);
     assert!(html.contains("mui-themed-header--outlined"));
-    assert!(html.contains("style=\""));
+    assert!(html.contains("<style>"));
+    assert!(html.contains("class=\""));
+    assert!(
+        !html.contains("style=\""),
+        "inline styles should be replaced with generated classes"
+    );
     assert!(html.contains("aria-label=\"greet\""));
 }
 
@@ -44,5 +54,9 @@ fn sycamore_adapter_renders() {
     let html = mui_system::themed_element::sycamore::render(&props);
     assert!(html.contains("role=\"note\""));
     assert!(html.contains("mui-themed-header"));
-    assert!(html.contains("style=\""));
+    assert!(html.contains("<style>"));
+    assert!(
+        !html.contains("style=\""),
+        "inline styles should be replaced with generated classes"
+    );
 }


### PR DESCRIPTION
## Summary
- document how the themed container derives padding, borders, and ARIA metadata from the active theme
- generate scoped CSS classes with `css_with_theme!` and reuse them across the Leptos, Dioxus, and Sycamore adapters instead of emitting inline styles
- update the framework test expectations to assert the new class-based markup

## Testing
- cargo test -p mui-system --features leptos
- cargo test -p mui-system --features dioxus
- cargo test -p mui-system --features sycamore

------
https://chatgpt.com/codex/tasks/task_e_68c9019d434c832eb679cfda1b4aa201