### PR TITLE
Add responsive style input descriptors for layout primitives

### DIFF
--- a/crates/mui-system/src/box.rs
+++ b/crates/mui-system/src/box.rs
@@ -47,7 +47,9 @@ fn apply_responsive_style(
 /// Assembles the inline CSS string for [`Box`] based on the supplied responsive
 /// props. Centralising the resolver keeps behaviour identical across the Yew
 /// and Leptos adapters and gives the integration tests something deterministic
-/// to exercise.
+/// to exercise. The grouped sections mirror the Issue 13 enhancements—spacing,
+/// typography, sizing, colour and positioning each route through
+/// `Responsive::resolve` so automated breakpoint handling stays declarative.
 #[doc(hidden)]
 pub fn build_box_style(
     width: u32,

--- a/crates/mui-system/src/container.rs
+++ b/crates/mui-system/src/container.rs
@@ -2,6 +2,17 @@ use crate::{responsive::Responsive, style, theme::Breakpoints};
 use mui_utils::deep_merge;
 use serde_json::{Map, Value};
 
+/// Lightweight descriptor mirroring the ergonomics of [`crate::r#box::BoxStyleInputs`].
+/// Enterprise applications frequently centralise layout rules, so allowing the
+/// adapters to pass borrowed responsive handles keeps cloning to a minimum and
+/// makes the automation surface explicit.
+pub struct ContainerStyleInputs<'a> {
+    /// Optional responsive maximum width declaration for the container.
+    pub max_width: Option<&'a Responsive<String>>,
+    /// Arbitrary JSON overrides merged through the `sx` pipeline.
+    pub sx: Option<&'a Value>,
+}
+
 /// Builds the inline style string for the container based on the current
 /// viewport width. The helper is used by all framework adapters and ensures the
 /// integration tests exercise the exact same resolution logic.
@@ -9,13 +20,12 @@ use serde_json::{Map, Value};
 pub fn build_container_style(
     width: u32,
     breakpoints: &Breakpoints,
-    max_width: Option<&Responsive<String>>,
-    sx: Option<&Value>,
+    inputs: ContainerStyleInputs<'_>,
 ) -> String {
     let mut style_map = Map::new();
     style_map.insert("width".into(), Value::String("100%".into()));
 
-    if let Some(mw) = max_width {
+    if let Some(mw) = inputs.max_width {
         let resolved = mw.resolve(width, breakpoints);
         style_map.insert("margin-left".into(), Value::String("auto".into()));
         style_map.insert("margin-right".into(), Value::String("auto".into()));
@@ -23,7 +33,7 @@ pub fn build_container_style(
     }
 
     let mut style_value = Value::Object(style_map);
-    if let Some(sx) = sx {
+    if let Some(sx) = inputs.sx {
         deep_merge(&mut style_value, sx.clone());
     }
 
@@ -57,8 +67,10 @@ mod yew_impl {
         let style_rules = build_container_style(
             width,
             &theme.breakpoints,
-            props.max_width.as_ref(),
-            props.sx.as_ref(),
+            ContainerStyleInputs {
+                max_width: props.max_width.as_ref(),
+                sx: props.sx.as_ref(),
+            },
         );
         // Convert the inline style string into a scoped class so the styled
         // engine can deduplicate rules and we avoid sprinkling CSP sensitive
@@ -90,8 +102,14 @@ mod leptos_impl {
     ) -> impl IntoView {
         let theme = crate::theme_provider::use_theme();
         let width = crate::responsive::viewport_width();
-        let style_rules =
-            build_container_style(width, &theme.breakpoints, max_width.as_ref(), sx.as_ref());
+        let style_rules = build_container_style(
+            width,
+            &theme.breakpoints,
+            ContainerStyleInputs {
+                max_width: max_width.as_ref(),
+                sx: sx.as_ref(),
+            },
+        );
         // Persist the scoped class for the component lifetime so the stylist
         // registry keeps the CSS mounted until Leptos disposes the view.
         let scoped = store_value(crate::ScopedClass::from_declarations(style_rules));

--- a/crates/mui-system/tests/responsive_container.rs
+++ b/crates/mui-system/tests/responsive_container.rs
@@ -1,4 +1,8 @@
-use mui_system::{container::build_container_style, responsive::Responsive, Theme};
+use mui_system::{
+    container::{build_container_style, ContainerStyleInputs},
+    responsive::Responsive,
+    Theme,
+};
 use serde_json::json;
 
 #[test]
@@ -12,17 +16,26 @@ fn container_applies_responsive_max_width() {
         xl: Some("1440px".into()),
     };
 
-    let mobile = build_container_style(400, &theme.breakpoints, Some(&max_width), None);
+    let mobile = build_container_style(
+        400,
+        &theme.breakpoints,
+        ContainerStyleInputs {
+            max_width: Some(&max_width),
+            sx: None,
+        },
+    );
     assert!(mobile.contains("width:100%;"));
     assert!(mobile.contains("max-width:100%;"));
 
     let desktop = build_container_style(
         1280,
         &theme.breakpoints,
-        Some(&max_width),
-        Some(&json!({
-            "padding": "24px",
-        })),
+        ContainerStyleInputs {
+            max_width: Some(&max_width),
+            sx: Some(&json!({
+                "padding": "24px",
+            })),
+        },
     );
     assert!(desktop.contains("max-width:1200px;"));
     assert!(desktop.contains("margin-left:auto;"));

--- a/crates/mui-system/tests/responsive_grid.rs
+++ b/crates/mui-system/tests/responsive_grid.rs
@@ -1,4 +1,8 @@
-use mui_system::{grid::build_grid_style, responsive::Responsive, Theme};
+use mui_system::{
+    grid::{build_grid_style, GridStyleInputs},
+    responsive::Responsive,
+    Theme,
+};
 use serde_json::json;
 
 #[test]
@@ -22,13 +26,15 @@ fn grid_breakpoints_resolve_width_and_alignment() {
     let base = build_grid_style(
         500,
         &theme.breakpoints,
-        Some(&columns),
-        Some(&span),
-        Some("center"),
-        None,
-        Some(&json!({
-            "border": "1px solid red",
-        })),
+        GridStyleInputs {
+            columns: Some(&columns),
+            span: Some(&span),
+            justify_content: Some("center"),
+            align_items: None,
+            sx: Some(&json!({
+                "border": "1px solid red",
+            })),
+        },
     );
     assert!(base.contains("border:1px solid red;"));
     assert!(base.contains("width:100%;"));
@@ -37,11 +43,13 @@ fn grid_breakpoints_resolve_width_and_alignment() {
     let medium = build_grid_style(
         950,
         &theme.breakpoints,
-        Some(&columns),
-        Some(&span),
-        None,
-        Some("flex-end"),
-        None,
+        GridStyleInputs {
+            columns: Some(&columns),
+            span: Some(&span),
+            justify_content: None,
+            align_items: Some("flex-end"),
+            sx: None,
+        },
     );
     assert!(medium.contains("width:50%;"));
     assert!(medium.contains("align-items:flex-end;"));
@@ -49,11 +57,13 @@ fn grid_breakpoints_resolve_width_and_alignment() {
     let extra_large = build_grid_style(
         1600,
         &theme.breakpoints,
-        Some(&columns),
-        Some(&span),
-        None,
-        None,
-        None,
+        GridStyleInputs {
+            columns: Some(&columns),
+            span: Some(&span),
+            justify_content: None,
+            align_items: None,
+            sx: None,
+        },
     );
     assert!(extra_large.contains("width:75%;"));
 }

--- a/crates/mui-system/tests/responsive_stack.rs
+++ b/crates/mui-system/tests/responsive_stack.rs
@@ -1,6 +1,6 @@
 use mui_system::{
     responsive::Responsive,
-    stack::{build_stack_style, StackDirection},
+    stack::{build_stack_style, StackDirection, StackStyleInputs},
     Theme,
 };
 use serde_json::json;
@@ -19,11 +19,13 @@ fn stack_spacing_scales_with_breakpoints() {
     let column = build_stack_style(
         480,
         &theme.breakpoints,
-        None,
-        Some(&spacing),
-        Some("center"),
-        None,
-        None,
+        StackStyleInputs {
+            direction: None,
+            spacing: Some(&spacing),
+            align_items: Some("center"),
+            justify_content: None,
+            sx: None,
+        },
     );
     assert!(column.contains("display:flex;"));
     assert!(column.contains("flex-direction:column;"));
@@ -33,13 +35,15 @@ fn stack_spacing_scales_with_breakpoints() {
     let row = build_stack_style(
         1000,
         &theme.breakpoints,
-        Some(StackDirection::Row),
-        Some(&spacing),
-        None,
-        Some("space-between"),
-        Some(&json!({
-            "background": "blue",
-        })),
+        StackStyleInputs {
+            direction: Some(StackDirection::Row),
+            spacing: Some(&spacing),
+            align_items: None,
+            justify_content: Some("space-between"),
+            sx: Some(&json!({
+                "background": "blue",
+            })),
+        },
     );
     assert!(row.contains("flex-direction:row;"));
     assert!(row.contains("gap:16px;"));

--- a/crates/mui-system/tests/sx_json.rs
+++ b/crates/mui-system/tests/sx_json.rs
@@ -1,5 +1,5 @@
 use mui_system::{
-    container::build_container_style,
+    container::{build_container_style, ContainerStyleInputs},
     r#box::{build_box_style, BoxStyleInputs},
     responsive::Responsive,
     Theme,
@@ -12,11 +12,13 @@ fn container_json_sx_overrides_width() {
     let style = build_container_style(
         1024,
         &theme.breakpoints,
-        None,
-        Some(&json!({
-            "width": "80%",
-            "background-color": "#fafafa",
-        })),
+        ContainerStyleInputs {
+            max_width: None,
+            sx: Some(&json!({
+                "width": "80%",
+                "background-color": "#fafafa",
+            })),
+        },
     );
 
     assert!(style.contains("width:80%;"));


### PR DESCRIPTION
## Summary
- introduce `GridStyleInputs`, `ContainerStyleInputs`, and `StackStyleInputs` so grid, container, and stack builders consistently resolve `Responsive` props against theme breakpoints
- document Issue 13 responsive props in `Box` and expand tests to cover the new input descriptors across grid, container, stack, and sx overrides
- refresh the README with updated responsive examples and guidance on the shared `*StyleInputs` automation surface

## Testing
- `cargo test -p mui-system`


------
https://chatgpt.com/codex/tasks/task_e_68cc0bd2dbd0832e8dc3e7cd81d5446e