### PR TITLE
feat(headless): add listbox and menu state machines

### DIFF
--- a/crates/mui-headless/src/aria.rs
+++ b/crates/mui-headless/src/aria.rs
@@ -8,6 +8,18 @@ pub const fn role_button() -> &'static str {
     "button"
 }
 
+/// Returns the ARIA role for the listbox container element.
+#[inline]
+pub const fn role_listbox() -> &'static str {
+    "listbox"
+}
+
+/// Returns the ARIA role for individual options within a listbox.
+#[inline]
+pub const fn role_option() -> &'static str {
+    "option"
+}
+
 /// Returns the ARIA role used by checkbox controls.
 #[inline]
 pub const fn role_checkbox() -> &'static str {
@@ -27,6 +39,18 @@ pub const fn role_switch() -> &'static str {
     "switch"
 }
 
+/// Returns the ARIA role used by menu surfaces.
+#[inline]
+pub const fn role_menu() -> &'static str {
+    "menu"
+}
+
+/// Returns the ARIA role used by interactive menu items.
+#[inline]
+pub const fn role_menuitem() -> &'static str {
+    "menuitem"
+}
+
 /// Compute the `aria-pressed` attribute for toggleable buttons.
 #[inline]
 pub const fn aria_pressed(pressed: bool) -> (&'static str, &'static str) {
@@ -43,4 +67,16 @@ pub const fn aria_checked(checked: bool) -> (&'static str, &'static str) {
 #[inline]
 pub const fn aria_disabled(disabled: bool) -> (&'static str, &'static str) {
     ("aria-disabled", if disabled { "true" } else { "false" })
+}
+
+/// Compute the `aria-expanded` attribute shared by disclosure widgets.
+#[inline]
+pub const fn aria_expanded(expanded: bool) -> (&'static str, &'static str) {
+    ("aria-expanded", if expanded { "true" } else { "false" })
+}
+
+/// Compute the `aria-haspopup` attribute indicating the popup type.
+#[inline]
+pub const fn aria_haspopup(kind: &'static str) -> (&'static str, &'static str) {
+    ("aria-haspopup", kind)
 }

--- a/crates/mui-headless/src/lib.rs
+++ b/crates/mui-headless/src/lib.rs
@@ -11,7 +11,10 @@ pub mod aria;
 pub mod button;
 pub mod checkbox;
 pub mod interaction;
+pub mod menu;
 pub mod radio;
+pub mod select;
 pub mod switch;
 
+mod selection;
 mod toggle;

--- a/crates/mui-headless/src/menu.rs
+++ b/crates/mui-headless/src/menu.rs
@@ -1,0 +1,266 @@
+//! State machine for building accessible menu button patterns.
+//!
+//! The menu manages disclosure state, keyboard focus (highlight) and a
+//! typeahead buffer allowing for rapid navigation.  Unlike the select state
+//! machine, menu activation is ephemeral — callbacks fire for highlighted items
+//! but no persistent selection is stored.
+
+use crate::aria;
+use crate::interaction::ControlKey;
+use crate::selection::{clamp_index, wrap_index, ControlStrategy, TypeaheadBuffer};
+use std::time::Duration;
+
+const TYPEAHEAD_TIMEOUT: Duration = Duration::from_millis(1000);
+
+/// Headless menu button state machine.
+#[derive(Debug, Clone)]
+pub struct MenuState {
+    item_count: usize,
+    highlighted: Option<usize>,
+    open: bool,
+    open_mode: ControlStrategy,
+    highlight_mode: ControlStrategy,
+    typeahead: TypeaheadBuffer,
+}
+
+impl MenuState {
+    /// Construct a new menu state instance.
+    ///
+    /// * `item_count` — number of menu items currently rendered.
+    /// * `default_open` — whether the menu starts visible when uncontrolled.
+    /// * `open_mode` — describes if the open state is controlled externally.
+    /// * `highlight_mode` — describes if focus management is controlled.
+    pub fn new(
+        item_count: usize,
+        default_open: bool,
+        open_mode: ControlStrategy,
+        highlight_mode: ControlStrategy,
+    ) -> Self {
+        Self {
+            item_count,
+            highlighted: if item_count > 0 { Some(0) } else { None },
+            open: if open_mode.is_controlled() {
+                false
+            } else {
+                default_open
+            },
+            open_mode,
+            highlight_mode,
+            typeahead: TypeaheadBuffer::new(TYPEAHEAD_TIMEOUT),
+        }
+    }
+
+    /// Returns whether the menu surface is currently expanded.
+    #[inline]
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Returns the highlighted menu item.
+    #[inline]
+    pub fn highlighted(&self) -> Option<usize> {
+        self.highlighted
+    }
+
+    /// Update the number of rendered menu items.
+    pub fn set_item_count(&mut self, count: usize) {
+        self.item_count = count;
+        self.highlighted = clamp_index(self.highlighted, count);
+        if self.highlighted.is_none() && count > 0 && !self.highlight_mode.is_controlled() {
+            self.highlighted = Some(0);
+        }
+    }
+
+    /// Synchronize the open flag when controlled by the parent.
+    pub fn sync_open(&mut self, open: bool) {
+        self.open = open;
+        if open {
+            self.ensure_highlight();
+        } else {
+            self.typeahead.reset();
+        }
+    }
+
+    /// Synchronize the highlighted item when focus is controlled externally.
+    pub fn sync_highlighted(&mut self, index: Option<usize>) {
+        if self.highlight_mode.is_controlled() {
+            self.highlighted = clamp_index(index, self.item_count);
+        }
+    }
+
+    /// Imperatively set the highlighted item (uncontrolled mode).
+    pub fn set_highlighted(&mut self, index: Option<usize>) {
+        if !self.highlight_mode.is_controlled() {
+            self.highlighted = clamp_index(index, self.item_count);
+        }
+    }
+
+    /// Request the menu to open.
+    pub fn open<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(true, notify);
+    }
+
+    /// Request the menu to close.
+    pub fn close<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(false, notify);
+    }
+
+    /// Toggle the disclosure state.
+    pub fn toggle<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(!self.open, notify);
+    }
+
+    /// Handle navigation keys.  Returns the new highlight so adapters can ensure
+    /// the item is visible (for example by scrolling into view).
+    pub fn on_key(&mut self, key: ControlKey) -> Option<usize> {
+        let mut next = self.highlighted;
+        match key {
+            ControlKey::Home => {
+                next = if self.item_count > 0 { Some(0) } else { None };
+            }
+            ControlKey::End => {
+                next = if self.item_count > 0 {
+                    Some(self.item_count - 1)
+                } else {
+                    None
+                };
+            }
+            _ if key.is_forward() => {
+                self.ensure_highlight();
+                next = wrap_index(self.highlighted, 1, self.item_count);
+            }
+            _ if key.is_backward() => {
+                self.ensure_highlight();
+                next = wrap_index(self.highlighted, -1, self.item_count);
+            }
+            _ => {}
+        }
+        if self.highlight_mode.is_controlled() {
+            next
+        } else {
+            self.highlighted = next;
+            self.highlighted
+        }
+    }
+
+    /// Handle printable characters for typeahead navigation.
+    pub fn on_typeahead<F>(&mut self, ch: char, matcher: F) -> Option<usize>
+    where
+        F: Fn(&str, Option<usize>, usize) -> Option<usize>,
+    {
+        let query = self.typeahead.push(ch);
+        let next = matcher(query, self.highlighted, self.item_count);
+        if self.highlight_mode.is_controlled() {
+            next
+        } else {
+            if next.is_some() {
+                self.highlighted = next;
+            }
+            self.highlighted
+        }
+    }
+
+    /// Invoke the supplied callback for the highlighted menu item.
+    pub fn activate_highlighted<F: FnMut(usize)>(&mut self, mut on_activate: F) {
+        if let Some(index) = self.highlighted {
+            on_activate(index);
+        }
+    }
+
+    /// Returns the ARIA role for the trigger button.
+    #[inline]
+    pub fn trigger_role(&self) -> &'static str {
+        aria::role_button()
+    }
+
+    /// Returns the `aria-haspopup="menu"` tuple for the trigger element.
+    #[inline]
+    pub fn trigger_haspopup(&self) -> (&'static str, &'static str) {
+        aria::aria_haspopup("menu")
+    }
+
+    /// Returns the `aria-expanded` tuple for the trigger element.
+    #[inline]
+    pub fn trigger_expanded(&self) -> (&'static str, &'static str) {
+        aria::aria_expanded(self.open)
+    }
+
+    /// Returns the ARIA role for the menu surface.
+    #[inline]
+    pub fn menu_role(&self) -> &'static str {
+        aria::role_menu()
+    }
+
+    /// Returns the ARIA role for menu items.
+    #[inline]
+    pub fn item_role(&self) -> &'static str {
+        aria::role_menuitem()
+    }
+
+    fn set_open<F: FnOnce(bool)>(&mut self, next: bool, notify: F) {
+        if !self.open_mode.is_controlled() {
+            self.open = next;
+        }
+        if next {
+            self.ensure_highlight();
+        } else {
+            self.typeahead.reset();
+        }
+        notify(next);
+    }
+
+    fn ensure_highlight(&mut self) {
+        if self.item_count == 0 {
+            self.highlighted = None;
+            return;
+        }
+        if self.highlight_mode.is_controlled() {
+            self.highlighted = clamp_index(self.highlighted, self.item_count);
+        } else if self.highlighted.is_none() {
+            self.highlighted = Some(0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uncontrolled_highlight_updates() {
+        let mut state = MenuState::new(
+            3,
+            true,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        state.on_key(ControlKey::ArrowDown);
+        assert_eq!(state.highlighted(), Some(1));
+    }
+
+    #[test]
+    fn controlled_highlight_requires_sync() {
+        let mut state = MenuState::new(
+            3,
+            false,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Controlled,
+        );
+        state.on_key(ControlKey::ArrowDown);
+        assert_eq!(state.highlighted(), Some(0));
+        state.sync_highlighted(Some(2));
+        assert_eq!(state.highlighted(), Some(2));
+    }
+
+    #[test]
+    fn typeahead_updates_highlight() {
+        let mut state = MenuState::new(
+            3,
+            false,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        state.on_typeahead('b', |query, _, _| if query == "b" { Some(1) } else { None });
+        assert_eq!(state.highlighted(), Some(1));
+    }
+}

--- a/crates/mui-headless/src/select.rs
+++ b/crates/mui-headless/src/select.rs
@@ -1,0 +1,345 @@
+//! State machine powering headless select/listbox components.
+//!
+//! The implementation keeps track of open state, the currently highlighted
+//! option, the committed selection and a rolling typeahead buffer.  Framework
+//! adapters can drive the state machine through the provided public API to
+//! implement either controlled or uncontrolled widgets.
+
+use crate::aria;
+use crate::interaction::ControlKey;
+use crate::selection::{clamp_index, wrap_index, ControlStrategy, TypeaheadBuffer};
+use std::time::Duration;
+
+/// Default timeout before the typeahead buffer resets.  The value mirrors the
+/// recommendation from the WAI-ARIA authoring guide.
+const TYPEAHEAD_TIMEOUT: Duration = Duration::from_millis(1000);
+
+/// Headless select/listbox state machine.
+#[derive(Debug, Clone)]
+pub struct SelectState {
+    option_count: usize,
+    highlighted: Option<usize>,
+    selected: Option<usize>,
+    open: bool,
+    open_mode: ControlStrategy,
+    selection_mode: ControlStrategy,
+    typeahead: TypeaheadBuffer,
+}
+
+impl SelectState {
+    /// Create a new select state machine.
+    ///
+    /// * `option_count` — number of options currently rendered.
+    /// * `initial_selected` — zero based index of the pre-selected option.
+    /// * `default_open` — whether the popover starts open (uncontrolled mode).
+    /// * `open_mode` — describes if the open state is controlled externally.
+    /// * `selection_mode` — describes if the selected value is controlled.
+    pub fn new(
+        option_count: usize,
+        initial_selected: Option<usize>,
+        default_open: bool,
+        open_mode: ControlStrategy,
+        selection_mode: ControlStrategy,
+    ) -> Self {
+        let selected = clamp_index(initial_selected, option_count);
+        let highlighted = selected.or_else(|| if option_count > 0 { Some(0) } else { None });
+        Self {
+            option_count,
+            highlighted,
+            selected,
+            open: if open_mode.is_controlled() {
+                false
+            } else {
+                default_open
+            },
+            open_mode,
+            selection_mode,
+            typeahead: TypeaheadBuffer::new(TYPEAHEAD_TIMEOUT),
+        }
+    }
+
+    /// Returns the total number of options.
+    #[inline]
+    pub fn option_count(&self) -> usize {
+        self.option_count
+    }
+
+    /// Synchronizes the internal option count with the UI.
+    ///
+    /// The method clamps the selection and highlighted indices to prevent
+    /// referencing stale entries when options are dynamically removed.
+    pub fn set_option_count(&mut self, count: usize) {
+        self.option_count = count;
+        self.selected = clamp_index(self.selected, count);
+        self.highlighted = clamp_index(self.highlighted, count)
+            .or_else(|| self.selected)
+            .or_else(|| if count > 0 { Some(0) } else { None });
+    }
+
+    /// Returns whether the listbox popover is currently visible.
+    #[inline]
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Returns the currently highlighted option index.
+    #[inline]
+    pub fn highlighted(&self) -> Option<usize> {
+        self.highlighted
+    }
+
+    /// Returns the committed selection.
+    #[inline]
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Imperatively set the open state (uncontrolled mode) or emit an intent to
+    /// open the popover (controlled mode).
+    pub fn open<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(true, notify);
+    }
+
+    /// Imperatively set the closed state (uncontrolled mode) or emit an intent
+    /// to close the popover (controlled mode).
+    pub fn close<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(false, notify);
+    }
+
+    /// Toggle between open and closed states.
+    pub fn toggle<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(!self.open, notify);
+    }
+
+    /// Synchronize the open flag when the value is owned by the parent.
+    pub fn sync_open(&mut self, open: bool) {
+        self.open = open;
+        if open {
+            self.ensure_highlight();
+        } else {
+            self.typeahead.reset();
+        }
+    }
+
+    /// Synchronize the selected option when the value is controlled by a
+    /// parent.  The highlighted option is also aligned to the controlled value
+    /// to preserve the active descendant relationship.
+    pub fn sync_selected(&mut self, selected: Option<usize>) {
+        self.selected = clamp_index(selected, self.option_count);
+        if self.selection_mode.is_controlled() {
+            if self.selected.is_some() {
+                self.highlighted = self.selected;
+            } else {
+                self.highlighted = clamp_index(self.highlighted, self.option_count);
+            }
+        }
+    }
+
+    /// Manually override the highlighted index.  This is primarily used by
+    /// adapters when focus moves via pointer interaction.
+    pub fn set_highlighted(&mut self, index: Option<usize>) {
+        self.highlighted = clamp_index(index, self.option_count);
+    }
+
+    /// Selects the provided option index, invoking the supplied callback.
+    pub fn select<F: FnMut(usize)>(&mut self, index: usize, mut on_select: F) {
+        if index >= self.option_count {
+            return;
+        }
+        self.highlighted = Some(index);
+        if !self.selection_mode.is_controlled() {
+            self.selected = Some(index);
+        }
+        on_select(index);
+    }
+
+    /// Commits the current highlight if present.
+    pub fn select_highlighted<F: FnMut(usize)>(&mut self, mut on_select: F) {
+        if let Some(index) = self.highlighted {
+            self.select(index, &mut on_select);
+        }
+    }
+
+    /// Handle navigation keys by moving the highlight or committing the
+    /// selection.  The method returns the new highlighted index so adapters can
+    /// react (for example by scrolling the active option into view).
+    pub fn on_key<F: FnMut(usize)>(&mut self, key: ControlKey, on_select: F) -> Option<usize> {
+        match key {
+            ControlKey::Enter | ControlKey::Space => {
+                self.select_highlighted(on_select);
+            }
+            ControlKey::Home => {
+                self.highlighted = if self.option_count > 0 { Some(0) } else { None };
+            }
+            ControlKey::End => {
+                self.highlighted = if self.option_count > 0 {
+                    Some(self.option_count - 1)
+                } else {
+                    None
+                };
+            }
+            _ if key.is_forward() => {
+                self.ensure_highlight();
+                self.highlighted = wrap_index(self.highlighted, 1, self.option_count);
+            }
+            _ if key.is_backward() => {
+                self.ensure_highlight();
+                self.highlighted = wrap_index(self.highlighted, -1, self.option_count);
+            }
+            _ => {}
+        }
+        self.highlighted
+    }
+
+    /// Handle printable key input by updating the typeahead buffer and asking
+    /// the provided matcher to resolve the index of the matching option.
+    ///
+    /// The matcher receives the full query, the currently highlighted index and
+    /// the option count.  When it returns a new index the highlight (and
+    /// selection for uncontrolled widgets) is updated before invoking the
+    /// supplied callback.
+    pub fn on_typeahead<F, G>(&mut self, ch: char, matcher: F, mut on_select: G)
+    where
+        F: Fn(&str, Option<usize>, usize) -> Option<usize>,
+        G: FnMut(usize),
+    {
+        let query = self.typeahead.push(ch);
+        if let Some(index) = matcher(query, self.highlighted, self.option_count) {
+            self.highlighted = Some(index);
+            if !self.selection_mode.is_controlled() {
+                self.selected = Some(index);
+            }
+            on_select(index);
+        }
+    }
+
+    /// Returns the ARIA role of the trigger element.  Select popovers are
+    /// typically toggled by a button per the WAI-ARIA practices.
+    #[inline]
+    pub fn trigger_role(&self) -> &'static str {
+        aria::role_button()
+    }
+
+    /// Returns the `aria-haspopup="listbox"` tuple for the trigger element.
+    #[inline]
+    pub fn trigger_haspopup(&self) -> (&'static str, &'static str) {
+        aria::aria_haspopup("listbox")
+    }
+
+    /// Returns the `aria-expanded` attribute for the trigger element.
+    #[inline]
+    pub fn trigger_expanded(&self) -> (&'static str, &'static str) {
+        aria::aria_expanded(self.open)
+    }
+
+    /// Returns the ARIA role for the list element (listbox).
+    #[inline]
+    pub fn list_role(&self) -> &'static str {
+        aria::role_listbox()
+    }
+
+    /// Returns the ARIA role for an option element.
+    #[inline]
+    pub fn option_role(&self) -> &'static str {
+        aria::role_option()
+    }
+
+    fn set_open<F: FnOnce(bool)>(&mut self, next: bool, notify: F) {
+        if !self.open_mode.is_controlled() {
+            self.open = next;
+        }
+        if next {
+            self.ensure_highlight();
+        } else {
+            self.typeahead.reset();
+        }
+        notify(next);
+    }
+
+    fn ensure_highlight(&mut self) {
+        if self.option_count == 0 {
+            self.highlighted = None;
+            return;
+        }
+        if self.highlighted.is_some() {
+            self.highlighted = clamp_index(self.highlighted, self.option_count);
+            if self.highlighted.is_some() {
+                return;
+            }
+        }
+        self.highlighted =
+            self.selected
+                .or_else(|| if self.option_count > 0 { Some(0) } else { None });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn noop(_: usize) {}
+
+    #[test]
+    fn uncontrolled_selection_updates_internal_state() {
+        let mut state = SelectState::new(
+            3,
+            Some(1),
+            false,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        state.select(2, noop);
+        assert_eq!(state.selected(), Some(2));
+    }
+
+    #[test]
+    fn controlled_selection_does_not_mutate_internal_value() {
+        let mut state = SelectState::new(
+            3,
+            Some(1),
+            false,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Controlled,
+        );
+        state.select(2, noop);
+        assert_eq!(state.selected(), Some(1));
+        state.sync_selected(Some(2));
+        assert_eq!(state.selected(), Some(2));
+    }
+
+    #[test]
+    fn keyboard_navigation_wraps() {
+        let mut state = SelectState::new(
+            2,
+            Some(0),
+            true,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        state.on_key(ControlKey::ArrowUp, noop);
+        assert_eq!(state.highlighted(), Some(1));
+    }
+
+    #[test]
+    fn typeahead_invokes_matcher() {
+        let mut state = SelectState::new(
+            3,
+            None,
+            false,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        state.on_typeahead(
+            'c',
+            |query, _, _| {
+                if query == "c" {
+                    Some(2)
+                } else {
+                    None
+                }
+            },
+            noop,
+        );
+        assert_eq!(state.selected(), Some(2));
+    }
+}

--- a/crates/mui-headless/src/selection.rs
+++ b/crates/mui-headless/src/selection.rs
@@ -1,0 +1,120 @@
+//! Shared building blocks for list based controls.
+//!
+//! The select and menu state machines both require typeahead handling and a
+//! consistent approach to controlled/uncontrolled state management.  Keeping
+//! the primitives centralized avoids duplicating the bookkeeping logic and
+//! provides a single location for future components such as autocomplete to
+//! reuse.
+
+use std::time::{Duration, Instant};
+
+/// Describes whether a piece of state is owned by the component or by an
+/// external controller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlStrategy {
+    /// Controlled widgets only emit intents through callbacks and expect their
+    /// parent to call a synchronization method with the latest value.
+    Controlled,
+    /// Uncontrolled widgets mutate the internal field immediately and still
+    /// emit callbacks so observers remain informed.
+    Uncontrolled,
+}
+
+impl ControlStrategy {
+    #[inline]
+    pub(crate) fn is_controlled(self) -> bool {
+        matches!(self, Self::Controlled)
+    }
+}
+
+/// Rolling buffer used to implement typeahead navigation in list based
+/// controls.
+#[derive(Debug, Clone)]
+pub(crate) struct TypeaheadBuffer {
+    timeout: Duration,
+    last_key: Option<Instant>,
+    value: String,
+}
+
+impl TypeaheadBuffer {
+    /// Construct a new buffer with a configurable timeout.  WAI-ARIA authoring
+    /// practices recommend clearing the query after roughly one second to keep
+    /// the interaction feeling responsive even when users pause between key
+    /// strokes.
+    pub(crate) fn new(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            last_key: None,
+            value: String::new(),
+        }
+    }
+
+    /// Clears the buffer immediately.  This is typically called whenever the
+    /// popover closes so the next open interaction starts from a clean slate.
+    pub(crate) fn reset(&mut self) {
+        self.value.clear();
+        self.last_key = None;
+    }
+
+    /// Push a new character into the rolling buffer and return the updated
+    /// query slice.  Whenever the elapsed time exceeds the configured timeout
+    /// the buffer is cleared before appending the next character.
+    pub(crate) fn push(&mut self, ch: char) -> &str {
+        let now = Instant::now();
+        if let Some(previous) = self.last_key {
+            if now.duration_since(previous) > self.timeout {
+                self.value.clear();
+            }
+        }
+        self.last_key = Some(now);
+        self.value.push(ch);
+        &self.value
+    }
+}
+
+/// Wraps an index change inside an option count, returning the new highlighted
+/// index.  When the list is empty the function returns `None`.
+#[inline]
+pub(crate) fn wrap_index(current: Option<usize>, delta: isize, len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    let base = current.unwrap_or(0);
+    let len_isize = len as isize;
+    let mut next = (base as isize + delta) % len_isize;
+    if next < 0 {
+        next += len_isize;
+    }
+    Some(next as usize)
+}
+
+/// Clamp a provided index to the current list bounds returning `None` whenever
+/// the index falls outside the range.
+#[inline]
+pub(crate) fn clamp_index(index: Option<usize>, len: usize) -> Option<usize> {
+    index.filter(|value| *value < len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn typeahead_rolls_over_after_timeout() {
+        let mut buffer = TypeaheadBuffer::new(Duration::from_millis(1));
+        buffer.push('a');
+        std::thread::sleep(Duration::from_millis(10));
+        assert_eq!(buffer.push('b'), "b");
+    }
+
+    #[test]
+    fn wrap_index_handles_negative_deltas() {
+        assert_eq!(wrap_index(Some(0), -1, 5), Some(4));
+    }
+
+    #[test]
+    fn clamp_index_filters_out_of_range_values() {
+        assert_eq!(clamp_index(Some(10), 3), None);
+    }
+}


### PR DESCRIPTION
## Summary
- add shared control strategy and typeahead helpers for list-driven widgets
- implement a headless select/listbox state machine with controlled and uncontrolled flows
- introduce a menu button state machine and extend ARIA helpers to cover listbox/menu roles

## Testing
- cargo test -p mui-headless

------
https://chatgpt.com/codex/tasks/task_e_68cd7da462a8832eb24e1479ffda36ed