### PR TITLE
feat(headless): add tab and drawer primitives

### DIFF
--- a/crates/mui-headless/src/aria.rs
+++ b/crates/mui-headless/src/aria.rs
@@ -51,6 +51,30 @@ pub const fn role_menuitem() -> &'static str {
     "menuitem"
 }
 
+/// Returns the ARIA role for tablist containers.
+#[inline]
+pub const fn role_tablist() -> &'static str {
+    "tablist"
+}
+
+/// Returns the ARIA role for individual tabs within a tablist.
+#[inline]
+pub const fn role_tab() -> &'static str {
+    "tab"
+}
+
+/// Returns the ARIA role for tab panels associated with tabs.
+#[inline]
+pub const fn role_tabpanel() -> &'static str {
+    "tabpanel"
+}
+
+/// Returns the ARIA role for modal dialogs such as drawers.
+#[inline]
+pub const fn role_dialog() -> &'static str {
+    "dialog"
+}
+
 /// Compute the `aria-pressed` attribute for toggleable buttons.
 #[inline]
 pub const fn aria_pressed(pressed: bool) -> (&'static str, &'static str) {
@@ -79,4 +103,40 @@ pub const fn aria_expanded(expanded: bool) -> (&'static str, &'static str) {
 #[inline]
 pub const fn aria_haspopup(kind: &'static str) -> (&'static str, &'static str) {
     ("aria-haspopup", kind)
+}
+
+/// Compute the `aria-selected` attribute used by tabs and similar widgets.
+#[inline]
+pub const fn aria_selected(selected: bool) -> (&'static str, &'static str) {
+    ("aria-selected", if selected { "true" } else { "false" })
+}
+
+/// Compute the `aria-controls` attribute linking tabs to their panels.
+#[inline]
+pub fn aria_controls(id: &str) -> (&'static str, &str) {
+    ("aria-controls", id)
+}
+
+/// Compute the `aria-labelledby` attribute for elements referenced by labels.
+#[inline]
+pub fn aria_labelledby(id: &str) -> (&'static str, &str) {
+    ("aria-labelledby", id)
+}
+
+/// Compute the `aria-describedby` attribute linking to additional context.
+#[inline]
+pub fn aria_describedby(id: &str) -> (&'static str, &str) {
+    ("aria-describedby", id)
+}
+
+/// Compute the `aria-orientation` attribute for multi-directional widgets.
+#[inline]
+pub const fn aria_orientation(orientation: &'static str) -> (&'static str, &'static str) {
+    ("aria-orientation", orientation)
+}
+
+/// Compute the `aria-modal` attribute for dialog style surfaces.
+#[inline]
+pub const fn aria_modal(modal: bool) -> (&'static str, &'static str) {
+    ("aria-modal", if modal { "true" } else { "false" })
 }

--- a/crates/mui-headless/src/drawer.rs
+++ b/crates/mui-headless/src/drawer.rs
@@ -1,0 +1,333 @@
+//! State management for drawers and side sheets.
+//!
+//! Drawers share behaviour with disclosure widgets such as menus but introduce
+//! additional metadata (anchor and variant) that adapters often need when
+//! orchestrating layout.  Centralizing the logic keeps behaviour consistent
+//! across frameworks and unlocks automation for future variants.
+
+use crate::aria;
+use crate::selection::ControlStrategy;
+
+/// Describes whether the drawer behaves like a modal surface or a persistent
+/// side sheet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrawerVariant {
+    /// Modal drawers block interaction with background content and require
+    /// focus management.
+    Modal,
+    /// Persistent drawers remain visible without blocking background
+    /// interaction.  They typically anchor navigation affordances.
+    Persistent,
+}
+
+impl DrawerVariant {
+    #[inline]
+    fn is_modal(self) -> bool {
+        matches!(self, Self::Modal)
+    }
+}
+
+/// Represents where the drawer originates from on screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrawerAnchor {
+    /// Drawer slides from the leading edge (left in LTR, right in RTL).
+    Start,
+    /// Drawer slides from the trailing edge (right in LTR, left in RTL).
+    End,
+    /// Drawer drops from the top edge.
+    Top,
+    /// Drawer raises from the bottom edge.
+    Bottom,
+}
+
+impl DrawerAnchor {
+    /// Returns a string representation that adapters can map to CSS classes.
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::End => "end",
+            Self::Top => "top",
+            Self::Bottom => "bottom",
+        }
+    }
+}
+
+/// High level drawer state machine.
+#[derive(Debug, Clone)]
+pub struct DrawerState {
+    open: bool,
+    control_mode: ControlStrategy,
+    variant: DrawerVariant,
+    anchor: DrawerAnchor,
+}
+
+impl DrawerState {
+    /// Create a new drawer state machine.
+    pub fn new(
+        default_open: bool,
+        control_mode: ControlStrategy,
+        variant: DrawerVariant,
+        anchor: DrawerAnchor,
+    ) -> Self {
+        Self {
+            open: if control_mode.is_controlled() {
+                false
+            } else {
+                default_open
+            },
+            control_mode,
+            variant,
+            anchor,
+        }
+    }
+
+    /// Returns whether the drawer is currently visible.
+    #[inline]
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Returns the configured variant.
+    #[inline]
+    pub fn variant(&self) -> DrawerVariant {
+        self.variant
+    }
+
+    /// Returns the configured anchor.
+    #[inline]
+    pub fn anchor(&self) -> DrawerAnchor {
+        self.anchor
+    }
+
+    /// Request the drawer to open.
+    pub fn open<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(true, notify);
+    }
+
+    /// Request the drawer to close.
+    pub fn close<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(false, notify);
+    }
+
+    /// Toggle the drawer state.
+    pub fn toggle<F: FnOnce(bool)>(&mut self, notify: F) {
+        self.set_open(!self.open, notify);
+    }
+
+    /// Synchronize the open flag when controlled externally.
+    pub fn sync_open(&mut self, open: bool) {
+        self.open = open;
+    }
+
+    /// Returns a builder for drawer surface attributes.
+    #[inline]
+    pub fn surface_attributes(&self) -> DrawerSurfaceAttributes<'_> {
+        DrawerSurfaceAttributes::new(self)
+    }
+
+    /// Returns a builder for drawer backdrop attributes.
+    #[inline]
+    pub fn backdrop_attributes(&self) -> DrawerBackdropAttributes<'_> {
+        DrawerBackdropAttributes::new(self)
+    }
+
+    fn set_open<F: FnOnce(bool)>(&mut self, next: bool, notify: F) {
+        if !self.control_mode.is_controlled() {
+            self.open = next;
+        }
+        notify(next);
+    }
+}
+
+/// Builder for drawer surface attributes.  The builder exposes ARIA metadata so
+/// adapters can keep markup declarative and ergonomic.
+#[derive(Debug, Clone)]
+pub struct DrawerSurfaceAttributes<'a> {
+    state: &'a DrawerState,
+    id: Option<&'a str>,
+    labelled_by: Option<&'a str>,
+    described_by: Option<&'a str>,
+}
+
+impl<'a> DrawerSurfaceAttributes<'a> {
+    #[inline]
+    fn new(state: &'a DrawerState) -> Self {
+        Self {
+            state,
+            id: None,
+            labelled_by: None,
+            described_by: None,
+        }
+    }
+
+    /// Attach an `id` attribute to the drawer element.
+    #[inline]
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Configure the labelling element for the drawer surface.
+    #[inline]
+    pub fn labelled_by(mut self, value: &'a str) -> Self {
+        self.labelled_by = Some(value);
+        self
+    }
+
+    /// Configure an element that describes the drawer contents.
+    #[inline]
+    pub fn described_by(mut self, value: &'a str) -> Self {
+        self.described_by = Some(value);
+        self
+    }
+
+    /// Returns the `role` for the drawer surface.  Modal drawers use the dialog
+    /// role to communicate modality while persistent drawers expose the same
+    /// role for consistent semantics.
+    #[inline]
+    pub fn role(&self) -> &'static str {
+        aria::role_dialog()
+    }
+
+    /// Returns the `aria-modal` tuple describing whether focus should remain
+    /// trapped inside the drawer.
+    #[inline]
+    pub fn aria_modal(&self) -> (&'static str, &'static str) {
+        aria::aria_modal(self.state.variant.is_modal())
+    }
+
+    /// Returns the `aria-labelledby` tuple when configured.
+    #[inline]
+    pub fn aria_labelledby(&self) -> Option<(&'static str, &str)> {
+        self.labelled_by.map(aria::aria_labelledby)
+    }
+
+    /// Returns the `aria-describedby` tuple when configured.
+    #[inline]
+    pub fn aria_describedby(&self) -> Option<(&'static str, &str)> {
+        self.described_by.map(aria::aria_describedby)
+    }
+
+    /// Returns the `id` tuple when configured.
+    #[inline]
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Returns a helper attribute capturing the configured anchor.  This uses a
+    /// data attribute so adapters can style without reinventing naming
+    /// conventions.
+    #[inline]
+    pub fn data_anchor(&self) -> (&'static str, &'static str) {
+        ("data-anchor", self.state.anchor.as_str())
+    }
+}
+
+/// Builder for drawer backdrop attributes.
+#[derive(Debug, Clone)]
+pub struct DrawerBackdropAttributes<'a> {
+    state: &'a DrawerState,
+}
+
+impl<'a> DrawerBackdropAttributes<'a> {
+    #[inline]
+    fn new(state: &'a DrawerState) -> Self {
+        Self { state }
+    }
+
+    /// Backdrops are hidden from assistive technology while still signalling
+    /// modality to layout engines.
+    #[inline]
+    pub fn aria_hidden(&self) -> (&'static str, &'static str) {
+        ("aria-hidden", "true")
+    }
+
+    /// Returns whether the backdrop should be rendered.  Persistent drawers do
+    /// not require a backdrop since they keep the page interactive.
+    #[inline]
+    pub fn is_visible(&self) -> bool {
+        self.state.variant.is_modal()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uncontrolled_drawer_mutates_internal_state() {
+        let mut state = DrawerState::new(
+            false,
+            ControlStrategy::Uncontrolled,
+            DrawerVariant::Modal,
+            DrawerAnchor::Start,
+        );
+        state.open(|_| {});
+        assert!(state.is_open());
+        state.close(|_| {});
+        assert!(!state.is_open());
+    }
+
+    #[test]
+    fn controlled_drawer_emits_intents_without_mutating_state() {
+        let mut state = DrawerState::new(
+            false,
+            ControlStrategy::Controlled,
+            DrawerVariant::Modal,
+            DrawerAnchor::End,
+        );
+        let mut last = None;
+        state.toggle(|open| last = Some(open));
+        assert_eq!(state.is_open(), false);
+        assert_eq!(last, Some(true));
+        state.sync_open(true);
+        assert!(state.is_open());
+    }
+
+    #[test]
+    fn surface_builder_emits_expected_attributes() {
+        let state = DrawerState::new(
+            true,
+            ControlStrategy::Uncontrolled,
+            DrawerVariant::Modal,
+            DrawerAnchor::Bottom,
+        );
+        let attrs = state
+            .surface_attributes()
+            .id("drawer")
+            .labelled_by("drawer-title")
+            .described_by("drawer-description");
+        assert_eq!(attrs.role(), "dialog");
+        assert_eq!(attrs.aria_modal(), ("aria-modal", "true"));
+        assert_eq!(attrs.id_attr(), Some(("id", "drawer")));
+        assert_eq!(
+            attrs.aria_labelledby(),
+            Some(("aria-labelledby", "drawer-title"))
+        );
+        assert_eq!(
+            attrs.aria_describedby(),
+            Some(("aria-describedby", "drawer-description"))
+        );
+        assert_eq!(attrs.data_anchor(), ("data-anchor", "bottom"));
+    }
+
+    #[test]
+    fn backdrop_visibility_tracks_variant() {
+        let modal = DrawerState::new(
+            true,
+            ControlStrategy::Uncontrolled,
+            DrawerVariant::Modal,
+            DrawerAnchor::Start,
+        );
+        assert!(modal.backdrop_attributes().is_visible());
+
+        let persistent = DrawerState::new(
+            true,
+            ControlStrategy::Uncontrolled,
+            DrawerVariant::Persistent,
+            DrawerAnchor::End,
+        );
+        assert!(!persistent.backdrop_attributes().is_visible());
+    }
+}

--- a/crates/mui-headless/src/lib.rs
+++ b/crates/mui-headless/src/lib.rs
@@ -11,12 +11,16 @@
 pub mod aria;
 pub mod button;
 pub mod checkbox;
+pub mod drawer;
 pub mod interaction;
 pub mod list;
 pub mod menu;
 pub mod radio;
 pub mod select;
 pub mod switch;
+pub mod tab;
+pub mod tab_panel;
+pub mod tabs;
 
 mod selection;
 mod toggle;

--- a/crates/mui-headless/src/tab.rs
+++ b/crates/mui-headless/src/tab.rs
@@ -1,0 +1,121 @@
+//! Attribute helpers for individual tabs.
+//!
+//! The builder centralizes ARIA bookkeeping and provides convenient helpers so
+//! adapters can focus on rendering logic instead of remembering every required
+//! attribute pair.  The code intentionally includes detailed notes to outline
+//! the expectations from WAI-ARIA Authoring Practices for future maintainers.
+
+use crate::aria;
+use crate::tabs::TabsState;
+
+/// Builder exposing ergonomic helpers for wiring tab elements.
+#[derive(Debug, Clone)]
+pub struct TabAttributes<'a> {
+    state: &'a TabsState,
+    index: usize,
+    id: Option<&'a str>,
+    controls: Option<&'a str>,
+}
+
+impl<'a> TabAttributes<'a> {
+    /// Create a new tab attribute builder for the provided state/index pair.
+    #[inline]
+    pub fn new(state: &'a TabsState, index: usize) -> Self {
+        Self {
+            state,
+            index,
+            id: None,
+            controls: None,
+        }
+    }
+
+    /// Attach an `id` attribute to the tab.  This is typically used to link the
+    /// tab panel via `aria-labelledby`.
+    #[inline]
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Link the tab with its panel using `aria-controls`.
+    #[inline]
+    pub fn controls(mut self, value: &'a str) -> Self {
+        self.controls = Some(value);
+        self
+    }
+
+    /// Returns the ARIA role for the tab element.
+    #[inline]
+    pub fn role(&self) -> &'static str {
+        aria::role_tab()
+    }
+
+    /// Returns the `id` attribute tuple when configured.
+    #[inline]
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Returns the `aria-controls` tuple when configured.
+    #[inline]
+    pub fn aria_controls(&self) -> Option<(&'static str, &str)> {
+        self.controls.map(aria::aria_controls)
+    }
+
+    /// Returns the `aria-selected` tuple reflecting whether the tab is active.
+    #[inline]
+    pub fn aria_selected(&self) -> (&'static str, &'static str) {
+        aria::aria_selected(self.state.is_selected(self.index))
+    }
+
+    /// Returns the recommended `tabindex` tuple implementing the roving
+    /// tabindex pattern.  The focused tab is tabbable while all others are
+    /// removed from the natural tab order.
+    #[inline]
+    pub fn tabindex(&self) -> (&'static str, &'static str) {
+        if self.state.is_focused(self.index) {
+            ("tabindex", "0")
+        } else {
+            ("tabindex", "-1")
+        }
+    }
+
+    /// Convenience getter to expose whether the tab is currently focused.
+    #[inline]
+    pub fn is_focused(&self) -> bool {
+        self.state.is_focused(self.index)
+    }
+
+    /// Convenience getter to expose whether the tab is selected.
+    #[inline]
+    pub fn is_selected(&self) -> bool {
+        self.state.is_selected(self.index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selection::ControlStrategy;
+    use crate::tabs::{ActivationMode, TabsOrientation};
+
+    #[test]
+    fn builder_reports_selected_and_focused_state() {
+        let state = TabsState::new(
+            2,
+            Some(1),
+            ActivationMode::Automatic,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let attrs = state.tab(1).id("tab-1").controls("panel-1");
+        assert_eq!(attrs.role(), "tab");
+        assert_eq!(attrs.id_attr(), Some(("id", "tab-1")));
+        assert_eq!(attrs.aria_controls(), Some(("aria-controls", "panel-1")));
+        assert_eq!(attrs.aria_selected(), ("aria-selected", "true"));
+        assert_eq!(attrs.tabindex(), ("tabindex", "0"));
+        assert!(attrs.is_selected());
+        assert!(attrs.is_focused());
+    }
+}

--- a/crates/mui-headless/src/tab_panel.rs
+++ b/crates/mui-headless/src/tab_panel.rs
@@ -1,0 +1,98 @@
+//! Attribute helpers for tab panels.
+//!
+//! Panels mirror the tab attributes builder so adapters can declaratively wire
+//! both sides of the relationship.  Keeping the helpers colocated makes it easy
+//! to audit accessibility requirements while expanding the primitive.
+
+use crate::aria;
+use crate::tabs::TabsState;
+
+/// Builder exposing ergonomic helpers for wiring tab panel elements.
+#[derive(Debug, Clone)]
+pub struct TabPanelAttributes<'a> {
+    state: &'a TabsState,
+    index: usize,
+    id: Option<&'a str>,
+    labelled_by: Option<&'a str>,
+}
+
+impl<'a> TabPanelAttributes<'a> {
+    /// Create a new builder instance for the provided panel index.
+    #[inline]
+    pub fn new(state: &'a TabsState, index: usize) -> Self {
+        Self {
+            state,
+            index,
+            id: None,
+            labelled_by: None,
+        }
+    }
+
+    /// Attach an `id` attribute to the panel so tabs can reference it via
+    /// `aria-controls`.
+    #[inline]
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Link the panel to its controlling tab using `aria-labelledby`.
+    #[inline]
+    pub fn labelled_by(mut self, value: &'a str) -> Self {
+        self.labelled_by = Some(value);
+        self
+    }
+
+    /// Returns the ARIA role for the tab panel element.
+    #[inline]
+    pub fn role(&self) -> &'static str {
+        aria::role_tabpanel()
+    }
+
+    /// Returns the `id` attribute tuple when configured.
+    #[inline]
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Returns the `aria-labelledby` tuple when configured.
+    #[inline]
+    pub fn aria_labelledby(&self) -> Option<(&'static str, &str)> {
+        self.labelled_by.map(aria::aria_labelledby)
+    }
+
+    /// Returns whether the panel should be hidden from assistive tech.  The
+    /// builder emits the boolean hidden attribute which DOM adapters can apply
+    /// as-is or convert into framework specific properties.
+    #[inline]
+    pub fn hidden(&self) -> Option<(&'static str, &'static str)> {
+        if self.state.is_selected(self.index) {
+            None
+        } else {
+            Some(("hidden", "true"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selection::ControlStrategy;
+    use crate::tabs::{ActivationMode, TabsOrientation};
+
+    #[test]
+    fn builder_marks_non_active_panels_hidden() {
+        let state = TabsState::new(
+            2,
+            Some(0),
+            ActivationMode::Automatic,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let hidden = state.panel(1).hidden();
+        assert_eq!(hidden, Some(("hidden", "true")));
+        let visible = state.panel(0).hidden();
+        assert_eq!(visible, None);
+    }
+}

--- a/crates/mui-headless/src/tabs.rs
+++ b/crates/mui-headless/src/tabs.rs
@@ -1,0 +1,516 @@
+//! State machine powering headless tab interfaces.
+//!
+//! The implementation builds on top of the shared [`selection`] and
+//! [`interaction`] utilities to provide orientation aware keyboard handling,
+//! manual vs. automatic activation and ergonomic attribute builders for
+//! framework adapters.  The goal is to make writing a production grade tab
+//! implementation trivial: adapters only need to forward DOM events and wire up
+//! identifiers while the state machine takes care of accessibility and
+//! scalability concerns.
+
+use crate::aria;
+use crate::interaction::ControlKey;
+use crate::selection::{clamp_index, wrap_index, ControlStrategy};
+
+/// Determines how keyboard navigation affects the selected tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationMode {
+    /// Manual activation keeps selection stable while roving focus moves.  The
+    /// user must press <Space> or <Enter> (or use pointer input) to activate a
+    /// tab.  This mirrors the default behaviour described by the WAI-ARIA
+    /// Authoring Practices and matches how complex enterprise applications
+    /// prefer to defer activation.
+    Manual,
+    /// Automatic activation commits selection immediately whenever focus moves.
+    /// This is the ergonomics focused mode popular in consumer UI libraries.
+    Automatic,
+}
+
+impl ActivationMode {
+    #[inline]
+    fn is_automatic(self) -> bool {
+        matches!(self, Self::Automatic)
+    }
+}
+
+/// Orientation of the tab list which controls arrow key semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TabsOrientation {
+    /// Horizontal tablists respond to left/right keys.
+    Horizontal,
+    /// Vertical tablists respond to up/down keys.
+    Vertical,
+}
+
+impl TabsOrientation {
+    /// Returns the ARIA string describing the orientation.
+    #[inline]
+    pub const fn as_aria(self) -> &'static str {
+        match self {
+            Self::Horizontal => "horizontal",
+            Self::Vertical => "vertical",
+        }
+    }
+
+    /// Returns whether a key represents forward movement for this orientation.
+    #[inline]
+    fn is_forward(self, key: ControlKey) -> bool {
+        matches!(
+            (self, key),
+            (Self::Horizontal, ControlKey::ArrowRight) | (Self::Vertical, ControlKey::ArrowDown)
+        )
+    }
+
+    /// Returns whether a key represents backward movement for this orientation.
+    #[inline]
+    fn is_backward(self, key: ControlKey) -> bool {
+        matches!(
+            (self, key),
+            (Self::Horizontal, ControlKey::ArrowLeft) | (Self::Vertical, ControlKey::ArrowUp)
+        )
+    }
+}
+
+/// Captures the outcome of processing a keyboard event.  Adapters can inspect
+/// the fields to drive DOM side-effects such as scrolling the focused tab into
+/// view or updating controlled selection state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TabKeyboardOutcome {
+    /// The tab index that should receive focus after handling the key.
+    pub focused: Option<usize>,
+    /// The tab index that should be considered selected/active.
+    pub selected: Option<usize>,
+}
+
+/// Builder for tablist ARIA attributes.  Reusing the builder from adapters keeps
+/// stringly typed attribute names centralized and documented.
+#[derive(Debug, Clone)]
+pub struct TabListAttributes<'a> {
+    orientation: TabsOrientation,
+    id: Option<&'a str>,
+    labelled_by: Option<&'a str>,
+}
+
+impl<'a> TabListAttributes<'a> {
+    /// Construct a new builder instance.
+    #[inline]
+    pub fn new(state: &'a TabsState) -> Self {
+        Self {
+            orientation: state.orientation,
+            id: None,
+            labelled_by: None,
+        }
+    }
+
+    /// Assign an ID to the tablist element.
+    #[inline]
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Link the tablist to a labelling element via `aria-labelledby`.
+    #[inline]
+    pub fn labelled_by(mut self, value: &'a str) -> Self {
+        self.labelled_by = Some(value);
+        self
+    }
+
+    /// Returns the `role="tablist"` tuple.
+    #[inline]
+    pub fn role(&self) -> &'static str {
+        aria::role_tablist()
+    }
+
+    /// Returns the `aria-orientation` tuple.
+    #[inline]
+    pub fn orientation(&self) -> (&'static str, &'static str) {
+        aria::aria_orientation(self.orientation.as_aria())
+    }
+
+    /// Returns the `id` tuple when configured.
+    #[inline]
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Returns the `aria-labelledby` tuple when configured.
+    #[inline]
+    pub fn labelledby(&self) -> Option<(&'static str, &str)> {
+        self.labelled_by.map(aria::aria_labelledby)
+    }
+}
+
+/// Headless tab state machine.
+#[derive(Debug, Clone)]
+pub struct TabsState {
+    pub(crate) tab_count: usize,
+    pub(crate) selected: Option<usize>,
+    pub(crate) focused: Option<usize>,
+    pub(crate) activation: ActivationMode,
+    pub(crate) orientation: TabsOrientation,
+    selection_mode: ControlStrategy,
+    focus_mode: ControlStrategy,
+}
+
+impl TabsState {
+    /// Create a new tab state instance.
+    ///
+    /// * `tab_count` — number of tabs currently rendered.
+    /// * `initial_selected` — index of the initially selected tab.
+    /// * `activation` — whether selection follows focus automatically.
+    /// * `orientation` — axis along which arrow keys move focus.
+    /// * `selection_mode` — describes if the selected tab is externally
+    ///   controlled.
+    /// * `focus_mode` — describes if the focused tab (roving tabindex) is
+    ///   controlled.
+    pub fn new(
+        tab_count: usize,
+        initial_selected: Option<usize>,
+        activation: ActivationMode,
+        orientation: TabsOrientation,
+        selection_mode: ControlStrategy,
+        focus_mode: ControlStrategy,
+    ) -> Self {
+        let selected = clamp_index(initial_selected, tab_count);
+        let focused = selected.or_else(|| if tab_count > 0 { Some(0) } else { None });
+        Self {
+            tab_count,
+            selected,
+            focused,
+            activation,
+            orientation,
+            selection_mode,
+            focus_mode,
+        }
+    }
+
+    /// Returns the activation mode currently configured.
+    #[inline]
+    pub fn activation_mode(&self) -> ActivationMode {
+        self.activation
+    }
+
+    /// Returns the tablist orientation.
+    #[inline]
+    pub fn orientation(&self) -> TabsOrientation {
+        self.orientation
+    }
+
+    /// Returns the number of registered tabs.
+    #[inline]
+    pub fn tab_count(&self) -> usize {
+        self.tab_count
+    }
+
+    /// Returns the selected tab index.
+    #[inline]
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Returns the focused tab index (roving tabindex owner).
+    #[inline]
+    pub fn focused(&self) -> Option<usize> {
+        self.focused
+    }
+
+    /// Returns whether the provided index is currently selected.
+    #[inline]
+    pub fn is_selected(&self, index: usize) -> bool {
+        self.selected == Some(index)
+    }
+
+    /// Returns whether the provided index currently owns focus.
+    #[inline]
+    pub fn is_focused(&self, index: usize) -> bool {
+        self.focused == Some(index)
+    }
+
+    /// Update the number of tabs rendered and clamp state to the new bounds.
+    pub fn set_tab_count(&mut self, count: usize) {
+        self.tab_count = count;
+        self.selected = clamp_index(self.selected, count);
+        self.focused = if self.focus_mode.is_controlled() {
+            clamp_index(self.focused, count)
+        } else {
+            clamp_index(self.focused, count)
+                .or(self.selected)
+                .or_else(|| if count > 0 { Some(0) } else { None })
+        };
+    }
+
+    /// Synchronize the selected tab when controlled externally.
+    pub fn sync_selected(&mut self, selected: Option<usize>) {
+        self.selected = clamp_index(selected, self.tab_count);
+        if !self.focus_mode.is_controlled() {
+            if let Some(index) = self.selected {
+                self.focused = Some(index);
+            } else {
+                self.focused = clamp_index(self.focused, self.tab_count).or_else(|| {
+                    if self.tab_count > 0 {
+                        Some(0)
+                    } else {
+                        None
+                    }
+                });
+            }
+        }
+    }
+
+    /// Synchronize the focused tab when the roving tabindex is controlled.
+    pub fn sync_focused(&mut self, focused: Option<usize>) {
+        if self.focus_mode.is_controlled() {
+            self.focused = clamp_index(focused, self.tab_count);
+        }
+    }
+
+    /// Imperatively focus the provided tab (uncontrolled focus mode).
+    pub fn set_focused(&mut self, focused: Option<usize>) {
+        if !self.focus_mode.is_controlled() {
+            self.focused = clamp_index(focused, self.tab_count);
+        }
+    }
+
+    /// Activate the provided tab index, invoking the supplied callback.
+    pub fn select<F: FnMut(usize)>(&mut self, index: usize, mut on_select: F) {
+        if index >= self.tab_count {
+            return;
+        }
+        if !self.focus_mode.is_controlled() {
+            self.focused = Some(index);
+        }
+        if !self.selection_mode.is_controlled() {
+            self.selected = Some(index);
+        }
+        on_select(index);
+    }
+
+    /// Activate the currently focused tab when present.
+    pub fn select_focused<F: FnMut(usize)>(&mut self, on_select: F) {
+        if let Some(index) = self.focused {
+            self.select(index, on_select);
+        }
+    }
+
+    /// Process a keyboard control key returning the resulting focus/selection.
+    pub fn on_key<F: FnMut(usize)>(
+        &mut self,
+        key: ControlKey,
+        mut on_select: F,
+    ) -> TabKeyboardOutcome {
+        let mut outcome = TabKeyboardOutcome::default();
+        match key {
+            ControlKey::Enter | ControlKey::Space => {
+                if let Some(index) = self.focused {
+                    if index < self.tab_count {
+                        self.select(index, &mut on_select);
+                        outcome.focused = Some(index);
+                        outcome.selected = Some(index);
+                    }
+                }
+            }
+            ControlKey::Home => {
+                if self.tab_count > 0 {
+                    let next = Some(0);
+                    outcome.focused = self.apply_focus(next);
+                    if self.activation.is_automatic() {
+                        outcome.selected = outcome.focused.map(|index| {
+                            self.apply_selection(index, &mut on_select);
+                            index
+                        });
+                    }
+                }
+            }
+            ControlKey::End => {
+                if self.tab_count > 0 {
+                    let next = Some(self.tab_count - 1);
+                    outcome.focused = self.apply_focus(next);
+                    if self.activation.is_automatic() {
+                        outcome.selected = outcome.focused.map(|index| {
+                            self.apply_selection(index, &mut on_select);
+                            index
+                        });
+                    }
+                }
+            }
+            _ if self.orientation.is_forward(key) => {
+                if self.tab_count > 0 {
+                    self.ensure_focus();
+                    let next = wrap_index(self.focused, 1, self.tab_count);
+                    outcome.focused = self.apply_focus(next);
+                    if self.activation.is_automatic() {
+                        outcome.selected = outcome.focused.map(|index| {
+                            self.apply_selection(index, &mut on_select);
+                            index
+                        });
+                    }
+                }
+            }
+            _ if self.orientation.is_backward(key) => {
+                if self.tab_count > 0 {
+                    self.ensure_focus();
+                    let next = wrap_index(self.focused, -1, self.tab_count);
+                    outcome.focused = self.apply_focus(next);
+                    if self.activation.is_automatic() {
+                        outcome.selected = outcome.focused.map(|index| {
+                            self.apply_selection(index, &mut on_select);
+                            index
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+        outcome
+    }
+
+    /// Returns a builder for tablist attributes.
+    #[inline]
+    pub fn list_attributes(&self) -> TabListAttributes<'_> {
+        TabListAttributes::new(self)
+    }
+
+    /// Returns a builder for tab attributes.
+    #[inline]
+    pub fn tab(&self, index: usize) -> crate::tab::TabAttributes<'_> {
+        crate::tab::TabAttributes::new(self, index)
+    }
+
+    /// Returns a builder for tab panel attributes.
+    #[inline]
+    pub fn panel(&self, index: usize) -> crate::tab_panel::TabPanelAttributes<'_> {
+        crate::tab_panel::TabPanelAttributes::new(self, index)
+    }
+
+    fn ensure_focus(&mut self) {
+        if self.tab_count == 0 {
+            self.focused = None;
+            return;
+        }
+        if self.focus_mode.is_controlled() {
+            self.focused = clamp_index(self.focused, self.tab_count);
+        } else {
+            self.focused = clamp_index(self.focused, self.tab_count)
+                .or(self.selected)
+                .or(Some(0));
+        }
+    }
+
+    fn apply_focus(&mut self, next: Option<usize>) -> Option<usize> {
+        let next = clamp_index(next, self.tab_count);
+        if !self.focus_mode.is_controlled() {
+            self.focused = next;
+        }
+        next
+    }
+
+    fn apply_selection<F: FnMut(usize)>(&mut self, index: usize, on_select: &mut F) {
+        if !self.selection_mode.is_controlled() {
+            self.selected = Some(index);
+        }
+        if !self.focus_mode.is_controlled() {
+            self.focused = Some(index);
+        }
+        on_select(index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selection::ControlStrategy;
+
+    #[test]
+    fn automatic_activation_selects_on_arrow_navigation() {
+        let mut state = TabsState::new(
+            3,
+            Some(0),
+            ActivationMode::Automatic,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let mut selected = Vec::new();
+        state.on_key(ControlKey::ArrowRight, |index| selected.push(index));
+        assert_eq!(state.selected(), Some(1));
+        assert_eq!(state.focused(), Some(1));
+        assert_eq!(selected, vec![1]);
+    }
+
+    #[test]
+    fn manual_activation_defers_selection_until_explicit_request() {
+        let mut state = TabsState::new(
+            3,
+            Some(0),
+            ActivationMode::Manual,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let mut selected = Vec::new();
+        let outcome = state.on_key(ControlKey::ArrowRight, |index| selected.push(index));
+        assert_eq!(state.selected(), Some(0));
+        assert_eq!(state.focused(), Some(1));
+        assert_eq!(outcome.selected, None);
+        assert!(selected.is_empty());
+
+        state.on_key(ControlKey::Space, |index| selected.push(index));
+        assert_eq!(state.selected(), Some(1));
+        assert_eq!(selected, vec![1]);
+    }
+
+    #[test]
+    fn orientation_switches_arrow_key_mapping() {
+        let mut state = TabsState::new(
+            4,
+            Some(2),
+            ActivationMode::Automatic,
+            TabsOrientation::Vertical,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let mut selected = Vec::new();
+        state.on_key(ControlKey::ArrowDown, |index| selected.push(index));
+        assert_eq!(state.selected(), Some(3));
+        state.on_key(ControlKey::ArrowUp, |index| selected.push(index));
+        assert_eq!(state.selected(), Some(2));
+        assert_eq!(selected, vec![3, 2]);
+    }
+
+    #[test]
+    fn controlled_focus_returns_intent_without_mutating_internal_state() {
+        let mut state = TabsState::new(
+            3,
+            Some(0),
+            ActivationMode::Manual,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Controlled,
+        );
+        let mut selected = Vec::new();
+        let outcome = state.on_key(ControlKey::ArrowRight, |index| selected.push(index));
+        assert_eq!(state.focused(), Some(0));
+        assert_eq!(outcome.focused, Some(1));
+        assert!(selected.is_empty());
+        state.sync_focused(outcome.focused);
+        assert_eq!(state.focused(), Some(1));
+    }
+
+    #[test]
+    fn tablist_attribute_builder_exposes_expected_pairs() {
+        let state = TabsState::new(
+            2,
+            Some(0),
+            ActivationMode::Automatic,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let attrs = state.list_attributes().id("tabs").labelled_by("tabs-label");
+        assert_eq!(attrs.role(), "tablist");
+        assert_eq!(attrs.orientation(), ("aria-orientation", "horizontal"));
+        assert_eq!(attrs.id_attr(), Some(("id", "tabs")));
+        assert_eq!(attrs.labelledby(), Some(("aria-labelledby", "tabs-label")));
+    }
+}


### PR DESCRIPTION
## Summary
- add a tabs state machine with manual/automatic activation, orientation-aware navigation and attribute builders
- introduce tab and tab panel helpers to centralize WAI-ARIA wiring for adapters
- provide a drawer state machine with anchor/variant metadata and modal-friendly attribute builders

## Testing
- cargo test -p mui-headless

------
https://chatgpt.com/codex/tasks/task_e_68cde458c988832ea5b4df1260c51c81