### PR TITLE
feat: add material component parity tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,20 @@ Before starting large efforts, open a GitHub discussion or issue so the maintain
 
 All repetitive chores are encapsulated inside the `Makefile` or `cargo xtask`. Prefer these entry points over ad-hoc scripts.
 
+### Component parity tracker
+
+To monitor progress toward full Material UI coverage run the automated scanner:
+
+```bash
+cargo xtask material-parity
+```
+
+The command invokes the Rust CLI under `tools/material-parity` which parses the
+React source (`packages/mui-material/src`) and generates the consolidated
+report at `docs/material-component-parity.md`. Keep this artifact up to date in
+pull requests that add or remove components so downstream teams have a reliable
+signal when planning migrations.
+
 ## Branching and pull requests
 
 - Fork the repository and branch from `main`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +88,17 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ast_node"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a184645bcc6f52d69d8e7639720699c6a99efb711f886e251ed1d16db8dd90e"
+dependencies = [
+ "quote",
+ "swc_macros_common",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "async-recursion"
@@ -155,6 +175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "better_scoped_tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
+dependencies = [
+ "scoped-tls",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bytes-str"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c60b5ce37e0b883c37eb89f79a1e26fbe9c1081945d024eee93e8d91a7e18b3"
+dependencies = [
+ "bytes",
+ "serde",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +280,18 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -364,6 +415,12 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_maths"
@@ -499,7 +556,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "longest-increasing-subsequence",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "slab",
  "smallbox",
  "tracing",
@@ -617,6 +674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "from_variant"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308530a56b099da144ebc5d8e179f343ad928fa2b3558d1eb3db9af18d6eff43"
+dependencies = [
+ "swc_macros_common",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1152,6 +1219,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hstr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced1416104790052518d199e753d49a7d8130d476c664bc9e53f40cfecb8e615"
+dependencies = [
+ "hashbrown 0.14.5",
+ "new_debug_unreachable",
+ "once_cell",
+ "rustc-hash 2.1.1",
+ "triomphe",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1260,30 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1352,6 +1456,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,7 +1590,7 @@ dependencies = [
  "once_cell",
  "pad-adapter",
  "paste",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "server_fn",
@@ -1540,7 +1656,7 @@ dependencies = [
  "oco_ref",
  "paste",
  "pin-project",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "self_cell",
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -1646,6 +1762,22 @@ dependencies = [
  "proc-macro-utils 0.8.0",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "material-parity"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "heck",
+ "serde",
+ "serde_json",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "walkdir",
 ]
 
 [[package]]
@@ -1798,6 +1930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1943,26 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1903,6 +2061,48 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
 
 [[package]]
 name = "pico-args"
@@ -2146,6 +2346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,11 +2702,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "seq-macro"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2512,10 +2740,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2646,6 +2883,12 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
@@ -2679,10 +2922,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strict-num"
@@ -2691,6 +2964,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
+]
+
+[[package]]
+name = "string_enum"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
+dependencies = [
+ "quote",
+ "swc_macros_common",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2753,7 +3037,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
  "kurbo",
- "siphasher",
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "swc_atoms"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3500dcf04c84606b38464561edc5e46f5132201cb3e23cf9613ed4033d6b1bb2"
+dependencies = [
+ "hstr",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "swc_common"
+version = "14.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2bb772b3a26b8b71d4e8c112ced5b5867be2266364b58517407a270328a2696"
+dependencies = [
+ "anyhow",
+ "ast_node",
+ "better_scoped_tls",
+ "bytes-str",
+ "either",
+ "from_variant",
+ "new_debug_unreachable",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash 2.1.1",
+ "serde",
+ "siphasher 0.3.11",
+ "swc_atoms",
+ "swc_eq_ignore_macros",
+ "swc_visit",
+ "tracing",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c25af97d53cf8aab66a6c68f3418663313fc969ad267fc2a4d19402c329be1"
+dependencies = [
+ "bitflags",
+ "is-macro",
+ "num-bigint",
+ "once_cell",
+ "phf",
+ "rustc-hash 2.1.1",
+ "serde",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "swc_visit",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "swc_ecma_lexer"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c3bd958a5a67e2cc3f74abdd41fda688e54e7a25b866569260ef7018b67972"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "either",
+ "num-bigint",
+ "phf",
+ "rustc-hash 2.1.1",
+ "seq-macro",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "24.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8079e65c43d8f3e64e791321355f5864322425fce3a3ab7fc959bbddb531933"
+dependencies = [
+ "either",
+ "num-bigint",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_lexer",
+ "tracing",
+]
+
+[[package]]
+name = "swc_eq_ignore_macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16ce73424a6316e95e09065ba6a207eba7765496fed113702278b7711d4b632"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "swc_macros_common"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1efbaa74943dc5ad2a2fb16cbd78b77d7e4d63188f3c5b4df2b4dcd2faaae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "swc_visit"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fb71484b486c185e34d2172f0eabe7f4722742aad700f426a494bb2de232a2"
+dependencies = [
+ "either",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -3125,6 +3537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "trybuild"
 version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,6 +3615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,6 +3649,12 @@ name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -3278,7 +3712,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "simplecss",
- "siphasher",
+ "siphasher 1.0.1",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -3507,10 +3941,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "crates/mui-icons-material",
     "crates/mui-utils",
     "crates/xtask",
+    "tools/material-parity",
 ]
 
 # Use Cargo's second feature resolver so optional dependencies don't
@@ -83,13 +84,15 @@ once_cell = "1.21.3"
 proptest = "1.2"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["Window", "HtmlElement", "Event", "EventTarget"] }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 # Lightweight tooling dependencies used by maintenance utilities like the
 # icon updater. These are optional in downstream crates but centralised here
 # so versions stay consistent across the workspace.
 ureq = { version = "2.9", features = ["tls"], default-features = false }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+walkdir = "2.5"
+heck = "0.5"
 
 [profile.dev]
 # Development builds prioritize compile time over runtime performance.

--- a/crates/mui-material/README.md
+++ b/crates/mui-material/README.md
@@ -18,6 +18,22 @@ enterprise-friendly ergonomics: button callbacks can be throttled,
 text inputs debounced and style overrides appended directly within
 `css_with_theme!` blocks.
 
+## Component Coverage
+
+Parity with the upstream React package is tracked automatically in the
+[Material component parity report](../../docs/material-component-parity.md).
+The snapshot lists every export from `packages/mui-material/src` and highlights
+which widgets are implemented in this crate or delegated to `mui-headless`.
+
+Current gaps most relevant to enterprise adopters include:
+
+- Advanced form helpers such as `Autocomplete` and `Select`.
+- The data-heavy `Table` family (`Table`, `TableBody`, `TablePagination`).
+- Navigation primitives including `Tabs` and related panels.
+
+Contributions that land these components should reference the report to keep
+the automation in sync; `cargo xtask material-parity` refreshes the metrics.
+
 ## Feature Flags
 
 Select a single front-end framework to keep builds lean. All features are

--- a/crates/mui-styled-engine-macros/src/lib.rs
+++ b/crates/mui-styled-engine-macros/src/lib.rs
@@ -24,7 +24,7 @@ pub fn derive_theme(input: TokenStream) -> TokenStream {
     let assignments = fields.iter().map(|f| {
         let ident = f.ident.as_ref().unwrap();
         let ty = &f.ty;
-        let assignment = if is_option(ty) {
+        if is_option(ty) {
             quote! {
                 #ident: self.#ident
                     .map(::core::convert::Into::into)
@@ -32,8 +32,7 @@ pub fn derive_theme(input: TokenStream) -> TokenStream {
             }
         } else {
             quote! { #ident: ::core::convert::Into::into(self.#ident) }
-        };
-        assignment
+        }
     });
 
     let expanded = quote! {

--- a/crates/mui-utils/src/compose_classes.rs
+++ b/crates/mui-utils/src/compose_classes.rs
@@ -51,25 +51,23 @@ where
     for (slot_name, slot_values) in slots {
         let mut buf = String::new();
         let mut seen = HashSet::new();
-        for opt in slot_values {
-            if let Some(ref value) = opt {
-                // Avoid repeating the same utility key
-                if seen.insert(value.clone()) {
-                    let util = get_utility_class(value);
-                    if !util.is_empty() {
-                        if !buf.is_empty() {
-                            buf.push(' ');
-                        }
-                        buf.push_str(&util);
+        for value in slot_values.iter().flatten() {
+            // Avoid repeating the same utility key
+            if seen.insert(value.clone()) {
+                let util = get_utility_class(value);
+                if !util.is_empty() {
+                    if !buf.is_empty() {
+                        buf.push(' ');
                     }
-                    if let Some(class_map) = classes {
-                        if let Some(extra) = class_map.get(value) {
-                            if !extra.is_empty() {
-                                if !buf.is_empty() {
-                                    buf.push(' ');
-                                }
-                                buf.push_str(extra);
+                    buf.push_str(&util);
+                }
+                if let Some(class_map) = classes {
+                    if let Some(extra) = class_map.get(value) {
+                        if !extra.is_empty() {
+                            if !buf.is_empty() {
+                                buf.push(' ');
                             }
+                            buf.push_str(extra);
                         }
                     }
                 }

--- a/crates/mui-utils/src/throttle.rs
+++ b/crates/mui-utils/src/throttle.rs
@@ -74,7 +74,7 @@ where
         }
         let now = Instant::now();
         let mut last_lock = last.lock().unwrap();
-        if last_lock.map_or(true, |l| now.duration_since(l) >= interval) {
+        if last_lock.is_none_or(|l| now.duration_since(l) >= interval) {
             *last_lock = Some(now);
             func(arg);
         }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -51,6 +51,8 @@ enum Commands {
     BuildDocs,
     /// Regenerate serialized theme templates and CSS baselines.
     GenerateTheme,
+    /// Recompute the Material component parity dashboard.
+    MaterialParity,
 }
 
 fn main() -> Result<()> {
@@ -68,6 +70,7 @@ fn main() -> Result<()> {
         Commands::AccessibilityAudit => accessibility_audit(),
         Commands::BuildDocs => build_docs(),
         Commands::GenerateTheme => generate_theme(),
+        Commands::MaterialParity => material_parity(),
     }
 }
 
@@ -239,6 +242,19 @@ fn generate_theme() -> Result<()> {
     println!("[xtask] wrote {}", css_path.display());
 
     Ok(())
+}
+
+fn material_parity() -> Result<()> {
+    // Keep the parity snapshot fresh so enterprise adopters can track adoption progress
+    // without spelunking through multiple repositories.
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run")
+        .arg("-p")
+        .arg("material-parity")
+        .arg("--")
+        .arg("--report")
+        .arg("docs/material-component-parity.md");
+    run(cmd)
 }
 
 fn bench() -> Result<()> {

--- a/docs/material-component-parity.md
+++ b/docs/material-component-parity.md
@@ -1,0 +1,2630 @@
+# Material Component Parity
+
+_Last updated 2025-09-19T13:05:32.393450968+00:00 via `cargo xtask material-parity`._
+
+## Coverage snapshot
+
+- React exports analyzed: 146\n- `mui-material` coverage: 6 (4.1%)\n- `mui-headless` coverage: 1 (0.7%)\n
+## Highest priority gaps
+
+| Rank | Component | Source |
+| --- | --- | --- |
+| 1 | Accordion | `packages/mui-material/src/Accordion` |
+| 2 | AccordionActions | `packages/mui-material/src/AccordionActions` |
+| 3 | AccordionDetails | `packages/mui-material/src/AccordionDetails` |
+| 4 | AccordionSummary | `packages/mui-material/src/AccordionSummary` |
+| 5 | Alert | `packages/mui-material/src/Alert` |
+| 6 | AlertTitle | `packages/mui-material/src/AlertTitle` |
+| 7 | Autocomplete | `packages/mui-material/src/Autocomplete` |
+| 8 | Avatar | `packages/mui-material/src/Avatar` |
+| 9 | AvatarGroup | `packages/mui-material/src/AvatarGroup` |
+| 10 | Backdrop | `packages/mui-material/src/Backdrop` |
+
+## Machine-readable snapshot
+
+```json
+{
+  "generated_at": "2025-09-19T13:05:32.393450968Z",
+  "total_components": 146,
+  "supported_in_material": 6,
+  "supported_in_headless": 1,
+  "material_coverage": 0.04109589,
+  "headless_coverage": 0.006849315,
+  "components": [
+    {
+      "name": "Accordion",
+      "normalized": "accordion",
+      "source": "packages/mui-material/src/Accordion",
+      "declared_in": "packages/mui-material/src/Accordion/index.js"
+    },
+    {
+      "name": "AccordionActions",
+      "normalized": "accordion_actions",
+      "source": "packages/mui-material/src/AccordionActions",
+      "declared_in": "packages/mui-material/src/AccordionActions/index.js"
+    },
+    {
+      "name": "AccordionDetails",
+      "normalized": "accordion_details",
+      "source": "packages/mui-material/src/AccordionDetails",
+      "declared_in": "packages/mui-material/src/AccordionDetails/index.js"
+    },
+    {
+      "name": "AccordionSummary",
+      "normalized": "accordion_summary",
+      "source": "packages/mui-material/src/AccordionSummary",
+      "declared_in": "packages/mui-material/src/AccordionSummary/index.js"
+    },
+    {
+      "name": "Alert",
+      "normalized": "alert",
+      "source": "packages/mui-material/src/Alert",
+      "declared_in": "packages/mui-material/src/Alert/index.js"
+    },
+    {
+      "name": "AlertTitle",
+      "normalized": "alert_title",
+      "source": "packages/mui-material/src/AlertTitle",
+      "declared_in": "packages/mui-material/src/AlertTitle/index.js"
+    },
+    {
+      "name": "AppBar",
+      "normalized": "app_bar",
+      "source": "packages/mui-material/src/AppBar",
+      "declared_in": "packages/mui-material/src/AppBar/index.js"
+    },
+    {
+      "name": "Autocomplete",
+      "normalized": "autocomplete",
+      "source": "packages/mui-material/src/Autocomplete",
+      "declared_in": "packages/mui-material/src/Autocomplete/index.js"
+    },
+    {
+      "name": "Avatar",
+      "normalized": "avatar",
+      "source": "packages/mui-material/src/Avatar",
+      "declared_in": "packages/mui-material/src/Avatar/index.js"
+    },
+    {
+      "name": "AvatarGroup",
+      "normalized": "avatar_group",
+      "source": "packages/mui-material/src/AvatarGroup",
+      "declared_in": "packages/mui-material/src/AvatarGroup/index.js"
+    },
+    {
+      "name": "Backdrop",
+      "normalized": "backdrop",
+      "source": "packages/mui-material/src/Backdrop",
+      "declared_in": "packages/mui-material/src/Backdrop/index.js"
+    },
+    {
+      "name": "Badge",
+      "normalized": "badge",
+      "source": "packages/mui-material/src/Badge",
+      "declared_in": "packages/mui-material/src/Badge/index.js"
+    },
+    {
+      "name": "BottomNavigation",
+      "normalized": "bottom_navigation",
+      "source": "packages/mui-material/src/BottomNavigation",
+      "declared_in": "packages/mui-material/src/BottomNavigation/index.js"
+    },
+    {
+      "name": "BottomNavigationAction",
+      "normalized": "bottom_navigation_action",
+      "source": "packages/mui-material/src/BottomNavigationAction",
+      "declared_in": "packages/mui-material/src/BottomNavigationAction/index.js"
+    },
+    {
+      "name": "Box",
+      "normalized": "box",
+      "source": "packages/mui-material/src/Box",
+      "declared_in": "packages/mui-material/src/Box/index.js"
+    },
+    {
+      "name": "Breadcrumbs",
+      "normalized": "breadcrumbs",
+      "source": "packages/mui-material/src/Breadcrumbs",
+      "declared_in": "packages/mui-material/src/Breadcrumbs/index.js"
+    },
+    {
+      "name": "Button",
+      "normalized": "button",
+      "source": "packages/mui-material/src/Button",
+      "declared_in": "packages/mui-material/src/Button/index.js"
+    },
+    {
+      "name": "ButtonBase",
+      "normalized": "button_base",
+      "source": "packages/mui-material/src/ButtonBase",
+      "declared_in": "packages/mui-material/src/ButtonBase/index.js"
+    },
+    {
+      "name": "ButtonGroup",
+      "normalized": "button_group",
+      "source": "packages/mui-material/src/ButtonGroup",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "ButtonGroupButtonContext",
+      "normalized": "button_group_button_context",
+      "source": "packages/mui-material/src/ButtonGroupButtonContext",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "ButtonGroupContext",
+      "normalized": "button_group_context",
+      "source": "packages/mui-material/src/ButtonGroupContext",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "Card",
+      "normalized": "card",
+      "source": "packages/mui-material/src/Card",
+      "declared_in": "packages/mui-material/src/Card/index.js"
+    },
+    {
+      "name": "CardActionArea",
+      "normalized": "card_action_area",
+      "source": "packages/mui-material/src/CardActionArea",
+      "declared_in": "packages/mui-material/src/CardActionArea/index.js"
+    },
+    {
+      "name": "CardActions",
+      "normalized": "card_actions",
+      "source": "packages/mui-material/src/CardActions",
+      "declared_in": "packages/mui-material/src/CardActions/index.js"
+    },
+    {
+      "name": "CardContent",
+      "normalized": "card_content",
+      "source": "packages/mui-material/src/CardContent",
+      "declared_in": "packages/mui-material/src/CardContent/index.js"
+    },
+    {
+      "name": "CardHeader",
+      "normalized": "card_header",
+      "source": "packages/mui-material/src/CardHeader",
+      "declared_in": "packages/mui-material/src/CardHeader/index.js"
+    },
+    {
+      "name": "CardMedia",
+      "normalized": "card_media",
+      "source": "packages/mui-material/src/CardMedia",
+      "declared_in": "packages/mui-material/src/CardMedia/index.js"
+    },
+    {
+      "name": "Checkbox",
+      "normalized": "checkbox",
+      "source": "packages/mui-material/src/Checkbox",
+      "declared_in": "packages/mui-material/src/Checkbox/index.js"
+    },
+    {
+      "name": "Chip",
+      "normalized": "chip",
+      "source": "packages/mui-material/src/Chip",
+      "declared_in": "packages/mui-material/src/Chip/index.js"
+    },
+    {
+      "name": "CircularProgress",
+      "normalized": "circular_progress",
+      "source": "packages/mui-material/src/CircularProgress",
+      "declared_in": "packages/mui-material/src/CircularProgress/index.js"
+    },
+    {
+      "name": "ClickAwayListener",
+      "normalized": "click_away_listener",
+      "source": "packages/mui-material/src/ClickAwayListener",
+      "declared_in": "packages/mui-material/src/index.js"
+    },
+    {
+      "name": "Collapse",
+      "normalized": "collapse",
+      "source": "packages/mui-material/src/Collapse",
+      "declared_in": "packages/mui-material/src/Collapse/index.js"
+    },
+    {
+      "name": "Container",
+      "normalized": "container",
+      "source": "packages/mui-material/src/Container",
+      "declared_in": "packages/mui-material/src/Container/index.js"
+    },
+    {
+      "name": "CssBaseline",
+      "normalized": "css_baseline",
+      "source": "packages/mui-material/src/CssBaseline",
+      "declared_in": "packages/mui-material/src/CssBaseline/index.js"
+    },
+    {
+      "name": "DefaultPropsProvider",
+      "normalized": "default_props_provider",
+      "source": "packages/mui-material/src/DefaultPropsProvider",
+      "declared_in": "packages/mui-material/src/DefaultPropsProvider/index.ts"
+    },
+    {
+      "name": "Dialog",
+      "normalized": "dialog",
+      "source": "packages/mui-material/src/Dialog",
+      "declared_in": "packages/mui-material/src/Dialog/index.js"
+    },
+    {
+      "name": "DialogActions",
+      "normalized": "dialog_actions",
+      "source": "packages/mui-material/src/DialogActions",
+      "declared_in": "packages/mui-material/src/DialogActions/index.js"
+    },
+    {
+      "name": "DialogContent",
+      "normalized": "dialog_content",
+      "source": "packages/mui-material/src/DialogContent",
+      "declared_in": "packages/mui-material/src/DialogContent/index.js"
+    },
+    {
+      "name": "DialogContentText",
+      "normalized": "dialog_content_text",
+      "source": "packages/mui-material/src/DialogContentText",
+      "declared_in": "packages/mui-material/src/DialogContentText/index.js"
+    },
+    {
+      "name": "DialogTitle",
+      "normalized": "dialog_title",
+      "source": "packages/mui-material/src/DialogTitle",
+      "declared_in": "packages/mui-material/src/DialogTitle/index.js"
+    },
+    {
+      "name": "Divider",
+      "normalized": "divider",
+      "source": "packages/mui-material/src/Divider",
+      "declared_in": "packages/mui-material/src/Divider/index.js"
+    },
+    {
+      "name": "Drawer",
+      "normalized": "drawer",
+      "source": "packages/mui-material/src/Drawer",
+      "declared_in": "packages/mui-material/src/Drawer/index.js"
+    },
+    {
+      "name": "Fab",
+      "normalized": "fab",
+      "source": "packages/mui-material/src/Fab",
+      "declared_in": "packages/mui-material/src/Fab/index.js"
+    },
+    {
+      "name": "Fade",
+      "normalized": "fade",
+      "source": "packages/mui-material/src/Fade",
+      "declared_in": "packages/mui-material/src/Fade/index.js"
+    },
+    {
+      "name": "FilledInput",
+      "normalized": "filled_input",
+      "source": "packages/mui-material/src/FilledInput",
+      "declared_in": "packages/mui-material/src/FilledInput/index.js"
+    },
+    {
+      "name": "FocusTrap",
+      "normalized": "focus_trap",
+      "source": "packages/mui-material/src/FocusTrap",
+      "declared_in": "packages/mui-material/src/Unstable_TrapFocus/index.js"
+    },
+    {
+      "name": "FormControl",
+      "normalized": "form_control",
+      "source": "packages/mui-material/src/FormControl",
+      "declared_in": "packages/mui-material/src/FormControl/index.js"
+    },
+    {
+      "name": "FormControlLabel",
+      "normalized": "form_control_label",
+      "source": "packages/mui-material/src/FormControlLabel",
+      "declared_in": "packages/mui-material/src/FormControlLabel/index.js"
+    },
+    {
+      "name": "FormGroup",
+      "normalized": "form_group",
+      "source": "packages/mui-material/src/FormGroup",
+      "declared_in": "packages/mui-material/src/FormGroup/index.js"
+    },
+    {
+      "name": "FormHelperText",
+      "normalized": "form_helper_text",
+      "source": "packages/mui-material/src/FormHelperText",
+      "declared_in": "packages/mui-material/src/FormHelperText/index.js"
+    },
+    {
+      "name": "FormLabel",
+      "normalized": "form_label",
+      "source": "packages/mui-material/src/FormLabel",
+      "declared_in": "packages/mui-material/src/FormLabel/index.js"
+    },
+    {
+      "name": "GlobalStyles",
+      "normalized": "global_styles",
+      "source": "packages/mui-material/src/GlobalStyles",
+      "declared_in": "packages/mui-material/src/GlobalStyles/index.js"
+    },
+    {
+      "name": "Grid",
+      "normalized": "grid",
+      "source": "packages/mui-material/src/Grid",
+      "declared_in": "packages/mui-material/src/Grid/index.ts"
+    },
+    {
+      "name": "GridLegacy",
+      "normalized": "grid_legacy",
+      "source": "packages/mui-material/src/GridLegacy",
+      "declared_in": "packages/mui-material/src/GridLegacy/index.js"
+    },
+    {
+      "name": "Grow",
+      "normalized": "grow",
+      "source": "packages/mui-material/src/Grow",
+      "declared_in": "packages/mui-material/src/Grow/index.js"
+    },
+    {
+      "name": "Icon",
+      "normalized": "icon",
+      "source": "packages/mui-material/src/Icon",
+      "declared_in": "packages/mui-material/src/Icon/index.js"
+    },
+    {
+      "name": "IconButton",
+      "normalized": "icon_button",
+      "source": "packages/mui-material/src/IconButton",
+      "declared_in": "packages/mui-material/src/IconButton/index.js"
+    },
+    {
+      "name": "ImageList",
+      "normalized": "image_list",
+      "source": "packages/mui-material/src/ImageList",
+      "declared_in": "packages/mui-material/src/ImageList/index.js"
+    },
+    {
+      "name": "ImageListItem",
+      "normalized": "image_list_item",
+      "source": "packages/mui-material/src/ImageListItem",
+      "declared_in": "packages/mui-material/src/ImageListItem/index.js"
+    },
+    {
+      "name": "ImageListItemBar",
+      "normalized": "image_list_item_bar",
+      "source": "packages/mui-material/src/ImageListItemBar",
+      "declared_in": "packages/mui-material/src/ImageListItemBar/index.js"
+    },
+    {
+      "name": "InitColorSchemeScript",
+      "normalized": "init_color_scheme_script",
+      "source": "packages/mui-material/src/InitColorSchemeScript",
+      "declared_in": "packages/mui-material/src/InitColorSchemeScript/index.ts"
+    },
+    {
+      "name": "Input",
+      "normalized": "input",
+      "source": "packages/mui-material/src/Input",
+      "declared_in": "packages/mui-material/src/Input/index.js"
+    },
+    {
+      "name": "InputAdornment",
+      "normalized": "input_adornment",
+      "source": "packages/mui-material/src/InputAdornment",
+      "declared_in": "packages/mui-material/src/InputAdornment/index.js"
+    },
+    {
+      "name": "InputBase",
+      "normalized": "input_base",
+      "source": "packages/mui-material/src/InputBase",
+      "declared_in": "packages/mui-material/src/InputBase/index.js"
+    },
+    {
+      "name": "InputLabel",
+      "normalized": "input_label",
+      "source": "packages/mui-material/src/InputLabel",
+      "declared_in": "packages/mui-material/src/InputLabel/index.js"
+    },
+    {
+      "name": "LinearProgress",
+      "normalized": "linear_progress",
+      "source": "packages/mui-material/src/LinearProgress",
+      "declared_in": "packages/mui-material/src/LinearProgress/index.js"
+    },
+    {
+      "name": "Link",
+      "normalized": "link",
+      "source": "packages/mui-material/src/Link",
+      "declared_in": "packages/mui-material/src/Link/index.js"
+    },
+    {
+      "name": "List",
+      "normalized": "list",
+      "source": "packages/mui-material/src/List",
+      "declared_in": "packages/mui-material/src/List/index.js"
+    },
+    {
+      "name": "ListItem",
+      "normalized": "list_item",
+      "source": "packages/mui-material/src/ListItem",
+      "declared_in": "packages/mui-material/src/ListItem/index.js"
+    },
+    {
+      "name": "ListItemAvatar",
+      "normalized": "list_item_avatar",
+      "source": "packages/mui-material/src/ListItemAvatar",
+      "declared_in": "packages/mui-material/src/ListItemAvatar/index.js"
+    },
+    {
+      "name": "ListItemButton",
+      "normalized": "list_item_button",
+      "source": "packages/mui-material/src/ListItemButton",
+      "declared_in": "packages/mui-material/src/ListItemButton/index.js"
+    },
+    {
+      "name": "ListItemIcon",
+      "normalized": "list_item_icon",
+      "source": "packages/mui-material/src/ListItemIcon",
+      "declared_in": "packages/mui-material/src/ListItemIcon/index.js"
+    },
+    {
+      "name": "ListItemSecondaryAction",
+      "normalized": "list_item_secondary_action",
+      "source": "packages/mui-material/src/ListItemSecondaryAction",
+      "declared_in": "packages/mui-material/src/ListItemSecondaryAction/index.js"
+    },
+    {
+      "name": "ListItemText",
+      "normalized": "list_item_text",
+      "source": "packages/mui-material/src/ListItemText",
+      "declared_in": "packages/mui-material/src/ListItemText/index.js"
+    },
+    {
+      "name": "ListSubheader",
+      "normalized": "list_subheader",
+      "source": "packages/mui-material/src/ListSubheader",
+      "declared_in": "packages/mui-material/src/ListSubheader/index.js"
+    },
+    {
+      "name": "Menu",
+      "normalized": "menu",
+      "source": "packages/mui-material/src/Menu",
+      "declared_in": "packages/mui-material/src/Menu/index.js"
+    },
+    {
+      "name": "MenuItem",
+      "normalized": "menu_item",
+      "source": "packages/mui-material/src/MenuItem",
+      "declared_in": "packages/mui-material/src/MenuItem/index.js"
+    },
+    {
+      "name": "MenuList",
+      "normalized": "menu_list",
+      "source": "packages/mui-material/src/MenuList",
+      "declared_in": "packages/mui-material/src/MenuList/index.js"
+    },
+    {
+      "name": "MobileStepper",
+      "normalized": "mobile_stepper",
+      "source": "packages/mui-material/src/MobileStepper",
+      "declared_in": "packages/mui-material/src/MobileStepper/index.js"
+    },
+    {
+      "name": "Modal",
+      "normalized": "modal",
+      "source": "packages/mui-material/src/Modal",
+      "declared_in": "packages/mui-material/src/Modal/index.js"
+    },
+    {
+      "name": "NativeSelect",
+      "normalized": "native_select",
+      "source": "packages/mui-material/src/NativeSelect",
+      "declared_in": "packages/mui-material/src/NativeSelect/index.js"
+    },
+    {
+      "name": "NoSsr",
+      "normalized": "no_ssr",
+      "source": "packages/mui-material/src/NoSsr",
+      "declared_in": "packages/mui-material/src/NoSsr/index.js"
+    },
+    {
+      "name": "OutlinedInput",
+      "normalized": "outlined_input",
+      "source": "packages/mui-material/src/OutlinedInput",
+      "declared_in": "packages/mui-material/src/OutlinedInput/index.js"
+    },
+    {
+      "name": "Pagination",
+      "normalized": "pagination",
+      "source": "packages/mui-material/src/Pagination",
+      "declared_in": "packages/mui-material/src/Pagination/index.js"
+    },
+    {
+      "name": "PaginationItem",
+      "normalized": "pagination_item",
+      "source": "packages/mui-material/src/PaginationItem",
+      "declared_in": "packages/mui-material/src/PaginationItem/index.js"
+    },
+    {
+      "name": "Paper",
+      "normalized": "paper",
+      "source": "packages/mui-material/src/Paper",
+      "declared_in": "packages/mui-material/src/Paper/index.js"
+    },
+    {
+      "name": "PigmentContainer",
+      "normalized": "pigment_container",
+      "source": "packages/mui-material/src/PigmentContainer",
+      "declared_in": "packages/mui-material/src/PigmentContainer/index.ts"
+    },
+    {
+      "name": "PigmentGrid",
+      "normalized": "pigment_grid",
+      "source": "packages/mui-material/src/PigmentGrid",
+      "declared_in": "packages/mui-material/src/PigmentGrid/index.ts"
+    },
+    {
+      "name": "PigmentStack",
+      "normalized": "pigment_stack",
+      "source": "packages/mui-material/src/PigmentStack",
+      "declared_in": "packages/mui-material/src/PigmentStack/index.ts"
+    },
+    {
+      "name": "Popover",
+      "normalized": "popover",
+      "source": "packages/mui-material/src/Popover",
+      "declared_in": "packages/mui-material/src/Popover/index.js"
+    },
+    {
+      "name": "Popper",
+      "normalized": "popper",
+      "source": "packages/mui-material/src/Popper",
+      "declared_in": "packages/mui-material/src/Popper/index.js"
+    },
+    {
+      "name": "Portal",
+      "normalized": "portal",
+      "source": "packages/mui-material/src/Portal",
+      "declared_in": "packages/mui-material/src/Portal/index.js"
+    },
+    {
+      "name": "Radio",
+      "normalized": "radio",
+      "source": "packages/mui-material/src/Radio",
+      "declared_in": "packages/mui-material/src/Radio/index.js"
+    },
+    {
+      "name": "RadioGroup",
+      "normalized": "radio_group",
+      "source": "packages/mui-material/src/RadioGroup",
+      "declared_in": "packages/mui-material/src/RadioGroup/index.js"
+    },
+    {
+      "name": "Rating",
+      "normalized": "rating",
+      "source": "packages/mui-material/src/Rating",
+      "declared_in": "packages/mui-material/src/Rating/index.js"
+    },
+    {
+      "name": "ScopedCssBaseline",
+      "normalized": "scoped_css_baseline",
+      "source": "packages/mui-material/src/ScopedCssBaseline",
+      "declared_in": "packages/mui-material/src/ScopedCssBaseline/index.js"
+    },
+    {
+      "name": "Select",
+      "normalized": "select",
+      "source": "packages/mui-material/src/Select",
+      "declared_in": "packages/mui-material/src/Select/index.js"
+    },
+    {
+      "name": "Skeleton",
+      "normalized": "skeleton",
+      "source": "packages/mui-material/src/Skeleton",
+      "declared_in": "packages/mui-material/src/Skeleton/index.js"
+    },
+    {
+      "name": "Slide",
+      "normalized": "slide",
+      "source": "packages/mui-material/src/Slide",
+      "declared_in": "packages/mui-material/src/Slide/index.js"
+    },
+    {
+      "name": "Slider",
+      "normalized": "slider",
+      "source": "packages/mui-material/src/Slider",
+      "declared_in": "packages/mui-material/src/Slider/index.js"
+    },
+    {
+      "name": "Snackbar",
+      "normalized": "snackbar",
+      "source": "packages/mui-material/src/Snackbar",
+      "declared_in": "packages/mui-material/src/Snackbar/index.js"
+    },
+    {
+      "name": "SnackbarContent",
+      "normalized": "snackbar_content",
+      "source": "packages/mui-material/src/SnackbarContent",
+      "declared_in": "packages/mui-material/src/SnackbarContent/index.js"
+    },
+    {
+      "name": "SpeedDial",
+      "normalized": "speed_dial",
+      "source": "packages/mui-material/src/SpeedDial",
+      "declared_in": "packages/mui-material/src/SpeedDial/index.js"
+    },
+    {
+      "name": "SpeedDialAction",
+      "normalized": "speed_dial_action",
+      "source": "packages/mui-material/src/SpeedDialAction",
+      "declared_in": "packages/mui-material/src/SpeedDialAction/index.js"
+    },
+    {
+      "name": "SpeedDialIcon",
+      "normalized": "speed_dial_icon",
+      "source": "packages/mui-material/src/SpeedDialIcon",
+      "declared_in": "packages/mui-material/src/SpeedDialIcon/index.js"
+    },
+    {
+      "name": "Stack",
+      "normalized": "stack",
+      "source": "packages/mui-material/src/Stack",
+      "declared_in": "packages/mui-material/src/Stack/index.js"
+    },
+    {
+      "name": "Step",
+      "normalized": "step",
+      "source": "packages/mui-material/src/Step",
+      "declared_in": "packages/mui-material/src/Step/index.js"
+    },
+    {
+      "name": "StepButton",
+      "normalized": "step_button",
+      "source": "packages/mui-material/src/StepButton",
+      "declared_in": "packages/mui-material/src/StepButton/index.js"
+    },
+    {
+      "name": "StepConnector",
+      "normalized": "step_connector",
+      "source": "packages/mui-material/src/StepConnector",
+      "declared_in": "packages/mui-material/src/StepConnector/index.js"
+    },
+    {
+      "name": "StepContent",
+      "normalized": "step_content",
+      "source": "packages/mui-material/src/StepContent",
+      "declared_in": "packages/mui-material/src/StepContent/index.js"
+    },
+    {
+      "name": "StepContext",
+      "normalized": "step_context",
+      "source": "packages/mui-material/src/StepContext",
+      "declared_in": "packages/mui-material/src/Step/index.js"
+    },
+    {
+      "name": "StepIcon",
+      "normalized": "step_icon",
+      "source": "packages/mui-material/src/StepIcon",
+      "declared_in": "packages/mui-material/src/StepIcon/index.js"
+    },
+    {
+      "name": "StepLabel",
+      "normalized": "step_label",
+      "source": "packages/mui-material/src/StepLabel",
+      "declared_in": "packages/mui-material/src/StepLabel/index.js"
+    },
+    {
+      "name": "Stepper",
+      "normalized": "stepper",
+      "source": "packages/mui-material/src/Stepper",
+      "declared_in": "packages/mui-material/src/Stepper/index.js"
+    },
+    {
+      "name": "StepperContext",
+      "normalized": "stepper_context",
+      "source": "packages/mui-material/src/StepperContext",
+      "declared_in": "packages/mui-material/src/Stepper/index.js"
+    },
+    {
+      "name": "SvgIcon",
+      "normalized": "svg_icon",
+      "source": "packages/mui-material/src/SvgIcon",
+      "declared_in": "packages/mui-material/src/SvgIcon/index.js"
+    },
+    {
+      "name": "SwipeableDrawer",
+      "normalized": "swipeable_drawer",
+      "source": "packages/mui-material/src/SwipeableDrawer",
+      "declared_in": "packages/mui-material/src/SwipeableDrawer/index.js"
+    },
+    {
+      "name": "Switch",
+      "normalized": "switch",
+      "source": "packages/mui-material/src/Switch",
+      "declared_in": "packages/mui-material/src/Switch/index.js"
+    },
+    {
+      "name": "Tab",
+      "normalized": "tab",
+      "source": "packages/mui-material/src/Tab",
+      "declared_in": "packages/mui-material/src/Tab/index.js"
+    },
+    {
+      "name": "TabScrollButton",
+      "normalized": "tab_scroll_button",
+      "source": "packages/mui-material/src/TabScrollButton",
+      "declared_in": "packages/mui-material/src/TabScrollButton/index.js"
+    },
+    {
+      "name": "Table",
+      "normalized": "table",
+      "source": "packages/mui-material/src/Table",
+      "declared_in": "packages/mui-material/src/Table/index.js"
+    },
+    {
+      "name": "TableBody",
+      "normalized": "table_body",
+      "source": "packages/mui-material/src/TableBody",
+      "declared_in": "packages/mui-material/src/TableBody/index.js"
+    },
+    {
+      "name": "TableCell",
+      "normalized": "table_cell",
+      "source": "packages/mui-material/src/TableCell",
+      "declared_in": "packages/mui-material/src/TableCell/index.js"
+    },
+    {
+      "name": "TableContainer",
+      "normalized": "table_container",
+      "source": "packages/mui-material/src/TableContainer",
+      "declared_in": "packages/mui-material/src/TableContainer/index.js"
+    },
+    {
+      "name": "TableFooter",
+      "normalized": "table_footer",
+      "source": "packages/mui-material/src/TableFooter",
+      "declared_in": "packages/mui-material/src/TableFooter/index.js"
+    },
+    {
+      "name": "TableHead",
+      "normalized": "table_head",
+      "source": "packages/mui-material/src/TableHead",
+      "declared_in": "packages/mui-material/src/TableHead/index.js"
+    },
+    {
+      "name": "TablePagination",
+      "normalized": "table_pagination",
+      "source": "packages/mui-material/src/TablePagination",
+      "declared_in": "packages/mui-material/src/TablePagination/index.js"
+    },
+    {
+      "name": "TablePaginationActions",
+      "normalized": "table_pagination_actions",
+      "source": "packages/mui-material/src/TablePaginationActions",
+      "declared_in": "packages/mui-material/src/TablePaginationActions/index.js"
+    },
+    {
+      "name": "TableRow",
+      "normalized": "table_row",
+      "source": "packages/mui-material/src/TableRow",
+      "declared_in": "packages/mui-material/src/TableRow/index.js"
+    },
+    {
+      "name": "TableSortLabel",
+      "normalized": "table_sort_label",
+      "source": "packages/mui-material/src/TableSortLabel",
+      "declared_in": "packages/mui-material/src/TableSortLabel/index.js"
+    },
+    {
+      "name": "Tabs",
+      "normalized": "tabs",
+      "source": "packages/mui-material/src/Tabs",
+      "declared_in": "packages/mui-material/src/Tabs/index.js"
+    },
+    {
+      "name": "TextField",
+      "normalized": "text_field",
+      "source": "packages/mui-material/src/TextField",
+      "declared_in": "packages/mui-material/src/TextField/index.js"
+    },
+    {
+      "name": "TextareaAutosize",
+      "normalized": "textarea_autosize",
+      "source": "packages/mui-material/src/TextareaAutosize",
+      "declared_in": "packages/mui-material/src/TextareaAutosize/index.js"
+    },
+    {
+      "name": "THEME_ID",
+      "normalized": "theme_id",
+      "source": "packages/mui-material/src/identifier",
+      "declared_in": "packages/mui-material/src/styles/index.js"
+    },
+    {
+      "name": "ThemeProvider",
+      "normalized": "theme_provider",
+      "source": "packages/mui-material/src/ThemeProvider",
+      "declared_in": "packages/mui-material/src/styles/index.js"
+    },
+    {
+      "name": "ToggleButton",
+      "normalized": "toggle_button",
+      "source": "packages/mui-material/src/ToggleButton",
+      "declared_in": "packages/mui-material/src/ToggleButton/index.js"
+    },
+    {
+      "name": "ToggleButtonGroup",
+      "normalized": "toggle_button_group",
+      "source": "packages/mui-material/src/ToggleButtonGroup",
+      "declared_in": "packages/mui-material/src/ToggleButtonGroup/index.js"
+    },
+    {
+      "name": "Toolbar",
+      "normalized": "toolbar",
+      "source": "packages/mui-material/src/Toolbar",
+      "declared_in": "packages/mui-material/src/Toolbar/index.js"
+    },
+    {
+      "name": "Tooltip",
+      "normalized": "tooltip",
+      "source": "packages/mui-material/src/Tooltip",
+      "declared_in": "packages/mui-material/src/Tooltip/index.js"
+    },
+    {
+      "name": "Typography",
+      "normalized": "typography",
+      "source": "packages/mui-material/src/Typography",
+      "declared_in": "packages/mui-material/src/Typography/index.js"
+    },
+    {
+      "name": "Unstable_TrapFocus",
+      "normalized": "unstable_trap_focus",
+      "source": "packages/mui-material/src/Unstable_TrapFocus",
+      "declared_in": "packages/mui-material/src/index.js"
+    },
+    {
+      "name": "UseAutocomplete",
+      "normalized": "use_autocomplete",
+      "source": "packages/mui-material/src/useAutocomplete",
+      "declared_in": "packages/mui-material/src/useAutocomplete/index.js"
+    },
+    {
+      "name": "UseLazyRipple",
+      "normalized": "use_lazy_ripple",
+      "source": "packages/mui-material/src/useLazyRipple",
+      "declared_in": "packages/mui-material/src/useLazyRipple/index.ts"
+    },
+    {
+      "name": "UsePagination",
+      "normalized": "use_pagination",
+      "source": "packages/mui-material/src/usePagination",
+      "declared_in": "packages/mui-material/src/usePagination/index.js"
+    },
+    {
+      "name": "UseScrollTrigger",
+      "normalized": "use_scroll_trigger",
+      "source": "packages/mui-material/src/useScrollTrigger",
+      "declared_in": "packages/mui-material/src/useScrollTrigger/index.js"
+    },
+    {
+      "name": "Zoom",
+      "normalized": "zoom",
+      "source": "packages/mui-material/src/Zoom",
+      "declared_in": "packages/mui-material/src/Zoom/index.js"
+    }
+  ],
+  "missing_from_material": [
+    {
+      "name": "Accordion",
+      "normalized": "accordion",
+      "source": "packages/mui-material/src/Accordion",
+      "declared_in": "packages/mui-material/src/Accordion/index.js"
+    },
+    {
+      "name": "AccordionActions",
+      "normalized": "accordion_actions",
+      "source": "packages/mui-material/src/AccordionActions",
+      "declared_in": "packages/mui-material/src/AccordionActions/index.js"
+    },
+    {
+      "name": "AccordionDetails",
+      "normalized": "accordion_details",
+      "source": "packages/mui-material/src/AccordionDetails",
+      "declared_in": "packages/mui-material/src/AccordionDetails/index.js"
+    },
+    {
+      "name": "AccordionSummary",
+      "normalized": "accordion_summary",
+      "source": "packages/mui-material/src/AccordionSummary",
+      "declared_in": "packages/mui-material/src/AccordionSummary/index.js"
+    },
+    {
+      "name": "Alert",
+      "normalized": "alert",
+      "source": "packages/mui-material/src/Alert",
+      "declared_in": "packages/mui-material/src/Alert/index.js"
+    },
+    {
+      "name": "AlertTitle",
+      "normalized": "alert_title",
+      "source": "packages/mui-material/src/AlertTitle",
+      "declared_in": "packages/mui-material/src/AlertTitle/index.js"
+    },
+    {
+      "name": "Autocomplete",
+      "normalized": "autocomplete",
+      "source": "packages/mui-material/src/Autocomplete",
+      "declared_in": "packages/mui-material/src/Autocomplete/index.js"
+    },
+    {
+      "name": "Avatar",
+      "normalized": "avatar",
+      "source": "packages/mui-material/src/Avatar",
+      "declared_in": "packages/mui-material/src/Avatar/index.js"
+    },
+    {
+      "name": "AvatarGroup",
+      "normalized": "avatar_group",
+      "source": "packages/mui-material/src/AvatarGroup",
+      "declared_in": "packages/mui-material/src/AvatarGroup/index.js"
+    },
+    {
+      "name": "Backdrop",
+      "normalized": "backdrop",
+      "source": "packages/mui-material/src/Backdrop",
+      "declared_in": "packages/mui-material/src/Backdrop/index.js"
+    },
+    {
+      "name": "Badge",
+      "normalized": "badge",
+      "source": "packages/mui-material/src/Badge",
+      "declared_in": "packages/mui-material/src/Badge/index.js"
+    },
+    {
+      "name": "BottomNavigation",
+      "normalized": "bottom_navigation",
+      "source": "packages/mui-material/src/BottomNavigation",
+      "declared_in": "packages/mui-material/src/BottomNavigation/index.js"
+    },
+    {
+      "name": "BottomNavigationAction",
+      "normalized": "bottom_navigation_action",
+      "source": "packages/mui-material/src/BottomNavigationAction",
+      "declared_in": "packages/mui-material/src/BottomNavigationAction/index.js"
+    },
+    {
+      "name": "Box",
+      "normalized": "box",
+      "source": "packages/mui-material/src/Box",
+      "declared_in": "packages/mui-material/src/Box/index.js"
+    },
+    {
+      "name": "Breadcrumbs",
+      "normalized": "breadcrumbs",
+      "source": "packages/mui-material/src/Breadcrumbs",
+      "declared_in": "packages/mui-material/src/Breadcrumbs/index.js"
+    },
+    {
+      "name": "ButtonBase",
+      "normalized": "button_base",
+      "source": "packages/mui-material/src/ButtonBase",
+      "declared_in": "packages/mui-material/src/ButtonBase/index.js"
+    },
+    {
+      "name": "ButtonGroup",
+      "normalized": "button_group",
+      "source": "packages/mui-material/src/ButtonGroup",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "ButtonGroupButtonContext",
+      "normalized": "button_group_button_context",
+      "source": "packages/mui-material/src/ButtonGroupButtonContext",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "ButtonGroupContext",
+      "normalized": "button_group_context",
+      "source": "packages/mui-material/src/ButtonGroupContext",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "CardActionArea",
+      "normalized": "card_action_area",
+      "source": "packages/mui-material/src/CardActionArea",
+      "declared_in": "packages/mui-material/src/CardActionArea/index.js"
+    },
+    {
+      "name": "CardActions",
+      "normalized": "card_actions",
+      "source": "packages/mui-material/src/CardActions",
+      "declared_in": "packages/mui-material/src/CardActions/index.js"
+    },
+    {
+      "name": "CardContent",
+      "normalized": "card_content",
+      "source": "packages/mui-material/src/CardContent",
+      "declared_in": "packages/mui-material/src/CardContent/index.js"
+    },
+    {
+      "name": "CardHeader",
+      "normalized": "card_header",
+      "source": "packages/mui-material/src/CardHeader",
+      "declared_in": "packages/mui-material/src/CardHeader/index.js"
+    },
+    {
+      "name": "CardMedia",
+      "normalized": "card_media",
+      "source": "packages/mui-material/src/CardMedia",
+      "declared_in": "packages/mui-material/src/CardMedia/index.js"
+    },
+    {
+      "name": "Checkbox",
+      "normalized": "checkbox",
+      "source": "packages/mui-material/src/Checkbox",
+      "declared_in": "packages/mui-material/src/Checkbox/index.js"
+    },
+    {
+      "name": "Chip",
+      "normalized": "chip",
+      "source": "packages/mui-material/src/Chip",
+      "declared_in": "packages/mui-material/src/Chip/index.js"
+    },
+    {
+      "name": "CircularProgress",
+      "normalized": "circular_progress",
+      "source": "packages/mui-material/src/CircularProgress",
+      "declared_in": "packages/mui-material/src/CircularProgress/index.js"
+    },
+    {
+      "name": "ClickAwayListener",
+      "normalized": "click_away_listener",
+      "source": "packages/mui-material/src/ClickAwayListener",
+      "declared_in": "packages/mui-material/src/index.js"
+    },
+    {
+      "name": "Collapse",
+      "normalized": "collapse",
+      "source": "packages/mui-material/src/Collapse",
+      "declared_in": "packages/mui-material/src/Collapse/index.js"
+    },
+    {
+      "name": "Container",
+      "normalized": "container",
+      "source": "packages/mui-material/src/Container",
+      "declared_in": "packages/mui-material/src/Container/index.js"
+    },
+    {
+      "name": "CssBaseline",
+      "normalized": "css_baseline",
+      "source": "packages/mui-material/src/CssBaseline",
+      "declared_in": "packages/mui-material/src/CssBaseline/index.js"
+    },
+    {
+      "name": "DefaultPropsProvider",
+      "normalized": "default_props_provider",
+      "source": "packages/mui-material/src/DefaultPropsProvider",
+      "declared_in": "packages/mui-material/src/DefaultPropsProvider/index.ts"
+    },
+    {
+      "name": "DialogActions",
+      "normalized": "dialog_actions",
+      "source": "packages/mui-material/src/DialogActions",
+      "declared_in": "packages/mui-material/src/DialogActions/index.js"
+    },
+    {
+      "name": "DialogContent",
+      "normalized": "dialog_content",
+      "source": "packages/mui-material/src/DialogContent",
+      "declared_in": "packages/mui-material/src/DialogContent/index.js"
+    },
+    {
+      "name": "DialogContentText",
+      "normalized": "dialog_content_text",
+      "source": "packages/mui-material/src/DialogContentText",
+      "declared_in": "packages/mui-material/src/DialogContentText/index.js"
+    },
+    {
+      "name": "DialogTitle",
+      "normalized": "dialog_title",
+      "source": "packages/mui-material/src/DialogTitle",
+      "declared_in": "packages/mui-material/src/DialogTitle/index.js"
+    },
+    {
+      "name": "Divider",
+      "normalized": "divider",
+      "source": "packages/mui-material/src/Divider",
+      "declared_in": "packages/mui-material/src/Divider/index.js"
+    },
+    {
+      "name": "Drawer",
+      "normalized": "drawer",
+      "source": "packages/mui-material/src/Drawer",
+      "declared_in": "packages/mui-material/src/Drawer/index.js"
+    },
+    {
+      "name": "Fab",
+      "normalized": "fab",
+      "source": "packages/mui-material/src/Fab",
+      "declared_in": "packages/mui-material/src/Fab/index.js"
+    },
+    {
+      "name": "Fade",
+      "normalized": "fade",
+      "source": "packages/mui-material/src/Fade",
+      "declared_in": "packages/mui-material/src/Fade/index.js"
+    },
+    {
+      "name": "FilledInput",
+      "normalized": "filled_input",
+      "source": "packages/mui-material/src/FilledInput",
+      "declared_in": "packages/mui-material/src/FilledInput/index.js"
+    },
+    {
+      "name": "FocusTrap",
+      "normalized": "focus_trap",
+      "source": "packages/mui-material/src/FocusTrap",
+      "declared_in": "packages/mui-material/src/Unstable_TrapFocus/index.js"
+    },
+    {
+      "name": "FormControl",
+      "normalized": "form_control",
+      "source": "packages/mui-material/src/FormControl",
+      "declared_in": "packages/mui-material/src/FormControl/index.js"
+    },
+    {
+      "name": "FormControlLabel",
+      "normalized": "form_control_label",
+      "source": "packages/mui-material/src/FormControlLabel",
+      "declared_in": "packages/mui-material/src/FormControlLabel/index.js"
+    },
+    {
+      "name": "FormGroup",
+      "normalized": "form_group",
+      "source": "packages/mui-material/src/FormGroup",
+      "declared_in": "packages/mui-material/src/FormGroup/index.js"
+    },
+    {
+      "name": "FormHelperText",
+      "normalized": "form_helper_text",
+      "source": "packages/mui-material/src/FormHelperText",
+      "declared_in": "packages/mui-material/src/FormHelperText/index.js"
+    },
+    {
+      "name": "FormLabel",
+      "normalized": "form_label",
+      "source": "packages/mui-material/src/FormLabel",
+      "declared_in": "packages/mui-material/src/FormLabel/index.js"
+    },
+    {
+      "name": "GlobalStyles",
+      "normalized": "global_styles",
+      "source": "packages/mui-material/src/GlobalStyles",
+      "declared_in": "packages/mui-material/src/GlobalStyles/index.js"
+    },
+    {
+      "name": "Grid",
+      "normalized": "grid",
+      "source": "packages/mui-material/src/Grid",
+      "declared_in": "packages/mui-material/src/Grid/index.ts"
+    },
+    {
+      "name": "GridLegacy",
+      "normalized": "grid_legacy",
+      "source": "packages/mui-material/src/GridLegacy",
+      "declared_in": "packages/mui-material/src/GridLegacy/index.js"
+    },
+    {
+      "name": "Grow",
+      "normalized": "grow",
+      "source": "packages/mui-material/src/Grow",
+      "declared_in": "packages/mui-material/src/Grow/index.js"
+    },
+    {
+      "name": "Icon",
+      "normalized": "icon",
+      "source": "packages/mui-material/src/Icon",
+      "declared_in": "packages/mui-material/src/Icon/index.js"
+    },
+    {
+      "name": "IconButton",
+      "normalized": "icon_button",
+      "source": "packages/mui-material/src/IconButton",
+      "declared_in": "packages/mui-material/src/IconButton/index.js"
+    },
+    {
+      "name": "ImageList",
+      "normalized": "image_list",
+      "source": "packages/mui-material/src/ImageList",
+      "declared_in": "packages/mui-material/src/ImageList/index.js"
+    },
+    {
+      "name": "ImageListItem",
+      "normalized": "image_list_item",
+      "source": "packages/mui-material/src/ImageListItem",
+      "declared_in": "packages/mui-material/src/ImageListItem/index.js"
+    },
+    {
+      "name": "ImageListItemBar",
+      "normalized": "image_list_item_bar",
+      "source": "packages/mui-material/src/ImageListItemBar",
+      "declared_in": "packages/mui-material/src/ImageListItemBar/index.js"
+    },
+    {
+      "name": "InitColorSchemeScript",
+      "normalized": "init_color_scheme_script",
+      "source": "packages/mui-material/src/InitColorSchemeScript",
+      "declared_in": "packages/mui-material/src/InitColorSchemeScript/index.ts"
+    },
+    {
+      "name": "Input",
+      "normalized": "input",
+      "source": "packages/mui-material/src/Input",
+      "declared_in": "packages/mui-material/src/Input/index.js"
+    },
+    {
+      "name": "InputAdornment",
+      "normalized": "input_adornment",
+      "source": "packages/mui-material/src/InputAdornment",
+      "declared_in": "packages/mui-material/src/InputAdornment/index.js"
+    },
+    {
+      "name": "InputBase",
+      "normalized": "input_base",
+      "source": "packages/mui-material/src/InputBase",
+      "declared_in": "packages/mui-material/src/InputBase/index.js"
+    },
+    {
+      "name": "InputLabel",
+      "normalized": "input_label",
+      "source": "packages/mui-material/src/InputLabel",
+      "declared_in": "packages/mui-material/src/InputLabel/index.js"
+    },
+    {
+      "name": "LinearProgress",
+      "normalized": "linear_progress",
+      "source": "packages/mui-material/src/LinearProgress",
+      "declared_in": "packages/mui-material/src/LinearProgress/index.js"
+    },
+    {
+      "name": "Link",
+      "normalized": "link",
+      "source": "packages/mui-material/src/Link",
+      "declared_in": "packages/mui-material/src/Link/index.js"
+    },
+    {
+      "name": "List",
+      "normalized": "list",
+      "source": "packages/mui-material/src/List",
+      "declared_in": "packages/mui-material/src/List/index.js"
+    },
+    {
+      "name": "ListItem",
+      "normalized": "list_item",
+      "source": "packages/mui-material/src/ListItem",
+      "declared_in": "packages/mui-material/src/ListItem/index.js"
+    },
+    {
+      "name": "ListItemAvatar",
+      "normalized": "list_item_avatar",
+      "source": "packages/mui-material/src/ListItemAvatar",
+      "declared_in": "packages/mui-material/src/ListItemAvatar/index.js"
+    },
+    {
+      "name": "ListItemButton",
+      "normalized": "list_item_button",
+      "source": "packages/mui-material/src/ListItemButton",
+      "declared_in": "packages/mui-material/src/ListItemButton/index.js"
+    },
+    {
+      "name": "ListItemIcon",
+      "normalized": "list_item_icon",
+      "source": "packages/mui-material/src/ListItemIcon",
+      "declared_in": "packages/mui-material/src/ListItemIcon/index.js"
+    },
+    {
+      "name": "ListItemSecondaryAction",
+      "normalized": "list_item_secondary_action",
+      "source": "packages/mui-material/src/ListItemSecondaryAction",
+      "declared_in": "packages/mui-material/src/ListItemSecondaryAction/index.js"
+    },
+    {
+      "name": "ListItemText",
+      "normalized": "list_item_text",
+      "source": "packages/mui-material/src/ListItemText",
+      "declared_in": "packages/mui-material/src/ListItemText/index.js"
+    },
+    {
+      "name": "ListSubheader",
+      "normalized": "list_subheader",
+      "source": "packages/mui-material/src/ListSubheader",
+      "declared_in": "packages/mui-material/src/ListSubheader/index.js"
+    },
+    {
+      "name": "Menu",
+      "normalized": "menu",
+      "source": "packages/mui-material/src/Menu",
+      "declared_in": "packages/mui-material/src/Menu/index.js"
+    },
+    {
+      "name": "MenuItem",
+      "normalized": "menu_item",
+      "source": "packages/mui-material/src/MenuItem",
+      "declared_in": "packages/mui-material/src/MenuItem/index.js"
+    },
+    {
+      "name": "MenuList",
+      "normalized": "menu_list",
+      "source": "packages/mui-material/src/MenuList",
+      "declared_in": "packages/mui-material/src/MenuList/index.js"
+    },
+    {
+      "name": "MobileStepper",
+      "normalized": "mobile_stepper",
+      "source": "packages/mui-material/src/MobileStepper",
+      "declared_in": "packages/mui-material/src/MobileStepper/index.js"
+    },
+    {
+      "name": "Modal",
+      "normalized": "modal",
+      "source": "packages/mui-material/src/Modal",
+      "declared_in": "packages/mui-material/src/Modal/index.js"
+    },
+    {
+      "name": "NativeSelect",
+      "normalized": "native_select",
+      "source": "packages/mui-material/src/NativeSelect",
+      "declared_in": "packages/mui-material/src/NativeSelect/index.js"
+    },
+    {
+      "name": "NoSsr",
+      "normalized": "no_ssr",
+      "source": "packages/mui-material/src/NoSsr",
+      "declared_in": "packages/mui-material/src/NoSsr/index.js"
+    },
+    {
+      "name": "OutlinedInput",
+      "normalized": "outlined_input",
+      "source": "packages/mui-material/src/OutlinedInput",
+      "declared_in": "packages/mui-material/src/OutlinedInput/index.js"
+    },
+    {
+      "name": "Pagination",
+      "normalized": "pagination",
+      "source": "packages/mui-material/src/Pagination",
+      "declared_in": "packages/mui-material/src/Pagination/index.js"
+    },
+    {
+      "name": "PaginationItem",
+      "normalized": "pagination_item",
+      "source": "packages/mui-material/src/PaginationItem",
+      "declared_in": "packages/mui-material/src/PaginationItem/index.js"
+    },
+    {
+      "name": "Paper",
+      "normalized": "paper",
+      "source": "packages/mui-material/src/Paper",
+      "declared_in": "packages/mui-material/src/Paper/index.js"
+    },
+    {
+      "name": "PigmentContainer",
+      "normalized": "pigment_container",
+      "source": "packages/mui-material/src/PigmentContainer",
+      "declared_in": "packages/mui-material/src/PigmentContainer/index.ts"
+    },
+    {
+      "name": "PigmentGrid",
+      "normalized": "pigment_grid",
+      "source": "packages/mui-material/src/PigmentGrid",
+      "declared_in": "packages/mui-material/src/PigmentGrid/index.ts"
+    },
+    {
+      "name": "PigmentStack",
+      "normalized": "pigment_stack",
+      "source": "packages/mui-material/src/PigmentStack",
+      "declared_in": "packages/mui-material/src/PigmentStack/index.ts"
+    },
+    {
+      "name": "Popover",
+      "normalized": "popover",
+      "source": "packages/mui-material/src/Popover",
+      "declared_in": "packages/mui-material/src/Popover/index.js"
+    },
+    {
+      "name": "Popper",
+      "normalized": "popper",
+      "source": "packages/mui-material/src/Popper",
+      "declared_in": "packages/mui-material/src/Popper/index.js"
+    },
+    {
+      "name": "Portal",
+      "normalized": "portal",
+      "source": "packages/mui-material/src/Portal",
+      "declared_in": "packages/mui-material/src/Portal/index.js"
+    },
+    {
+      "name": "Radio",
+      "normalized": "radio",
+      "source": "packages/mui-material/src/Radio",
+      "declared_in": "packages/mui-material/src/Radio/index.js"
+    },
+    {
+      "name": "RadioGroup",
+      "normalized": "radio_group",
+      "source": "packages/mui-material/src/RadioGroup",
+      "declared_in": "packages/mui-material/src/RadioGroup/index.js"
+    },
+    {
+      "name": "Rating",
+      "normalized": "rating",
+      "source": "packages/mui-material/src/Rating",
+      "declared_in": "packages/mui-material/src/Rating/index.js"
+    },
+    {
+      "name": "ScopedCssBaseline",
+      "normalized": "scoped_css_baseline",
+      "source": "packages/mui-material/src/ScopedCssBaseline",
+      "declared_in": "packages/mui-material/src/ScopedCssBaseline/index.js"
+    },
+    {
+      "name": "Select",
+      "normalized": "select",
+      "source": "packages/mui-material/src/Select",
+      "declared_in": "packages/mui-material/src/Select/index.js"
+    },
+    {
+      "name": "Skeleton",
+      "normalized": "skeleton",
+      "source": "packages/mui-material/src/Skeleton",
+      "declared_in": "packages/mui-material/src/Skeleton/index.js"
+    },
+    {
+      "name": "Slide",
+      "normalized": "slide",
+      "source": "packages/mui-material/src/Slide",
+      "declared_in": "packages/mui-material/src/Slide/index.js"
+    },
+    {
+      "name": "Slider",
+      "normalized": "slider",
+      "source": "packages/mui-material/src/Slider",
+      "declared_in": "packages/mui-material/src/Slider/index.js"
+    },
+    {
+      "name": "SnackbarContent",
+      "normalized": "snackbar_content",
+      "source": "packages/mui-material/src/SnackbarContent",
+      "declared_in": "packages/mui-material/src/SnackbarContent/index.js"
+    },
+    {
+      "name": "SpeedDial",
+      "normalized": "speed_dial",
+      "source": "packages/mui-material/src/SpeedDial",
+      "declared_in": "packages/mui-material/src/SpeedDial/index.js"
+    },
+    {
+      "name": "SpeedDialAction",
+      "normalized": "speed_dial_action",
+      "source": "packages/mui-material/src/SpeedDialAction",
+      "declared_in": "packages/mui-material/src/SpeedDialAction/index.js"
+    },
+    {
+      "name": "SpeedDialIcon",
+      "normalized": "speed_dial_icon",
+      "source": "packages/mui-material/src/SpeedDialIcon",
+      "declared_in": "packages/mui-material/src/SpeedDialIcon/index.js"
+    },
+    {
+      "name": "Stack",
+      "normalized": "stack",
+      "source": "packages/mui-material/src/Stack",
+      "declared_in": "packages/mui-material/src/Stack/index.js"
+    },
+    {
+      "name": "Step",
+      "normalized": "step",
+      "source": "packages/mui-material/src/Step",
+      "declared_in": "packages/mui-material/src/Step/index.js"
+    },
+    {
+      "name": "StepButton",
+      "normalized": "step_button",
+      "source": "packages/mui-material/src/StepButton",
+      "declared_in": "packages/mui-material/src/StepButton/index.js"
+    },
+    {
+      "name": "StepConnector",
+      "normalized": "step_connector",
+      "source": "packages/mui-material/src/StepConnector",
+      "declared_in": "packages/mui-material/src/StepConnector/index.js"
+    },
+    {
+      "name": "StepContent",
+      "normalized": "step_content",
+      "source": "packages/mui-material/src/StepContent",
+      "declared_in": "packages/mui-material/src/StepContent/index.js"
+    },
+    {
+      "name": "StepContext",
+      "normalized": "step_context",
+      "source": "packages/mui-material/src/StepContext",
+      "declared_in": "packages/mui-material/src/Step/index.js"
+    },
+    {
+      "name": "StepIcon",
+      "normalized": "step_icon",
+      "source": "packages/mui-material/src/StepIcon",
+      "declared_in": "packages/mui-material/src/StepIcon/index.js"
+    },
+    {
+      "name": "StepLabel",
+      "normalized": "step_label",
+      "source": "packages/mui-material/src/StepLabel",
+      "declared_in": "packages/mui-material/src/StepLabel/index.js"
+    },
+    {
+      "name": "Stepper",
+      "normalized": "stepper",
+      "source": "packages/mui-material/src/Stepper",
+      "declared_in": "packages/mui-material/src/Stepper/index.js"
+    },
+    {
+      "name": "StepperContext",
+      "normalized": "stepper_context",
+      "source": "packages/mui-material/src/StepperContext",
+      "declared_in": "packages/mui-material/src/Stepper/index.js"
+    },
+    {
+      "name": "SvgIcon",
+      "normalized": "svg_icon",
+      "source": "packages/mui-material/src/SvgIcon",
+      "declared_in": "packages/mui-material/src/SvgIcon/index.js"
+    },
+    {
+      "name": "SwipeableDrawer",
+      "normalized": "swipeable_drawer",
+      "source": "packages/mui-material/src/SwipeableDrawer",
+      "declared_in": "packages/mui-material/src/SwipeableDrawer/index.js"
+    },
+    {
+      "name": "Switch",
+      "normalized": "switch",
+      "source": "packages/mui-material/src/Switch",
+      "declared_in": "packages/mui-material/src/Switch/index.js"
+    },
+    {
+      "name": "Tab",
+      "normalized": "tab",
+      "source": "packages/mui-material/src/Tab",
+      "declared_in": "packages/mui-material/src/Tab/index.js"
+    },
+    {
+      "name": "TabScrollButton",
+      "normalized": "tab_scroll_button",
+      "source": "packages/mui-material/src/TabScrollButton",
+      "declared_in": "packages/mui-material/src/TabScrollButton/index.js"
+    },
+    {
+      "name": "Table",
+      "normalized": "table",
+      "source": "packages/mui-material/src/Table",
+      "declared_in": "packages/mui-material/src/Table/index.js"
+    },
+    {
+      "name": "TableBody",
+      "normalized": "table_body",
+      "source": "packages/mui-material/src/TableBody",
+      "declared_in": "packages/mui-material/src/TableBody/index.js"
+    },
+    {
+      "name": "TableCell",
+      "normalized": "table_cell",
+      "source": "packages/mui-material/src/TableCell",
+      "declared_in": "packages/mui-material/src/TableCell/index.js"
+    },
+    {
+      "name": "TableContainer",
+      "normalized": "table_container",
+      "source": "packages/mui-material/src/TableContainer",
+      "declared_in": "packages/mui-material/src/TableContainer/index.js"
+    },
+    {
+      "name": "TableFooter",
+      "normalized": "table_footer",
+      "source": "packages/mui-material/src/TableFooter",
+      "declared_in": "packages/mui-material/src/TableFooter/index.js"
+    },
+    {
+      "name": "TableHead",
+      "normalized": "table_head",
+      "source": "packages/mui-material/src/TableHead",
+      "declared_in": "packages/mui-material/src/TableHead/index.js"
+    },
+    {
+      "name": "TablePagination",
+      "normalized": "table_pagination",
+      "source": "packages/mui-material/src/TablePagination",
+      "declared_in": "packages/mui-material/src/TablePagination/index.js"
+    },
+    {
+      "name": "TablePaginationActions",
+      "normalized": "table_pagination_actions",
+      "source": "packages/mui-material/src/TablePaginationActions",
+      "declared_in": "packages/mui-material/src/TablePaginationActions/index.js"
+    },
+    {
+      "name": "TableRow",
+      "normalized": "table_row",
+      "source": "packages/mui-material/src/TableRow",
+      "declared_in": "packages/mui-material/src/TableRow/index.js"
+    },
+    {
+      "name": "TableSortLabel",
+      "normalized": "table_sort_label",
+      "source": "packages/mui-material/src/TableSortLabel",
+      "declared_in": "packages/mui-material/src/TableSortLabel/index.js"
+    },
+    {
+      "name": "Tabs",
+      "normalized": "tabs",
+      "source": "packages/mui-material/src/Tabs",
+      "declared_in": "packages/mui-material/src/Tabs/index.js"
+    },
+    {
+      "name": "TextareaAutosize",
+      "normalized": "textarea_autosize",
+      "source": "packages/mui-material/src/TextareaAutosize",
+      "declared_in": "packages/mui-material/src/TextareaAutosize/index.js"
+    },
+    {
+      "name": "THEME_ID",
+      "normalized": "theme_id",
+      "source": "packages/mui-material/src/identifier",
+      "declared_in": "packages/mui-material/src/styles/index.js"
+    },
+    {
+      "name": "ThemeProvider",
+      "normalized": "theme_provider",
+      "source": "packages/mui-material/src/ThemeProvider",
+      "declared_in": "packages/mui-material/src/styles/index.js"
+    },
+    {
+      "name": "ToggleButton",
+      "normalized": "toggle_button",
+      "source": "packages/mui-material/src/ToggleButton",
+      "declared_in": "packages/mui-material/src/ToggleButton/index.js"
+    },
+    {
+      "name": "ToggleButtonGroup",
+      "normalized": "toggle_button_group",
+      "source": "packages/mui-material/src/ToggleButtonGroup",
+      "declared_in": "packages/mui-material/src/ToggleButtonGroup/index.js"
+    },
+    {
+      "name": "Toolbar",
+      "normalized": "toolbar",
+      "source": "packages/mui-material/src/Toolbar",
+      "declared_in": "packages/mui-material/src/Toolbar/index.js"
+    },
+    {
+      "name": "Tooltip",
+      "normalized": "tooltip",
+      "source": "packages/mui-material/src/Tooltip",
+      "declared_in": "packages/mui-material/src/Tooltip/index.js"
+    },
+    {
+      "name": "Typography",
+      "normalized": "typography",
+      "source": "packages/mui-material/src/Typography",
+      "declared_in": "packages/mui-material/src/Typography/index.js"
+    },
+    {
+      "name": "Unstable_TrapFocus",
+      "normalized": "unstable_trap_focus",
+      "source": "packages/mui-material/src/Unstable_TrapFocus",
+      "declared_in": "packages/mui-material/src/index.js"
+    },
+    {
+      "name": "UseAutocomplete",
+      "normalized": "use_autocomplete",
+      "source": "packages/mui-material/src/useAutocomplete",
+      "declared_in": "packages/mui-material/src/useAutocomplete/index.js"
+    },
+    {
+      "name": "UseLazyRipple",
+      "normalized": "use_lazy_ripple",
+      "source": "packages/mui-material/src/useLazyRipple",
+      "declared_in": "packages/mui-material/src/useLazyRipple/index.ts"
+    },
+    {
+      "name": "UsePagination",
+      "normalized": "use_pagination",
+      "source": "packages/mui-material/src/usePagination",
+      "declared_in": "packages/mui-material/src/usePagination/index.js"
+    },
+    {
+      "name": "UseScrollTrigger",
+      "normalized": "use_scroll_trigger",
+      "source": "packages/mui-material/src/useScrollTrigger",
+      "declared_in": "packages/mui-material/src/useScrollTrigger/index.js"
+    },
+    {
+      "name": "Zoom",
+      "normalized": "zoom",
+      "source": "packages/mui-material/src/Zoom",
+      "declared_in": "packages/mui-material/src/Zoom/index.js"
+    }
+  ],
+  "missing_from_headless": [
+    {
+      "name": "Accordion",
+      "normalized": "accordion",
+      "source": "packages/mui-material/src/Accordion",
+      "declared_in": "packages/mui-material/src/Accordion/index.js"
+    },
+    {
+      "name": "AccordionActions",
+      "normalized": "accordion_actions",
+      "source": "packages/mui-material/src/AccordionActions",
+      "declared_in": "packages/mui-material/src/AccordionActions/index.js"
+    },
+    {
+      "name": "AccordionDetails",
+      "normalized": "accordion_details",
+      "source": "packages/mui-material/src/AccordionDetails",
+      "declared_in": "packages/mui-material/src/AccordionDetails/index.js"
+    },
+    {
+      "name": "AccordionSummary",
+      "normalized": "accordion_summary",
+      "source": "packages/mui-material/src/AccordionSummary",
+      "declared_in": "packages/mui-material/src/AccordionSummary/index.js"
+    },
+    {
+      "name": "Alert",
+      "normalized": "alert",
+      "source": "packages/mui-material/src/Alert",
+      "declared_in": "packages/mui-material/src/Alert/index.js"
+    },
+    {
+      "name": "AlertTitle",
+      "normalized": "alert_title",
+      "source": "packages/mui-material/src/AlertTitle",
+      "declared_in": "packages/mui-material/src/AlertTitle/index.js"
+    },
+    {
+      "name": "AppBar",
+      "normalized": "app_bar",
+      "source": "packages/mui-material/src/AppBar",
+      "declared_in": "packages/mui-material/src/AppBar/index.js"
+    },
+    {
+      "name": "Autocomplete",
+      "normalized": "autocomplete",
+      "source": "packages/mui-material/src/Autocomplete",
+      "declared_in": "packages/mui-material/src/Autocomplete/index.js"
+    },
+    {
+      "name": "Avatar",
+      "normalized": "avatar",
+      "source": "packages/mui-material/src/Avatar",
+      "declared_in": "packages/mui-material/src/Avatar/index.js"
+    },
+    {
+      "name": "AvatarGroup",
+      "normalized": "avatar_group",
+      "source": "packages/mui-material/src/AvatarGroup",
+      "declared_in": "packages/mui-material/src/AvatarGroup/index.js"
+    },
+    {
+      "name": "Backdrop",
+      "normalized": "backdrop",
+      "source": "packages/mui-material/src/Backdrop",
+      "declared_in": "packages/mui-material/src/Backdrop/index.js"
+    },
+    {
+      "name": "Badge",
+      "normalized": "badge",
+      "source": "packages/mui-material/src/Badge",
+      "declared_in": "packages/mui-material/src/Badge/index.js"
+    },
+    {
+      "name": "BottomNavigation",
+      "normalized": "bottom_navigation",
+      "source": "packages/mui-material/src/BottomNavigation",
+      "declared_in": "packages/mui-material/src/BottomNavigation/index.js"
+    },
+    {
+      "name": "BottomNavigationAction",
+      "normalized": "bottom_navigation_action",
+      "source": "packages/mui-material/src/BottomNavigationAction",
+      "declared_in": "packages/mui-material/src/BottomNavigationAction/index.js"
+    },
+    {
+      "name": "Box",
+      "normalized": "box",
+      "source": "packages/mui-material/src/Box",
+      "declared_in": "packages/mui-material/src/Box/index.js"
+    },
+    {
+      "name": "Breadcrumbs",
+      "normalized": "breadcrumbs",
+      "source": "packages/mui-material/src/Breadcrumbs",
+      "declared_in": "packages/mui-material/src/Breadcrumbs/index.js"
+    },
+    {
+      "name": "ButtonBase",
+      "normalized": "button_base",
+      "source": "packages/mui-material/src/ButtonBase",
+      "declared_in": "packages/mui-material/src/ButtonBase/index.js"
+    },
+    {
+      "name": "ButtonGroup",
+      "normalized": "button_group",
+      "source": "packages/mui-material/src/ButtonGroup",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "ButtonGroupButtonContext",
+      "normalized": "button_group_button_context",
+      "source": "packages/mui-material/src/ButtonGroupButtonContext",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "ButtonGroupContext",
+      "normalized": "button_group_context",
+      "source": "packages/mui-material/src/ButtonGroupContext",
+      "declared_in": "packages/mui-material/src/ButtonGroup/index.js"
+    },
+    {
+      "name": "Card",
+      "normalized": "card",
+      "source": "packages/mui-material/src/Card",
+      "declared_in": "packages/mui-material/src/Card/index.js"
+    },
+    {
+      "name": "CardActionArea",
+      "normalized": "card_action_area",
+      "source": "packages/mui-material/src/CardActionArea",
+      "declared_in": "packages/mui-material/src/CardActionArea/index.js"
+    },
+    {
+      "name": "CardActions",
+      "normalized": "card_actions",
+      "source": "packages/mui-material/src/CardActions",
+      "declared_in": "packages/mui-material/src/CardActions/index.js"
+    },
+    {
+      "name": "CardContent",
+      "normalized": "card_content",
+      "source": "packages/mui-material/src/CardContent",
+      "declared_in": "packages/mui-material/src/CardContent/index.js"
+    },
+    {
+      "name": "CardHeader",
+      "normalized": "card_header",
+      "source": "packages/mui-material/src/CardHeader",
+      "declared_in": "packages/mui-material/src/CardHeader/index.js"
+    },
+    {
+      "name": "CardMedia",
+      "normalized": "card_media",
+      "source": "packages/mui-material/src/CardMedia",
+      "declared_in": "packages/mui-material/src/CardMedia/index.js"
+    },
+    {
+      "name": "Checkbox",
+      "normalized": "checkbox",
+      "source": "packages/mui-material/src/Checkbox",
+      "declared_in": "packages/mui-material/src/Checkbox/index.js"
+    },
+    {
+      "name": "Chip",
+      "normalized": "chip",
+      "source": "packages/mui-material/src/Chip",
+      "declared_in": "packages/mui-material/src/Chip/index.js"
+    },
+    {
+      "name": "CircularProgress",
+      "normalized": "circular_progress",
+      "source": "packages/mui-material/src/CircularProgress",
+      "declared_in": "packages/mui-material/src/CircularProgress/index.js"
+    },
+    {
+      "name": "ClickAwayListener",
+      "normalized": "click_away_listener",
+      "source": "packages/mui-material/src/ClickAwayListener",
+      "declared_in": "packages/mui-material/src/index.js"
+    },
+    {
+      "name": "Collapse",
+      "normalized": "collapse",
+      "source": "packages/mui-material/src/Collapse",
+      "declared_in": "packages/mui-material/src/Collapse/index.js"
+    },
+    {
+      "name": "Container",
+      "normalized": "container",
+      "source": "packages/mui-material/src/Container",
+      "declared_in": "packages/mui-material/src/Container/index.js"
+    },
+    {
+      "name": "CssBaseline",
+      "normalized": "css_baseline",
+      "source": "packages/mui-material/src/CssBaseline",
+      "declared_in": "packages/mui-material/src/CssBaseline/index.js"
+    },
+    {
+      "name": "DefaultPropsProvider",
+      "normalized": "default_props_provider",
+      "source": "packages/mui-material/src/DefaultPropsProvider",
+      "declared_in": "packages/mui-material/src/DefaultPropsProvider/index.ts"
+    },
+    {
+      "name": "Dialog",
+      "normalized": "dialog",
+      "source": "packages/mui-material/src/Dialog",
+      "declared_in": "packages/mui-material/src/Dialog/index.js"
+    },
+    {
+      "name": "DialogActions",
+      "normalized": "dialog_actions",
+      "source": "packages/mui-material/src/DialogActions",
+      "declared_in": "packages/mui-material/src/DialogActions/index.js"
+    },
+    {
+      "name": "DialogContent",
+      "normalized": "dialog_content",
+      "source": "packages/mui-material/src/DialogContent",
+      "declared_in": "packages/mui-material/src/DialogContent/index.js"
+    },
+    {
+      "name": "DialogContentText",
+      "normalized": "dialog_content_text",
+      "source": "packages/mui-material/src/DialogContentText",
+      "declared_in": "packages/mui-material/src/DialogContentText/index.js"
+    },
+    {
+      "name": "DialogTitle",
+      "normalized": "dialog_title",
+      "source": "packages/mui-material/src/DialogTitle",
+      "declared_in": "packages/mui-material/src/DialogTitle/index.js"
+    },
+    {
+      "name": "Divider",
+      "normalized": "divider",
+      "source": "packages/mui-material/src/Divider",
+      "declared_in": "packages/mui-material/src/Divider/index.js"
+    },
+    {
+      "name": "Drawer",
+      "normalized": "drawer",
+      "source": "packages/mui-material/src/Drawer",
+      "declared_in": "packages/mui-material/src/Drawer/index.js"
+    },
+    {
+      "name": "Fab",
+      "normalized": "fab",
+      "source": "packages/mui-material/src/Fab",
+      "declared_in": "packages/mui-material/src/Fab/index.js"
+    },
+    {
+      "name": "Fade",
+      "normalized": "fade",
+      "source": "packages/mui-material/src/Fade",
+      "declared_in": "packages/mui-material/src/Fade/index.js"
+    },
+    {
+      "name": "FilledInput",
+      "normalized": "filled_input",
+      "source": "packages/mui-material/src/FilledInput",
+      "declared_in": "packages/mui-material/src/FilledInput/index.js"
+    },
+    {
+      "name": "FocusTrap",
+      "normalized": "focus_trap",
+      "source": "packages/mui-material/src/FocusTrap",
+      "declared_in": "packages/mui-material/src/Unstable_TrapFocus/index.js"
+    },
+    {
+      "name": "FormControl",
+      "normalized": "form_control",
+      "source": "packages/mui-material/src/FormControl",
+      "declared_in": "packages/mui-material/src/FormControl/index.js"
+    },
+    {
+      "name": "FormControlLabel",
+      "normalized": "form_control_label",
+      "source": "packages/mui-material/src/FormControlLabel",
+      "declared_in": "packages/mui-material/src/FormControlLabel/index.js"
+    },
+    {
+      "name": "FormGroup",
+      "normalized": "form_group",
+      "source": "packages/mui-material/src/FormGroup",
+      "declared_in": "packages/mui-material/src/FormGroup/index.js"
+    },
+    {
+      "name": "FormHelperText",
+      "normalized": "form_helper_text",
+      "source": "packages/mui-material/src/FormHelperText",
+      "declared_in": "packages/mui-material/src/FormHelperText/index.js"
+    },
+    {
+      "name": "FormLabel",
+      "normalized": "form_label",
+      "source": "packages/mui-material/src/FormLabel",
+      "declared_in": "packages/mui-material/src/FormLabel/index.js"
+    },
+    {
+      "name": "GlobalStyles",
+      "normalized": "global_styles",
+      "source": "packages/mui-material/src/GlobalStyles",
+      "declared_in": "packages/mui-material/src/GlobalStyles/index.js"
+    },
+    {
+      "name": "Grid",
+      "normalized": "grid",
+      "source": "packages/mui-material/src/Grid",
+      "declared_in": "packages/mui-material/src/Grid/index.ts"
+    },
+    {
+      "name": "GridLegacy",
+      "normalized": "grid_legacy",
+      "source": "packages/mui-material/src/GridLegacy",
+      "declared_in": "packages/mui-material/src/GridLegacy/index.js"
+    },
+    {
+      "name": "Grow",
+      "normalized": "grow",
+      "source": "packages/mui-material/src/Grow",
+      "declared_in": "packages/mui-material/src/Grow/index.js"
+    },
+    {
+      "name": "Icon",
+      "normalized": "icon",
+      "source": "packages/mui-material/src/Icon",
+      "declared_in": "packages/mui-material/src/Icon/index.js"
+    },
+    {
+      "name": "IconButton",
+      "normalized": "icon_button",
+      "source": "packages/mui-material/src/IconButton",
+      "declared_in": "packages/mui-material/src/IconButton/index.js"
+    },
+    {
+      "name": "ImageList",
+      "normalized": "image_list",
+      "source": "packages/mui-material/src/ImageList",
+      "declared_in": "packages/mui-material/src/ImageList/index.js"
+    },
+    {
+      "name": "ImageListItem",
+      "normalized": "image_list_item",
+      "source": "packages/mui-material/src/ImageListItem",
+      "declared_in": "packages/mui-material/src/ImageListItem/index.js"
+    },
+    {
+      "name": "ImageListItemBar",
+      "normalized": "image_list_item_bar",
+      "source": "packages/mui-material/src/ImageListItemBar",
+      "declared_in": "packages/mui-material/src/ImageListItemBar/index.js"
+    },
+    {
+      "name": "InitColorSchemeScript",
+      "normalized": "init_color_scheme_script",
+      "source": "packages/mui-material/src/InitColorSchemeScript",
+      "declared_in": "packages/mui-material/src/InitColorSchemeScript/index.ts"
+    },
+    {
+      "name": "Input",
+      "normalized": "input",
+      "source": "packages/mui-material/src/Input",
+      "declared_in": "packages/mui-material/src/Input/index.js"
+    },
+    {
+      "name": "InputAdornment",
+      "normalized": "input_adornment",
+      "source": "packages/mui-material/src/InputAdornment",
+      "declared_in": "packages/mui-material/src/InputAdornment/index.js"
+    },
+    {
+      "name": "InputBase",
+      "normalized": "input_base",
+      "source": "packages/mui-material/src/InputBase",
+      "declared_in": "packages/mui-material/src/InputBase/index.js"
+    },
+    {
+      "name": "InputLabel",
+      "normalized": "input_label",
+      "source": "packages/mui-material/src/InputLabel",
+      "declared_in": "packages/mui-material/src/InputLabel/index.js"
+    },
+    {
+      "name": "LinearProgress",
+      "normalized": "linear_progress",
+      "source": "packages/mui-material/src/LinearProgress",
+      "declared_in": "packages/mui-material/src/LinearProgress/index.js"
+    },
+    {
+      "name": "Link",
+      "normalized": "link",
+      "source": "packages/mui-material/src/Link",
+      "declared_in": "packages/mui-material/src/Link/index.js"
+    },
+    {
+      "name": "List",
+      "normalized": "list",
+      "source": "packages/mui-material/src/List",
+      "declared_in": "packages/mui-material/src/List/index.js"
+    },
+    {
+      "name": "ListItem",
+      "normalized": "list_item",
+      "source": "packages/mui-material/src/ListItem",
+      "declared_in": "packages/mui-material/src/ListItem/index.js"
+    },
+    {
+      "name": "ListItemAvatar",
+      "normalized": "list_item_avatar",
+      "source": "packages/mui-material/src/ListItemAvatar",
+      "declared_in": "packages/mui-material/src/ListItemAvatar/index.js"
+    },
+    {
+      "name": "ListItemButton",
+      "normalized": "list_item_button",
+      "source": "packages/mui-material/src/ListItemButton",
+      "declared_in": "packages/mui-material/src/ListItemButton/index.js"
+    },
+    {
+      "name": "ListItemIcon",
+      "normalized": "list_item_icon",
+      "source": "packages/mui-material/src/ListItemIcon",
+      "declared_in": "packages/mui-material/src/ListItemIcon/index.js"
+    },
+    {
+      "name": "ListItemSecondaryAction",
+      "normalized": "list_item_secondary_action",
+      "source": "packages/mui-material/src/ListItemSecondaryAction",
+      "declared_in": "packages/mui-material/src/ListItemSecondaryAction/index.js"
+    },
+    {
+      "name": "ListItemText",
+      "normalized": "list_item_text",
+      "source": "packages/mui-material/src/ListItemText",
+      "declared_in": "packages/mui-material/src/ListItemText/index.js"
+    },
+    {
+      "name": "ListSubheader",
+      "normalized": "list_subheader",
+      "source": "packages/mui-material/src/ListSubheader",
+      "declared_in": "packages/mui-material/src/ListSubheader/index.js"
+    },
+    {
+      "name": "Menu",
+      "normalized": "menu",
+      "source": "packages/mui-material/src/Menu",
+      "declared_in": "packages/mui-material/src/Menu/index.js"
+    },
+    {
+      "name": "MenuItem",
+      "normalized": "menu_item",
+      "source": "packages/mui-material/src/MenuItem",
+      "declared_in": "packages/mui-material/src/MenuItem/index.js"
+    },
+    {
+      "name": "MenuList",
+      "normalized": "menu_list",
+      "source": "packages/mui-material/src/MenuList",
+      "declared_in": "packages/mui-material/src/MenuList/index.js"
+    },
+    {
+      "name": "MobileStepper",
+      "normalized": "mobile_stepper",
+      "source": "packages/mui-material/src/MobileStepper",
+      "declared_in": "packages/mui-material/src/MobileStepper/index.js"
+    },
+    {
+      "name": "Modal",
+      "normalized": "modal",
+      "source": "packages/mui-material/src/Modal",
+      "declared_in": "packages/mui-material/src/Modal/index.js"
+    },
+    {
+      "name": "NativeSelect",
+      "normalized": "native_select",
+      "source": "packages/mui-material/src/NativeSelect",
+      "declared_in": "packages/mui-material/src/NativeSelect/index.js"
+    },
+    {
+      "name": "NoSsr",
+      "normalized": "no_ssr",
+      "source": "packages/mui-material/src/NoSsr",
+      "declared_in": "packages/mui-material/src/NoSsr/index.js"
+    },
+    {
+      "name": "OutlinedInput",
+      "normalized": "outlined_input",
+      "source": "packages/mui-material/src/OutlinedInput",
+      "declared_in": "packages/mui-material/src/OutlinedInput/index.js"
+    },
+    {
+      "name": "Pagination",
+      "normalized": "pagination",
+      "source": "packages/mui-material/src/Pagination",
+      "declared_in": "packages/mui-material/src/Pagination/index.js"
+    },
+    {
+      "name": "PaginationItem",
+      "normalized": "pagination_item",
+      "source": "packages/mui-material/src/PaginationItem",
+      "declared_in": "packages/mui-material/src/PaginationItem/index.js"
+    },
+    {
+      "name": "Paper",
+      "normalized": "paper",
+      "source": "packages/mui-material/src/Paper",
+      "declared_in": "packages/mui-material/src/Paper/index.js"
+    },
+    {
+      "name": "PigmentContainer",
+      "normalized": "pigment_container",
+      "source": "packages/mui-material/src/PigmentContainer",
+      "declared_in": "packages/mui-material/src/PigmentContainer/index.ts"
+    },
+    {
+      "name": "PigmentGrid",
+      "normalized": "pigment_grid",
+      "source": "packages/mui-material/src/PigmentGrid",
+      "declared_in": "packages/mui-material/src/PigmentGrid/index.ts"
+    },
+    {
+      "name": "PigmentStack",
+      "normalized": "pigment_stack",
+      "source": "packages/mui-material/src/PigmentStack",
+      "declared_in": "packages/mui-material/src/PigmentStack/index.ts"
+    },
+    {
+      "name": "Popover",
+      "normalized": "popover",
+      "source": "packages/mui-material/src/Popover",
+      "declared_in": "packages/mui-material/src/Popover/index.js"
+    },
+    {
+      "name": "Popper",
+      "normalized": "popper",
+      "source": "packages/mui-material/src/Popper",
+      "declared_in": "packages/mui-material/src/Popper/index.js"
+    },
+    {
+      "name": "Portal",
+      "normalized": "portal",
+      "source": "packages/mui-material/src/Portal",
+      "declared_in": "packages/mui-material/src/Portal/index.js"
+    },
+    {
+      "name": "Radio",
+      "normalized": "radio",
+      "source": "packages/mui-material/src/Radio",
+      "declared_in": "packages/mui-material/src/Radio/index.js"
+    },
+    {
+      "name": "RadioGroup",
+      "normalized": "radio_group",
+      "source": "packages/mui-material/src/RadioGroup",
+      "declared_in": "packages/mui-material/src/RadioGroup/index.js"
+    },
+    {
+      "name": "Rating",
+      "normalized": "rating",
+      "source": "packages/mui-material/src/Rating",
+      "declared_in": "packages/mui-material/src/Rating/index.js"
+    },
+    {
+      "name": "ScopedCssBaseline",
+      "normalized": "scoped_css_baseline",
+      "source": "packages/mui-material/src/ScopedCssBaseline",
+      "declared_in": "packages/mui-material/src/ScopedCssBaseline/index.js"
+    },
+    {
+      "name": "Select",
+      "normalized": "select",
+      "source": "packages/mui-material/src/Select",
+      "declared_in": "packages/mui-material/src/Select/index.js"
+    },
+    {
+      "name": "Skeleton",
+      "normalized": "skeleton",
+      "source": "packages/mui-material/src/Skeleton",
+      "declared_in": "packages/mui-material/src/Skeleton/index.js"
+    },
+    {
+      "name": "Slide",
+      "normalized": "slide",
+      "source": "packages/mui-material/src/Slide",
+      "declared_in": "packages/mui-material/src/Slide/index.js"
+    },
+    {
+      "name": "Slider",
+      "normalized": "slider",
+      "source": "packages/mui-material/src/Slider",
+      "declared_in": "packages/mui-material/src/Slider/index.js"
+    },
+    {
+      "name": "Snackbar",
+      "normalized": "snackbar",
+      "source": "packages/mui-material/src/Snackbar",
+      "declared_in": "packages/mui-material/src/Snackbar/index.js"
+    },
+    {
+      "name": "SnackbarContent",
+      "normalized": "snackbar_content",
+      "source": "packages/mui-material/src/SnackbarContent",
+      "declared_in": "packages/mui-material/src/SnackbarContent/index.js"
+    },
+    {
+      "name": "SpeedDial",
+      "normalized": "speed_dial",
+      "source": "packages/mui-material/src/SpeedDial",
+      "declared_in": "packages/mui-material/src/SpeedDial/index.js"
+    },
+    {
+      "name": "SpeedDialAction",
+      "normalized": "speed_dial_action",
+      "source": "packages/mui-material/src/SpeedDialAction",
+      "declared_in": "packages/mui-material/src/SpeedDialAction/index.js"
+    },
+    {
+      "name": "SpeedDialIcon",
+      "normalized": "speed_dial_icon",
+      "source": "packages/mui-material/src/SpeedDialIcon",
+      "declared_in": "packages/mui-material/src/SpeedDialIcon/index.js"
+    },
+    {
+      "name": "Stack",
+      "normalized": "stack",
+      "source": "packages/mui-material/src/Stack",
+      "declared_in": "packages/mui-material/src/Stack/index.js"
+    },
+    {
+      "name": "Step",
+      "normalized": "step",
+      "source": "packages/mui-material/src/Step",
+      "declared_in": "packages/mui-material/src/Step/index.js"
+    },
+    {
+      "name": "StepButton",
+      "normalized": "step_button",
+      "source": "packages/mui-material/src/StepButton",
+      "declared_in": "packages/mui-material/src/StepButton/index.js"
+    },
+    {
+      "name": "StepConnector",
+      "normalized": "step_connector",
+      "source": "packages/mui-material/src/StepConnector",
+      "declared_in": "packages/mui-material/src/StepConnector/index.js"
+    },
+    {
+      "name": "StepContent",
+      "normalized": "step_content",
+      "source": "packages/mui-material/src/StepContent",
+      "declared_in": "packages/mui-material/src/StepContent/index.js"
+    },
+    {
+      "name": "StepContext",
+      "normalized": "step_context",
+      "source": "packages/mui-material/src/StepContext",
+      "declared_in": "packages/mui-material/src/Step/index.js"
+    },
+    {
+      "name": "StepIcon",
+      "normalized": "step_icon",
+      "source": "packages/mui-material/src/StepIcon",
+      "declared_in": "packages/mui-material/src/StepIcon/index.js"
+    },
+    {
+      "name": "StepLabel",
+      "normalized": "step_label",
+      "source": "packages/mui-material/src/StepLabel",
+      "declared_in": "packages/mui-material/src/StepLabel/index.js"
+    },
+    {
+      "name": "Stepper",
+      "normalized": "stepper",
+      "source": "packages/mui-material/src/Stepper",
+      "declared_in": "packages/mui-material/src/Stepper/index.js"
+    },
+    {
+      "name": "StepperContext",
+      "normalized": "stepper_context",
+      "source": "packages/mui-material/src/StepperContext",
+      "declared_in": "packages/mui-material/src/Stepper/index.js"
+    },
+    {
+      "name": "SvgIcon",
+      "normalized": "svg_icon",
+      "source": "packages/mui-material/src/SvgIcon",
+      "declared_in": "packages/mui-material/src/SvgIcon/index.js"
+    },
+    {
+      "name": "SwipeableDrawer",
+      "normalized": "swipeable_drawer",
+      "source": "packages/mui-material/src/SwipeableDrawer",
+      "declared_in": "packages/mui-material/src/SwipeableDrawer/index.js"
+    },
+    {
+      "name": "Switch",
+      "normalized": "switch",
+      "source": "packages/mui-material/src/Switch",
+      "declared_in": "packages/mui-material/src/Switch/index.js"
+    },
+    {
+      "name": "Tab",
+      "normalized": "tab",
+      "source": "packages/mui-material/src/Tab",
+      "declared_in": "packages/mui-material/src/Tab/index.js"
+    },
+    {
+      "name": "TabScrollButton",
+      "normalized": "tab_scroll_button",
+      "source": "packages/mui-material/src/TabScrollButton",
+      "declared_in": "packages/mui-material/src/TabScrollButton/index.js"
+    },
+    {
+      "name": "Table",
+      "normalized": "table",
+      "source": "packages/mui-material/src/Table",
+      "declared_in": "packages/mui-material/src/Table/index.js"
+    },
+    {
+      "name": "TableBody",
+      "normalized": "table_body",
+      "source": "packages/mui-material/src/TableBody",
+      "declared_in": "packages/mui-material/src/TableBody/index.js"
+    },
+    {
+      "name": "TableCell",
+      "normalized": "table_cell",
+      "source": "packages/mui-material/src/TableCell",
+      "declared_in": "packages/mui-material/src/TableCell/index.js"
+    },
+    {
+      "name": "TableContainer",
+      "normalized": "table_container",
+      "source": "packages/mui-material/src/TableContainer",
+      "declared_in": "packages/mui-material/src/TableContainer/index.js"
+    },
+    {
+      "name": "TableFooter",
+      "normalized": "table_footer",
+      "source": "packages/mui-material/src/TableFooter",
+      "declared_in": "packages/mui-material/src/TableFooter/index.js"
+    },
+    {
+      "name": "TableHead",
+      "normalized": "table_head",
+      "source": "packages/mui-material/src/TableHead",
+      "declared_in": "packages/mui-material/src/TableHead/index.js"
+    },
+    {
+      "name": "TablePagination",
+      "normalized": "table_pagination",
+      "source": "packages/mui-material/src/TablePagination",
+      "declared_in": "packages/mui-material/src/TablePagination/index.js"
+    },
+    {
+      "name": "TablePaginationActions",
+      "normalized": "table_pagination_actions",
+      "source": "packages/mui-material/src/TablePaginationActions",
+      "declared_in": "packages/mui-material/src/TablePaginationActions/index.js"
+    },
+    {
+      "name": "TableRow",
+      "normalized": "table_row",
+      "source": "packages/mui-material/src/TableRow",
+      "declared_in": "packages/mui-material/src/TableRow/index.js"
+    },
+    {
+      "name": "TableSortLabel",
+      "normalized": "table_sort_label",
+      "source": "packages/mui-material/src/TableSortLabel",
+      "declared_in": "packages/mui-material/src/TableSortLabel/index.js"
+    },
+    {
+      "name": "Tabs",
+      "normalized": "tabs",
+      "source": "packages/mui-material/src/Tabs",
+      "declared_in": "packages/mui-material/src/Tabs/index.js"
+    },
+    {
+      "name": "TextField",
+      "normalized": "text_field",
+      "source": "packages/mui-material/src/TextField",
+      "declared_in": "packages/mui-material/src/TextField/index.js"
+    },
+    {
+      "name": "TextareaAutosize",
+      "normalized": "textarea_autosize",
+      "source": "packages/mui-material/src/TextareaAutosize",
+      "declared_in": "packages/mui-material/src/TextareaAutosize/index.js"
+    },
+    {
+      "name": "THEME_ID",
+      "normalized": "theme_id",
+      "source": "packages/mui-material/src/identifier",
+      "declared_in": "packages/mui-material/src/styles/index.js"
+    },
+    {
+      "name": "ThemeProvider",
+      "normalized": "theme_provider",
+      "source": "packages/mui-material/src/ThemeProvider",
+      "declared_in": "packages/mui-material/src/styles/index.js"
+    },
+    {
+      "name": "ToggleButton",
+      "normalized": "toggle_button",
+      "source": "packages/mui-material/src/ToggleButton",
+      "declared_in": "packages/mui-material/src/ToggleButton/index.js"
+    },
+    {
+      "name": "ToggleButtonGroup",
+      "normalized": "toggle_button_group",
+      "source": "packages/mui-material/src/ToggleButtonGroup",
+      "declared_in": "packages/mui-material/src/ToggleButtonGroup/index.js"
+    },
+    {
+      "name": "Toolbar",
+      "normalized": "toolbar",
+      "source": "packages/mui-material/src/Toolbar",
+      "declared_in": "packages/mui-material/src/Toolbar/index.js"
+    },
+    {
+      "name": "Tooltip",
+      "normalized": "tooltip",
+      "source": "packages/mui-material/src/Tooltip",
+      "declared_in": "packages/mui-material/src/Tooltip/index.js"
+    },
+    {
+      "name": "Typography",
+      "normalized": "typography",
+      "source": "packages/mui-material/src/Typography",
+      "declared_in": "packages/mui-material/src/Typography/index.js"
+    },
+    {
+      "name": "Unstable_TrapFocus",
+      "normalized": "unstable_trap_focus",
+      "source": "packages/mui-material/src/Unstable_TrapFocus",
+      "declared_in": "packages/mui-material/src/index.js"
+    },
+    {
+      "name": "UseAutocomplete",
+      "normalized": "use_autocomplete",
+      "source": "packages/mui-material/src/useAutocomplete",
+      "declared_in": "packages/mui-material/src/useAutocomplete/index.js"
+    },
+    {
+      "name": "UseLazyRipple",
+      "normalized": "use_lazy_ripple",
+      "source": "packages/mui-material/src/useLazyRipple",
+      "declared_in": "packages/mui-material/src/useLazyRipple/index.ts"
+    },
+    {
+      "name": "UsePagination",
+      "normalized": "use_pagination",
+      "source": "packages/mui-material/src/usePagination",
+      "declared_in": "packages/mui-material/src/usePagination/index.js"
+    },
+    {
+      "name": "UseScrollTrigger",
+      "normalized": "use_scroll_trigger",
+      "source": "packages/mui-material/src/useScrollTrigger",
+      "declared_in": "packages/mui-material/src/useScrollTrigger/index.js"
+    },
+    {
+      "name": "Zoom",
+      "normalized": "zoom",
+      "source": "packages/mui-material/src/Zoom",
+      "declared_in": "packages/mui-material/src/Zoom/index.js"
+    }
+  ],
+  "extra_in_material": [],
+  "extra_in_headless": [
+    "aria"
+  ]
+}
+```

--- a/tools/material-parity/Cargo.toml
+++ b/tools/material-parity/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "material-parity"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+walkdir = { workspace = true }
+heck = { workspace = true }
+swc_common = { version = "14.0.4" }
+swc_ecma_ast = { version = "15.0.0", features = ["serde"] }
+swc_ecma_parser = { version = "24.0.1", features = ["typescript"] }

--- a/tools/material-parity/src/main.rs
+++ b/tools/material-parity/src/main.rs
@@ -1,0 +1,457 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use heck::ToSnakeCase;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use swc_common::{sync::Lrc, Globals, SourceMap, GLOBALS};
+use swc_ecma_ast::{ExportSpecifier, Ident, Module, ModuleDecl, ModuleExportName, ModuleItem};
+use swc_ecma_parser::lexer::Lexer;
+use swc_ecma_parser::{EsSyntax, Parser as SwcParser, StringInput, Syntax, TsSyntax};
+use walkdir::WalkDir;
+
+/// Command line arguments for the component parity scanner.
+#[derive(Parser, Debug)]
+#[command(
+    name = "material-parity",
+    about = "Scans the React source tree to measure Rust component coverage.",
+    version
+)]
+struct Cli {
+    /// Root of the JavaScript implementation (the canonical source of truth).
+    #[arg(long, default_value = "packages/mui-material/src")]
+    material_src: PathBuf,
+
+    /// Location of the Rust Material crate that should mirror the JS API surface.
+    #[arg(long, default_value = "crates/mui-material/src")]
+    rust_material: PathBuf,
+
+    /// Location of the headless primitives crate for comparison.
+    #[arg(long, default_value = "crates/mui-headless/src")]
+    rust_headless: PathBuf,
+
+    /// Destination markdown file that will host the parity report.
+    #[arg(long, default_value = "docs/material-component-parity.md")]
+    report: PathBuf,
+
+    /// Optional standalone JSON export path for downstream automation.
+    #[arg(long)]
+    json: Option<PathBuf>,
+
+    /// Number of missing components to highlight as the most urgent backlog.
+    #[arg(long, default_value_t = 10)]
+    top_n: usize,
+}
+
+/// Canonical representation of a component export from the React source tree.
+#[derive(Debug, Clone, Serialize)]
+struct ComponentEntry {
+    /// Display name that React exposes (e.g. `Button`).
+    name: String,
+    /// Normalized identifier derived from the name (e.g. `button`).
+    normalized: String,
+    /// Relative module specifier found in the source re-export (e.g. `./Button`).
+    source: String,
+    /// Path to the index file that declared the export. Useful for debugging duplicates.
+    declared_in: String,
+}
+
+/// Snapshot of Rust coverage alongside the full component inventory.
+#[derive(Debug, Serialize)]
+struct CoverageReport {
+    generated_at: DateTime<Utc>,
+    total_components: usize,
+    supported_in_material: usize,
+    supported_in_headless: usize,
+    material_coverage: f32,
+    headless_coverage: f32,
+    components: Vec<ComponentEntry>,
+    missing_from_material: Vec<ComponentEntry>,
+    missing_from_headless: Vec<ComponentEntry>,
+    extra_in_material: Vec<String>,
+    extra_in_headless: Vec<String>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let report = build_report(&cli)?;
+    write_markdown_report(&report, &cli.report, cli.top_n)?;
+
+    if let Some(json_path) = &cli.json {
+        let json = serde_json::to_string_pretty(&report)?;
+        fs::write(json_path, format!("{json}\n"))
+            .with_context(|| format!("failed to write JSON report to {}", json_path.display()))?;
+    }
+
+    println!(
+        "[material-parity] wrote {} (total components: {}, Rust coverage: {:.1}% / {:.1}%)",
+        cli.report.display(),
+        report.total_components,
+        report.material_coverage * 100.0,
+        report.headless_coverage * 100.0,
+    );
+
+    Ok(())
+}
+
+/// Entrypoint for orchestrating the full parity analysis flow.
+fn build_report(cli: &Cli) -> Result<CoverageReport> {
+    let js_components = scan_material_components(&cli.material_src)?;
+    let js_component_list: Vec<ComponentEntry> = js_components.values().cloned().collect();
+    let js_keys: BTreeSet<String> = js_components.keys().cloned().collect();
+    let material_modules = discover_rust_modules(&cli.rust_material)?;
+    let headless_modules = discover_rust_modules(&cli.rust_headless)?;
+
+    let mut supported_in_material = 0usize;
+    let mut supported_in_headless = 0usize;
+    let mut missing_from_material = Vec::new();
+    let mut missing_from_headless = Vec::new();
+
+    for entry in &js_component_list {
+        if material_modules.contains(&entry.normalized) {
+            supported_in_material += 1;
+        } else {
+            missing_from_material.push(entry.clone());
+        }
+
+        if headless_modules.contains(&entry.normalized) {
+            supported_in_headless += 1;
+        } else {
+            missing_from_headless.push(entry.clone());
+        }
+    }
+
+    let extra_in_material: Vec<String> = material_modules.difference(&js_keys).cloned().collect();
+    let extra_in_headless: Vec<String> = headless_modules.difference(&js_keys).cloned().collect();
+
+    let total = js_component_list.len();
+    let material_coverage = if total == 0 {
+        0.0
+    } else {
+        supported_in_material as f32 / total as f32
+    };
+    let headless_coverage = if total == 0 {
+        0.0
+    } else {
+        supported_in_headless as f32 / total as f32
+    };
+
+    Ok(CoverageReport {
+        generated_at: Utc::now(),
+        total_components: total,
+        supported_in_material,
+        supported_in_headless,
+        material_coverage,
+        headless_coverage,
+        components: js_component_list,
+        missing_from_material,
+        missing_from_headless,
+        extra_in_material,
+        extra_in_headless,
+    })
+}
+
+/// Parse the React source tree and extract component exports declared in `index` files.
+fn scan_material_components(material_src: &Path) -> Result<BTreeMap<String, ComponentEntry>> {
+    let cm: Lrc<SourceMap> = Lrc::new(SourceMap::default());
+    let globals = Globals::new();
+
+    GLOBALS.set(&globals, || -> Result<BTreeMap<String, ComponentEntry>> {
+        let mut entries: BTreeMap<String, ComponentEntry> = BTreeMap::new();
+
+        for entry in WalkDir::new(material_src).sort_by_file_name() {
+            let entry = entry?;
+            if !entry.file_type().is_file() {
+                continue;
+            }
+
+            let path = entry.path();
+            if !is_index_file(path) {
+                continue;
+            }
+
+            let module = parse_module(&cm, path)?;
+            for export in extract_component_exports(&module, path, material_src) {
+                entries.entry(export.normalized.clone()).or_insert(export);
+            }
+        }
+
+        Ok(entries)
+    })
+}
+
+/// Determine if a filesystem path corresponds to an `index` module that may contain re-exports.
+fn is_index_file(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    matches!(
+        file_name,
+        "index.ts" | "index.tsx" | "index.js" | "index.mjs" | "index.cjs"
+    )
+}
+
+/// Parse a source file into an ECMAScript module using SWC.
+fn parse_module(cm: &Lrc<SourceMap>, path: &Path) -> Result<Module> {
+    let fm = cm
+        .load_file(path)
+        .with_context(|| format!("failed to load {}", path.display()))?;
+
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase());
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    let is_jsx = matches!(
+        extension.as_deref(),
+        Some("tsx") | Some("jsx") | Some("mjsx") | Some("cjsx")
+    );
+    let is_ts = matches!(
+        extension.as_deref(),
+        Some("ts") | Some("tsx") | Some("mts") | Some("cts")
+    );
+    let is_d_ts = file_name.ends_with(".d.ts") || file_name.ends_with(".d.tsx");
+
+    let syntax = if is_ts {
+        Syntax::Typescript(TsSyntax {
+            tsx: is_jsx,
+            dts: is_d_ts,
+            ..Default::default()
+        })
+    } else {
+        Syntax::Es(EsSyntax {
+            jsx: is_jsx,
+            ..Default::default()
+        })
+    };
+
+    let lexer = Lexer::new(syntax, Default::default(), StringInput::from(&*fm), None);
+    let mut parser = SwcParser::new_from(lexer);
+    let module = parser
+        .parse_module()
+        .map_err(|err| anyhow!("{:?}", err))
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    let errors: Vec<_> = parser.take_errors();
+    if !errors.is_empty() {
+        let joined = errors
+            .into_iter()
+            .map(|err| format!("{:?}", err))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(anyhow!("{}", joined))
+            .with_context(|| format!("syntax errors in {}", path.display()));
+    }
+
+    Ok(module)
+}
+
+/// Extract component re-exports from a parsed module.
+fn extract_component_exports(
+    module: &Module,
+    module_path: &Path,
+    material_root: &Path,
+) -> Vec<ComponentEntry> {
+    let mut components = Vec::new();
+
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
+            continue;
+        };
+
+        let Some(src) = &named.src else {
+            // Skip `export { colors };` style statements which are not component entry points.
+            continue;
+        };
+
+        let specifier_path = src.value.to_string();
+        if !specifier_path.starts_with('.') {
+            // Ignore packages re-exported from npm modules.
+            continue;
+        }
+
+        for specifier in &named.specifiers {
+            if let Some(entry) =
+                build_component_entry(specifier, &specifier_path, module_path, material_root)
+            {
+                components.push(entry);
+            }
+        }
+    }
+
+    components
+}
+
+/// Convert an SWC export specifier into a structured [`ComponentEntry`] if it represents a widget.
+fn build_component_entry(
+    specifier: &ExportSpecifier,
+    specifier_path: &str,
+    module_path: &Path,
+    material_root: &Path,
+) -> Option<ComponentEntry> {
+    let exported_name = match specifier {
+        ExportSpecifier::Named(named) => {
+            let orig = export_name_to_string(&named.orig)?;
+            if orig != "default" {
+                // Only consider default exports; other named exports typically expose hooks or constants.
+                return None;
+            }
+            named
+                .exported
+                .as_ref()
+                .and_then(export_name_to_string)
+                .unwrap_or_else(|| derive_name_from_specifier(specifier_path))
+        }
+        ExportSpecifier::Default(default_spec) => ident_to_string(&default_spec.exported),
+        ExportSpecifier::Namespace(_) => return None,
+    };
+
+    if !exported_name
+        .chars()
+        .next()
+        .map(|c| c.is_uppercase())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let normalized = exported_name.to_snake_case();
+    let source = material_root
+        .join(specifier_path.trim_start_matches("./"))
+        .display()
+        .to_string()
+        .replace('\\', "/");
+
+    Some(ComponentEntry {
+        name: exported_name,
+        normalized,
+        source: source.replace('\r', ""),
+        declared_in: module_path.display().to_string(),
+    })
+}
+
+/// Convert a [`ModuleExportName`] into a string if possible.
+fn export_name_to_string(name: &ModuleExportName) -> Option<String> {
+    match name {
+        ModuleExportName::Ident(ident) => Some(ident.sym.to_string()),
+        ModuleExportName::Str(str_lit) => Some(str_lit.value.to_string()),
+    }
+}
+
+fn ident_to_string(ident: &Ident) -> String {
+    ident.sym.to_string()
+}
+
+/// Derive a PascalCase component name from a relative module specifier.
+fn derive_name_from_specifier(specifier: &str) -> String {
+    let without_dots = specifier.trim_start_matches("./");
+    let candidate = without_dots.rsplit('/').next().unwrap_or(without_dots);
+
+    // The JavaScript source already uses PascalCase folder names so we simply capitalize the
+    // first character to avoid pulling in a heavier inflector dependency.
+    let mut chars = candidate.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => candidate.to_string(),
+    }
+}
+
+/// Inspect a Rust crate directory and gather the module names that map to components.
+fn discover_rust_modules(root: &Path) -> Result<BTreeSet<String>> {
+    let mut modules = BTreeSet::new();
+
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            continue;
+        }
+
+        let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+            continue;
+        };
+        if ext != "rs" {
+            continue;
+        }
+
+        let file_stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(stem)
+                if stem != "lib"
+                    && stem != "mod"
+                    && stem != "macros"
+                    && stem != "style_helpers" =>
+            {
+                stem.to_string()
+            }
+            _ => continue,
+        };
+
+        modules.insert(file_stem);
+    }
+
+    Ok(modules)
+}
+
+/// Render the markdown artifact that blends narrative and machine-readable data.
+fn write_markdown_report(report: &CoverageReport, path: &Path, top_n: usize) -> Result<()> {
+    let json_blob = serde_json::to_string_pretty(report)?;
+    let mut markdown = String::new();
+
+    markdown.push_str("# Material Component Parity\n\n");
+    markdown.push_str(&format!(
+        "_Last updated {} via `cargo xtask material-parity`._\n\n",
+        report.generated_at.to_rfc3339()
+    ));
+
+    markdown.push_str("## Coverage snapshot\n\n");
+    markdown.push_str(&format!(
+        "- React exports analyzed: {}\\n",
+        report.total_components
+    ));
+    markdown.push_str(&format!(
+        "- `mui-material` coverage: {} ({:.1}%)\\n",
+        report.supported_in_material,
+        report.material_coverage * 100.0
+    ));
+    markdown.push_str(&format!(
+        "- `mui-headless` coverage: {} ({:.1}%)\\n\n",
+        report.supported_in_headless,
+        report.headless_coverage * 100.0
+    ));
+
+    markdown.push_str("## Highest priority gaps\n\n");
+    markdown.push_str("| Rank | Component | Source |\n");
+    markdown.push_str("| --- | --- | --- |\n");
+
+    for (idx, component) in report.missing_from_material.iter().take(top_n).enumerate() {
+        markdown.push_str(&format!(
+            "| {} | {} | `{}` |\n",
+            idx + 1,
+            component.name,
+            component.source
+        ));
+    }
+
+    if report.missing_from_material.is_empty() {
+        markdown.push_str("| – | All caught up! | – |\n");
+    }
+
+    markdown.push_str("\n## Machine-readable snapshot\n\n");
+    markdown.push_str("```json\n");
+    markdown.push_str(&json_blob);
+    markdown.push_str("\n```\n");
+
+    fs::create_dir_all(
+        path.parent()
+            .ok_or_else(|| anyhow::anyhow!("report path has no parent"))?,
+    )?;
+    fs::write(path, markdown)
+        .with_context(|| format!("failed to write report to {}", path.display()))?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a `material-parity` cargo binary that scans the React sources with swc, compares against the Rust crates, and writes a parity report
- wire the new tool into `cargo xtask` and document the workflow for contributors
- publish the generated coverage snapshot plus README guidance on the highest priority component gaps

## Testing
- cargo fmt
- cargo clippy -p material-parity -- -D warnings
- cargo run -p material-parity
- cargo test -p material-parity
- pnpm markdownlint docs/material-component-parity.md CONTRIBUTING.md crates/mui-material/README.md *(fails: unsupported Node.js version in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4e9b4110832eba81ad144421b9bd