### PR TITLE
Add snackbar adapter regression tests

### DIFF
--- a/crates/mui-material/tests/snackbar_adapters.rs
+++ b/crates/mui-material/tests/snackbar_adapters.rs
@@ -1,0 +1,68 @@
+#![cfg(any(feature = "dioxus", feature = "sycamore"))]
+
+//! Snapshot-style assertions that validate the HTML emitted by each
+//! framework specific Snackbar adapter. Keeping these checks close to the
+//! render functions guards against regressions in the scoped class generation
+//! and ARIA wiring shared across frameworks.
+
+use mui_material::snackbar::{SnackbarColor, SnackbarSize, SnackbarVariant};
+
+/// Dioxus adapter coverage ensures the SSR-focused `render` helper attaches
+/// the theme-derived class and politely announces updates with
+/// `role="status"`. These targeted assertions minimise future maintenance by
+/// avoiding brittle full string comparisons while still proving that critical
+/// attributes are present.
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use super::*;
+    use mui_material::snackbar::dioxus;
+
+    #[test]
+    fn renders_status_snackbar_with_class() {
+        let props = dioxus::SnackbarProps {
+            message: "Profile saved".into(),
+            color: SnackbarColor::Primary,
+            size: SnackbarSize::Medium,
+            variant: SnackbarVariant::Contained,
+        };
+        let out = dioxus::render(&props);
+
+        assert!(out.starts_with("<div"), "unexpected markup: {}", out);
+        assert!(out.contains("class=\""), "missing scoped class: {}", out);
+        assert!(
+            out.contains("role=\"status\""),
+            "missing ARIA role: {}",
+            out
+        );
+        assert!(out.contains(">Profile saved</div>"));
+    }
+}
+
+/// Sycamore adapter coverage mirrors the Dioxus test so both SSR renderers
+/// are exercised in isolation. This guarantees each framework surfaces the
+/// generated class and ARIA role without duplicating snapshot payloads.
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use super::*;
+    use mui_material::snackbar::sycamore;
+
+    #[test]
+    fn renders_status_snackbar_with_class() {
+        let props = sycamore::SnackbarProps {
+            message: "Profile saved".into(),
+            color: SnackbarColor::Primary,
+            size: SnackbarSize::Medium,
+            variant: SnackbarVariant::Contained,
+        };
+        let out = sycamore::render(&props);
+
+        assert!(out.starts_with("<div"), "unexpected markup: {}", out);
+        assert!(out.contains("class=\""), "missing scoped class: {}", out);
+        assert!(
+            out.contains("role=\"status\""),
+            "missing ARIA role: {}",
+            out
+        );
+        assert!(out.contains(">Profile saved</div>"));
+    }
+}


### PR DESCRIPTION
## Summary
- add SSR snackbar adapter tests that assert each framework emits the themed class and `role="status"` aria metadata

## Testing
- `cargo fmt`
- `cargo test -p mui-material --all-features` *(fails: upstream multi-framework exports in mui-system/mui-material conflict under full feature set)*
- `cargo test -p mui-material` *(fails: axe wasm-bindgen harness requires wasm target and dependencies not available on host runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cb13a63160832ebc7eb992aba24611