### PR TITLE
Expose tabs primitives and add regression coverage

### DIFF
--- a/crates/mui-headless/src/drawer.rs
+++ b/crates/mui-headless/src/drawer.rs
@@ -330,4 +330,21 @@ mod tests {
         );
         assert!(!persistent.backdrop_attributes().is_visible());
     }
+
+    #[test]
+    fn persistent_drawer_surface_marks_modal_false() {
+        // Persistent drawers remain interactive with the page so `aria-modal`
+        // should announce the lack of modality.  We still expose the dialog role
+        // for consistent semantics across variants.
+        let state = DrawerState::new(
+            false,
+            ControlStrategy::Uncontrolled,
+            DrawerVariant::Persistent,
+            DrawerAnchor::Top,
+        );
+        let attrs = state.surface_attributes();
+        assert_eq!(attrs.role(), "dialog");
+        assert_eq!(attrs.aria_modal(), ("aria-modal", "false"));
+        assert_eq!(attrs.data_anchor(), ("data-anchor", "top"));
+    }
 }

--- a/crates/mui-headless/src/lib.rs
+++ b/crates/mui-headless/src/lib.rs
@@ -5,8 +5,11 @@
 //! higher level crates which consume these primitives.  Beyond the existing
 //! [`button`] machine, the crate now ships specialized state for selection
 //! controls – [`checkbox`], [`radio`] and [`switch`] – along with data display
-//! helpers such as [`list`] and [`menu`]. The [`interaction`] primitives expose
-//! keyboard orchestration shared across each state machine.
+//! helpers such as [`list`], [`menu`] and the accessible [`tabs`] family which
+//! includes [`tab`] and [`tab_panel`] attribute builders.  Layout driven
+//! components such as [`drawer`] also reuse the centralized accessibility
+//! primitives.  The [`interaction`] primitives expose keyboard orchestration
+//! shared across each state machine.
 
 pub mod aria;
 pub mod button;

--- a/crates/mui-headless/src/tab.rs
+++ b/crates/mui-headless/src/tab.rs
@@ -118,4 +118,25 @@ mod tests {
         assert!(attrs.is_selected());
         assert!(attrs.is_focused());
     }
+
+    #[test]
+    fn builder_reflects_inactive_tab_state() {
+        // Secondary tabs should stay untabbable until navigation reaches them
+        // so screen reader users do not land on hidden panels accidentally.
+        let state = TabsState::new(
+            3,
+            Some(0),
+            ActivationMode::Manual,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let attrs = state.tab(2);
+        assert_eq!(attrs.aria_selected(), ("aria-selected", "false"));
+        assert_eq!(attrs.tabindex(), ("tabindex", "-1"));
+        assert!(!attrs.is_selected());
+        assert!(!attrs.is_focused());
+        assert_eq!(attrs.id_attr(), None);
+        assert_eq!(attrs.aria_controls(), None);
+    }
 }

--- a/crates/mui-headless/src/tab_panel.rs
+++ b/crates/mui-headless/src/tab_panel.rs
@@ -95,4 +95,23 @@ mod tests {
         let visible = state.panel(0).hidden();
         assert_eq!(visible, None);
     }
+
+    #[test]
+    fn builder_emits_label_and_identity_attributes() {
+        // Attribute builders must centralize ARIA wiring so frameworks do not
+        // duplicate knowledge about the correct IDs.
+        let state = TabsState::new(
+            2,
+            Some(1),
+            ActivationMode::Manual,
+            TabsOrientation::Horizontal,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        let attrs = state.panel(1).id("panel-1").labelled_by("tab-1");
+        assert_eq!(attrs.role(), "tabpanel");
+        assert_eq!(attrs.id_attr(), Some(("id", "panel-1")));
+        assert_eq!(attrs.aria_labelledby(), Some(("aria-labelledby", "tab-1")));
+        assert_eq!(attrs.hidden(), None);
+    }
 }


### PR DESCRIPTION
## Summary
- document the new headless tabs, tab, tab_panel, and drawer primitives in the public module docs
- expand the tabs state machine to use tighter option handling and exercise controlled/uncontrolled flows, focus management, orientation changes, and wrap behaviour through new unit tests
- extend the tab, tab_panel, and drawer attribute builders with additional ARIA-focused regression tests, including persistent drawer semantics

## Testing
- `cargo fmt`
- `cargo test`
- `cargo test -p mui-headless --lib`
- `cargo clippy -p mui-headless --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_68cdf2bb78ec832e9bc9130e3114cfc0