### PR TITLE
Document theme helpers and centralize attribute assembly

### DIFF
--- a/crates/mui-material/src/style_helpers.rs
+++ b/crates/mui-material/src/style_helpers.rs
@@ -6,6 +6,7 @@
 //! documenting the intended lifecycle of stylist [`Style`] handles.
 
 use mui_styled_engine::Style;
+use mui_utils::{attributes_to_html, collect_attributes};
 
 /// Consumes a [`Style`] and returns the scoped class name produced by the
 /// styled engine.
@@ -16,6 +17,41 @@ use mui_styled_engine::Style;
 #[must_use]
 pub(crate) fn themed_class(style: Style) -> String {
     style.get_class_name().to_string()
+}
+
+/// Converts a [`Style`] into a full attribute map that includes the scoped
+/// class followed by any additional key/value pairs.
+///
+/// Component adapters frequently need to attach both theme-driven styling and
+/// ARIA metadata to the same element. Centralizing the merge logic guarantees
+/// consistent ordering of the generated attributes across Yew, Leptos, Dioxus
+/// and Sycamore integrations.
+#[must_use]
+pub(crate) fn themed_attributes<I, K, V>(style: Style, iter: I) -> Vec<(String, String)>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    collect_attributes(Some(themed_class(style)), iter)
+}
+
+/// Collects themed attributes and renders them into a HTML-ready string.
+///
+/// The helper mirrors [`themed_attributes`] but directly returns the
+/// serialized representation which is handy for SSR adapters. Documenting the
+/// pattern encourages component authors to prefer this helper over hand-written
+/// string concatenation, reducing the likelihood of missing accessibility data
+/// or mis-ordering attributes between frameworks.
+#[must_use]
+pub(crate) fn themed_attributes_html<I, K, V>(style: Style, iter: I) -> String
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    let attrs = themed_attributes(style, iter);
+    attributes_to_html(&attrs)
 }
 
 #[cfg(test)]
@@ -29,5 +65,23 @@ mod tests {
             Style::new(css!("color: red;")).expect("css! macro should produce a valid style");
         let class = themed_class(style);
         assert!(!class.is_empty());
+    }
+
+    #[test]
+    fn themed_attributes_include_class_and_custom_pairs() {
+        let style =
+            Style::new(css!("color: red;")).expect("css! macro should produce a valid style");
+        let attrs = themed_attributes(style, [("role", "button")]);
+        assert_eq!(attrs[0].0, "class");
+        assert!(attrs.iter().any(|(k, v)| k == "role" && v == "button"));
+    }
+
+    #[test]
+    fn themed_attributes_html_serializes_pairs() {
+        let style =
+            Style::new(css!("color: red;")).expect("css! macro should produce a valid style");
+        let html = themed_attributes_html(style, [("aria-label", "Save")]);
+        assert!(html.contains("class=\""));
+        assert!(html.contains("aria-label=\"Save\""));
     }
 }


### PR DESCRIPTION
## Summary
- introduce reusable themed attribute helpers and rustdoc clarifications covering theme integration, style generation, and accessibility hooks
- adopt the helpers across Material component modules (AppBar, Button, Card, Dialog, Snackbar, TextField) while expanding inline documentation for consistent adapter patterns
- extend style helper tests to verify merged attribute handling and HTML serialization

## Testing
- cargo test -p mui-material *(fails: wasm-bindgen/js_sys/web_sys dependencies unavailable in host environment)*
- cargo test -p mui-material --lib


------
https://chatgpt.com/codex/tasks/task_e_68cb7bec1948832e9fb29b200d5e2059