### PR TITLE
feat(system): support JSON sx merging across layout primitives

### DIFF
--- a/crates/mui-system/tests/responsive_box.rs
+++ b/crates/mui-system/tests/responsive_box.rs
@@ -3,6 +3,7 @@ use mui_system::{
     responsive::Responsive,
     Theme,
 };
+use serde_json::json;
 
 #[test]
 fn box_resolves_all_responsive_groups() {
@@ -146,7 +147,9 @@ fn box_resolves_all_responsive_groups() {
             display: Some("flex"),
             align_items: Some("center"),
             justify_content: Some("flex-start"),
-            sx: "border-radius:4px;",
+            sx: Some(&json!({
+                "border-radius": "4px",
+            })),
         },
     );
     assert!(base.contains("margin:2px;"));
@@ -166,7 +169,7 @@ fn box_resolves_all_responsive_groups() {
     assert!(base.contains("position:relative;"));
     assert!(base.contains("top:0;"));
     assert!(base.contains("display:flex;"));
-    assert!(base.ends_with("border-radius:4px;"));
+    assert!(base.contains("border-radius:4px;"));
 
     let large = build_box_style(
         1400,
@@ -194,7 +197,9 @@ fn box_resolves_all_responsive_groups() {
             display: Some("flex"),
             align_items: Some("center"),
             justify_content: Some("flex-start"),
-            sx: "border-radius:4px;",
+            sx: Some(&json!({
+                "border-radius": "4px",
+            })),
         },
     );
     assert!(large.contains("margin:16px;"));

--- a/crates/mui-system/tests/responsive_container.rs
+++ b/crates/mui-system/tests/responsive_container.rs
@@ -1,4 +1,5 @@
 use mui_system::{container::build_container_style, responsive::Responsive, Theme};
+use serde_json::json;
 
 #[test]
 fn container_applies_responsive_max_width() {
@@ -11,13 +12,21 @@ fn container_applies_responsive_max_width() {
         xl: Some("1440px".into()),
     };
 
-    let mobile = build_container_style(400, &theme.breakpoints, Some(&max_width), "");
+    let mobile = build_container_style(400, &theme.breakpoints, Some(&max_width), None);
     assert!(mobile.contains("width:100%;"));
     assert!(mobile.contains("max-width:100%;"));
 
-    let desktop =
-        build_container_style(1280, &theme.breakpoints, Some(&max_width), "padding:24px;");
+    let desktop = build_container_style(
+        1280,
+        &theme.breakpoints,
+        Some(&max_width),
+        Some(&json!({
+            "padding": "24px",
+        })),
+    );
     assert!(desktop.contains("max-width:1200px;"));
-    assert!(desktop.starts_with("margin-left:auto;margin-right:auto;width:100%;"));
-    assert!(desktop.ends_with("padding:24px;"));
+    assert!(desktop.contains("margin-left:auto;"));
+    assert!(desktop.contains("margin-right:auto;"));
+    assert!(desktop.contains("width:100%;"));
+    assert!(desktop.contains("padding:24px;"));
 }

--- a/crates/mui-system/tests/responsive_grid.rs
+++ b/crates/mui-system/tests/responsive_grid.rs
@@ -1,4 +1,5 @@
 use mui_system::{grid::build_grid_style, responsive::Responsive, Theme};
+use serde_json::json;
 
 #[test]
 fn grid_breakpoints_resolve_width_and_alignment() {
@@ -25,7 +26,9 @@ fn grid_breakpoints_resolve_width_and_alignment() {
         Some(&span),
         Some("center"),
         None,
-        "border:1px solid red;",
+        Some(&json!({
+            "border": "1px solid red",
+        })),
     );
     assert!(base.contains("border:1px solid red;"));
     assert!(base.contains("width:100%;"));
@@ -38,7 +41,7 @@ fn grid_breakpoints_resolve_width_and_alignment() {
         Some(&span),
         None,
         Some("flex-end"),
-        "",
+        None,
     );
     assert!(medium.contains("width:50%;"));
     assert!(medium.contains("align-items:flex-end;"));
@@ -50,7 +53,7 @@ fn grid_breakpoints_resolve_width_and_alignment() {
         Some(&span),
         None,
         None,
-        "",
+        None,
     );
     assert!(extra_large.contains("width:75%;"));
 }

--- a/crates/mui-system/tests/responsive_stack.rs
+++ b/crates/mui-system/tests/responsive_stack.rs
@@ -3,6 +3,7 @@ use mui_system::{
     stack::{build_stack_style, StackDirection},
     Theme,
 };
+use serde_json::json;
 
 #[test]
 fn stack_spacing_scales_with_breakpoints() {
@@ -22,7 +23,7 @@ fn stack_spacing_scales_with_breakpoints() {
         Some(&spacing),
         Some("center"),
         None,
-        "",
+        None,
     );
     assert!(column.contains("display:flex;"));
     assert!(column.contains("flex-direction:column;"));
@@ -36,10 +37,12 @@ fn stack_spacing_scales_with_breakpoints() {
         Some(&spacing),
         None,
         Some("space-between"),
-        "background:blue;",
+        Some(&json!({
+            "background": "blue",
+        })),
     );
     assert!(row.contains("flex-direction:row;"));
     assert!(row.contains("gap:16px;"));
     assert!(row.contains("justify-content:space-between;"));
-    assert!(row.ends_with("background:blue;"));
+    assert!(row.contains("background:blue;"));
 }

--- a/crates/mui-system/tests/style.rs
+++ b/crates/mui-system/tests/style.rs
@@ -1,8 +1,26 @@
-use mui_system::{margin, padding};
+use mui_system::{
+    background_color, border_radius, box_shadow, font_size, font_weight, height, left, line_height,
+    margin, min_width, padding, position, top, width,
+};
 
 /// Ensure macro generated helpers emit valid CSS strings.
 #[test]
 fn spacing_helpers_work() {
     assert_eq!(margin("4px"), "margin:4px;");
     assert_eq!(padding("2px"), "padding:2px;");
+    assert_eq!(font_size("16px"), "font-size:16px;");
+    assert_eq!(font_weight("600"), "font-weight:600;");
+    assert_eq!(line_height("24px"), "line-height:24px;");
+    assert_eq!(width("100%"), "width:100%;");
+    assert_eq!(height("auto"), "height:auto;");
+    assert_eq!(min_width("120px"), "min-width:120px;");
+    assert_eq!(background_color("#fff"), "background-color:#fff;");
+    assert_eq!(border_radius("8px"), "border-radius:8px;");
+    assert_eq!(
+        box_shadow("0 1px 2px rgba(0,0,0,0.2)"),
+        "box-shadow:0 1px 2px rgba(0,0,0,0.2);"
+    );
+    assert_eq!(position("absolute"), "position:absolute;");
+    assert_eq!(top("8px"), "top:8px;");
+    assert_eq!(left("4px"), "left:4px;");
 }

--- a/crates/mui-system/tests/sx_json.rs
+++ b/crates/mui-system/tests/sx_json.rs
@@ -1,0 +1,67 @@
+use mui_system::{
+    container::build_container_style,
+    r#box::{build_box_style, BoxStyleInputs},
+    responsive::Responsive,
+    Theme,
+};
+use serde_json::json;
+
+#[test]
+fn container_json_sx_overrides_width() {
+    let theme = Theme::default();
+    let style = build_container_style(
+        1024,
+        &theme.breakpoints,
+        None,
+        Some(&json!({
+            "width": "80%",
+            "background-color": "#fafafa",
+        })),
+    );
+
+    assert!(style.contains("width:80%;"));
+    assert!(!style.contains("width:100%;"));
+    assert!(style.contains("background-color:#fafafa;"));
+}
+
+#[test]
+fn box_json_sx_merges_and_overrides_padding() {
+    let theme = Theme::default();
+    let padding = Responsive::constant("8px".to_string());
+    let style = build_box_style(
+        800,
+        &theme.breakpoints,
+        BoxStyleInputs {
+            margin: None,
+            padding: Some(&padding),
+            font_size: None,
+            font_weight: None,
+            line_height: None,
+            letter_spacing: None,
+            color: None,
+            background_color: None,
+            width: None,
+            height: None,
+            min_width: None,
+            max_width: None,
+            min_height: None,
+            max_height: None,
+            position: None,
+            top: None,
+            right: None,
+            bottom: None,
+            left: None,
+            display: None,
+            align_items: None,
+            justify_content: None,
+            sx: Some(&json!({
+                "padding": "24px",
+                "box-shadow": "0 1px 2px rgba(0,0,0,0.2)",
+            })),
+        },
+    );
+
+    assert!(style.contains("box-shadow:0 1px 2px rgba(0,0,0,0.2);"));
+    assert!(style.contains("padding:24px;"));
+    assert!(!style.contains("padding:8px;"));
+}


### PR DESCRIPTION
## Summary
- extend the style property macro list with typography, sizing, visual, and positioning helpers plus a JSON-to-CSS renderer
- refactor Box, Grid, Container, and Stack to merge generated styles with optional serde_json `sx` blobs using `mui_utils::deep_merge`
- expand the test suite with JSON merge assertions and document the new workflow in the README

## Testing
- cargo test -p mui-system

------
https://chatgpt.com/codex/tasks/task_e_68cba0a202ac832ea6d89b35a7c9af15