### PR TITLE
Add responsive tabs and drawer adapters across frameworks

### DIFF
--- a/crates/mui-material/src/drawer.rs
+++ b/crates/mui-material/src/drawer.rs
@@ -9,9 +9,142 @@
 //! Yew/Leptos/Dioxus/Sycamore without forcing each team to juggle bespoke CSS.
 
 use mui_headless::drawer::{
-    DrawerBackdropAttributes, DrawerState, DrawerSurfaceAttributes, DrawerVariant,
+    DrawerAnchor, DrawerBackdropAttributes, DrawerState, DrawerSurfaceAttributes, DrawerVariant,
 };
 use mui_styled_engine::{css_with_theme, Style};
+use mui_system::{
+    r#box::{build_box_style, BoxStyleInputs},
+    responsive::{viewport_width, Responsive},
+    theme::Theme,
+};
+
+/// Shared configuration describing how the drawer should react to viewport
+/// changes. The options are kept framework agnostic so Yew, Leptos, Sycamore,
+/// Dioxus and React adapters can all lean on the same responsive wiring.
+#[derive(Clone, Debug)]
+pub struct DrawerLayoutOptions {
+    /// Responsive anchor declaration. Persistent navigation often slides from
+    /// the leading edge on mobile but transitions to a top anchored sheet on
+    /// larger screens. Expressing that behaviour via [`Responsive`] keeps the
+    /// logic declarative.
+    pub anchor: Responsive<DrawerAnchor>,
+    /// Responsive size expressed as a spacing multiplier. For start/end anchors
+    /// the value controls the width while top/bottom anchors reuse it for
+    /// height. Leveraging spacing units ensures theme updates propagate without
+    /// touching component code.
+    pub size: Responsive<u16>,
+    /// Responsive padding around the drawer contents, also expressed as spacing
+    /// multipliers to align with the system scale.
+    pub padding: Responsive<u16>,
+}
+
+impl Default for DrawerLayoutOptions {
+    fn default() -> Self {
+        Self {
+            anchor: Responsive::constant(DrawerAnchor::Start),
+            size: Responsive {
+                xs: 40,
+                sm: Some(48),
+                md: None,
+                lg: Some(56),
+                xl: Some(56),
+            },
+            padding: Responsive {
+                xs: 2,
+                sm: Some(3),
+                md: None,
+                lg: Some(4),
+                xl: Some(4),
+            },
+        }
+    }
+}
+
+impl DrawerLayoutOptions {
+    /// Resolve the configured anchor for the provided viewport width.
+    #[must_use]
+    pub fn resolve_anchor(&self, theme: &Theme, viewport: u32) -> DrawerAnchor {
+        self.anchor.resolve(viewport, &theme.breakpoints)
+    }
+
+    fn spacing_to_css(&self, theme: &Theme) -> Responsive<String> {
+        Responsive {
+            xs: format!("{}px", theme.spacing(self.size.xs)),
+            sm: self
+                .size
+                .sm
+                .map(|value| format!("{}px", theme.spacing(value))),
+            md: self
+                .size
+                .md
+                .map(|value| format!("{}px", theme.spacing(value))),
+            lg: self
+                .size
+                .lg
+                .map(|value| format!("{}px", theme.spacing(value))),
+            xl: self
+                .size
+                .xl
+                .map(|value| format!("{}px", theme.spacing(value))),
+        }
+    }
+
+    fn padding_to_css(&self, theme: &Theme) -> Responsive<String> {
+        Responsive {
+            xs: format!("{}px", theme.spacing(self.padding.xs)),
+            sm: self
+                .padding
+                .sm
+                .map(|value| format!("{}px", theme.spacing(value))),
+            md: self
+                .padding
+                .md
+                .map(|value| format!("{}px", theme.spacing(value))),
+            lg: self
+                .padding
+                .lg
+                .map(|value| format!("{}px", theme.spacing(value))),
+            xl: self
+                .padding
+                .xl
+                .map(|value| format!("{}px", theme.spacing(value))),
+        }
+    }
+}
+
+/// Result returned by the drawer adapters. We expose both the surface markup
+/// and optional backdrop so integrators can slot them into portals or render the
+/// elements inline depending on their UX requirements.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DrawerRenderResult {
+    /// Serialized drawer surface.
+    pub surface: String,
+    /// Optional serialized backdrop depending on the configured variant.
+    pub backdrop: Option<String>,
+}
+
+/// Shared props consumed by every framework adapter.
+#[derive(Clone, Debug)]
+pub struct DrawerProps<'a> {
+    /// Drawer state machine provided by `mui-headless`.
+    pub state: &'a DrawerState,
+    /// Attribute builder for the drawer surface.
+    pub surface: DrawerSurfaceAttributes<'a>,
+    /// Attribute builder for the drawer backdrop.
+    pub backdrop: DrawerBackdropAttributes<'a>,
+    /// Serialized drawer body.
+    pub body: &'a str,
+    /// Layout behaviour shared across adapters.
+    pub layout: &'a DrawerLayoutOptions,
+    /// Active theme driving spacing and breakpoint resolution.
+    pub theme: &'a Theme,
+    /// Optional viewport width override for deterministic snapshot tests.
+    pub viewport: Option<u32>,
+    /// Optional event channel identifier surfaced via `data-on-toggle` so
+    /// enterprise orchestration layers can listen to drawer visibility changes
+    /// without diverging adapter implementations.
+    pub on_toggle_event: Option<&'a str>,
+}
 
 /// Convert surface attributes into key/value pairs enriched with automation
 /// hints.
@@ -191,6 +324,175 @@ fn drawer_backdrop_style() -> Style {
     "#,
         scrim = theme.palette.text_primary.clone(),
     )
+}
+
+struct DrawerRenderParams<'a> {
+    state: &'a DrawerState,
+    surface: DrawerSurfaceAttributes<'a>,
+    backdrop: DrawerBackdropAttributes<'a>,
+    body: &'a str,
+    layout: &'a DrawerLayoutOptions,
+    theme: &'a Theme,
+    viewport: u32,
+    on_toggle_event: Option<&'a str>,
+}
+
+impl<'a> From<DrawerProps<'a>> for DrawerRenderParams<'a> {
+    fn from(props: DrawerProps<'a>) -> Self {
+        Self {
+            state: props.state,
+            surface: props.surface,
+            backdrop: props.backdrop,
+            body: props.body,
+            layout: props.layout,
+            theme: props.theme,
+            viewport: props.viewport.unwrap_or_else(viewport_width),
+            on_toggle_event: props.on_toggle_event,
+        }
+    }
+}
+
+fn render_drawer(params: DrawerRenderParams<'_>) -> DrawerRenderResult {
+    let anchor = params.layout.resolve_anchor(params.theme, params.viewport);
+    debug_assert_eq!(
+        params.state.anchor(),
+        anchor,
+        "DrawerState anchor should align with responsive layout",
+    );
+
+    let size_css = params.layout.spacing_to_css(params.theme);
+    let padding_css = params.layout.padding_to_css(params.theme);
+    let position = Responsive::constant("fixed".to_string());
+    let zero_top = Responsive::constant("0".to_string());
+    let zero_bottom = Responsive::constant("0".to_string());
+    let zero_lr = Responsive::constant("0".to_string());
+    let full_height = Responsive::constant("100%".to_string());
+    let full_width = Responsive::constant("100%".to_string());
+
+    let mut inputs = BoxStyleInputs {
+        margin: None,
+        padding: Some(&padding_css),
+        font_size: None,
+        font_weight: None,
+        line_height: None,
+        letter_spacing: None,
+        color: None,
+        background_color: None,
+        width: None,
+        height: Some(&full_height),
+        min_width: None,
+        max_width: None,
+        min_height: None,
+        max_height: None,
+        position: Some(&position),
+        top: Some(&zero_top),
+        right: None,
+        bottom: Some(&zero_bottom),
+        left: None,
+        display: Some("flex"),
+        align_items: Some("stretch"),
+        justify_content: Some("flex-start"),
+        sx: None,
+    };
+
+    match anchor {
+        DrawerAnchor::Start => {
+            inputs.width = Some(&size_css);
+            inputs.left = Some(&zero_lr);
+        }
+        DrawerAnchor::End => {
+            inputs.width = Some(&size_css);
+            inputs.right = Some(&zero_lr);
+        }
+        DrawerAnchor::Top => {
+            inputs.height = Some(&size_css);
+            inputs.width = Some(&full_width);
+            inputs.left = Some(&zero_lr);
+            inputs.right = Some(&zero_lr);
+            inputs.bottom = None;
+        }
+        DrawerAnchor::Bottom => {
+            inputs.height = Some(&size_css);
+            inputs.width = Some(&full_width);
+            inputs.left = Some(&zero_lr);
+            inputs.right = Some(&zero_lr);
+            inputs.top = None;
+        }
+    }
+
+    let container_css = build_box_style(params.viewport, &params.theme.breakpoints, inputs);
+    let container_style =
+        Style::new(container_css).expect("mui-system box builder should emit valid CSS");
+    let surface_html = render_drawer_surface_html(params.state, params.surface, params.body);
+
+    let mut outer_attrs = Vec::with_capacity(1);
+    if let Some(event) = params.on_toggle_event {
+        outer_attrs.push(("data-on-toggle".to_string(), event.to_string()));
+    }
+
+    let wrapped_surface = crate::render_helpers::render_element_html(
+        "div",
+        container_style,
+        outer_attrs,
+        &surface_html,
+    );
+    let backdrop = render_drawer_backdrop_html(params.state, params.backdrop);
+
+    DrawerRenderResult {
+        surface: wrapped_surface,
+        backdrop,
+    }
+}
+
+/// Adapter targeting server rendered React experiences.
+pub mod react {
+    use super::*;
+
+    /// Render the drawer surface/backdrop pair into serialized HTML.
+    pub fn render(props: DrawerProps<'_>) -> DrawerRenderResult {
+        super::render_drawer(props.into())
+    }
+}
+
+/// Adapter targeting the [`yew`] framework.  Returns serialized markup so tests
+/// can validate SSR output matches client rendering.
+pub mod yew {
+    use super::*;
+
+    /// Render the drawer surface/backdrop pair into serialized HTML.
+    pub fn render(props: DrawerProps<'_>) -> DrawerRenderResult {
+        super::render_drawer(props.into())
+    }
+}
+
+/// Adapter targeting the [`leptos`] framework.
+pub mod leptos {
+    use super::*;
+
+    /// Render the drawer surface/backdrop pair into serialized HTML.
+    pub fn render(props: DrawerProps<'_>) -> DrawerRenderResult {
+        super::render_drawer(props.into())
+    }
+}
+
+/// Adapter targeting the [`sycamore`] framework.
+pub mod sycamore {
+    use super::*;
+
+    /// Render the drawer surface/backdrop pair into serialized HTML.
+    pub fn render(props: DrawerProps<'_>) -> DrawerRenderResult {
+        super::render_drawer(props.into())
+    }
+}
+
+/// Adapter targeting the [`dioxus`] framework.
+pub mod dioxus {
+    use super::*;
+
+    /// Render the drawer surface/backdrop pair into serialized HTML.
+    pub fn render(props: DrawerProps<'_>) -> DrawerRenderResult {
+        super::render_drawer(props.into())
+    }
 }
 
 #[cfg(test)]

--- a/crates/mui-material/tests/drawer_adapters.rs
+++ b/crates/mui-material/tests/drawer_adapters.rs
@@ -1,0 +1,119 @@
+use mui_headless::drawer::{DrawerAnchor, DrawerState, DrawerVariant};
+use mui_material::drawer::{self, DrawerLayoutOptions, DrawerProps};
+use mui_material::Theme;
+
+fn sample_state(anchor: DrawerAnchor, variant: DrawerVariant) -> DrawerState {
+    DrawerState::new(true, unsafe { std::mem::transmute(1u8) }, variant, anchor)
+}
+
+fn build_props<'a>(
+    state: &'a DrawerState,
+    layout: &'a DrawerLayoutOptions,
+    theme: &'a Theme,
+    viewport: u32,
+) -> DrawerProps<'a> {
+    DrawerProps {
+        state,
+        surface: state.surface_attributes().id("drawer"),
+        backdrop: state.backdrop_attributes(),
+        body: "<nav>Links</nav>",
+        layout,
+        theme,
+        viewport: Some(viewport),
+        on_toggle_event: Some("drawer-toggle"),
+    }
+}
+
+#[test]
+fn react_adapter_wraps_surface_and_backdrop() {
+    let layout = DrawerLayoutOptions::default();
+    let theme = Theme::default();
+    let state = sample_state(DrawerAnchor::Start, DrawerVariant::Modal);
+    let render = drawer::react::render(build_props(&state, &layout, &theme, 640));
+
+    assert!(render.surface.starts_with("<div class=\""));
+    assert!(render.surface.contains("data-on-toggle=\"drawer-toggle\""));
+    assert!(render.surface.contains("data-anchor=\"start\""));
+    assert!(render.backdrop.is_some());
+}
+
+#[test]
+fn react_adapter_resolves_top_anchor_on_large_viewports() {
+    let mut layout = DrawerLayoutOptions::default();
+    layout.anchor.md = Some(DrawerAnchor::Top);
+    layout.anchor.lg = Some(DrawerAnchor::Top);
+    let theme = Theme::default();
+    let state = sample_state(DrawerAnchor::Top, DrawerVariant::Persistent);
+    let render = drawer::react::render(build_props(&state, &layout, &theme, 1280));
+
+    assert!(render.surface.contains("data-anchor=\"top\""));
+    assert!(render.backdrop.is_none());
+}
+
+#[cfg(feature = "yew")]
+mod yew_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = DrawerLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(DrawerAnchor::Start, DrawerVariant::Modal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = drawer::react::render(props.clone());
+        let yew = drawer::yew::render(props);
+        assert_eq!(yew.surface, react.surface);
+        assert_eq!(yew.backdrop, react.backdrop);
+    }
+}
+
+#[cfg(feature = "leptos")]
+mod leptos_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = DrawerLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(DrawerAnchor::Start, DrawerVariant::Modal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = drawer::react::render(props.clone());
+        let leptos = drawer::leptos::render(props);
+        assert_eq!(leptos.surface, react.surface);
+        assert_eq!(leptos.backdrop, react.backdrop);
+    }
+}
+
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = DrawerLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(DrawerAnchor::Start, DrawerVariant::Modal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = drawer::react::render(props.clone());
+        let sycamore = drawer::sycamore::render(props);
+        assert_eq!(sycamore.surface, react.surface);
+        assert_eq!(sycamore.backdrop, react.backdrop);
+    }
+}
+
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = DrawerLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(DrawerAnchor::Start, DrawerVariant::Modal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = drawer::react::render(props.clone());
+        let dioxus = drawer::dioxus::render(props);
+        assert_eq!(dioxus.surface, react.surface);
+        assert_eq!(dioxus.backdrop, react.backdrop);
+    }
+}

--- a/crates/mui-material/tests/tabs_adapters.rs
+++ b/crates/mui-material/tests/tabs_adapters.rs
@@ -1,0 +1,118 @@
+use mui_headless::tabs::{ActivationMode, TabsOrientation, TabsState};
+use mui_material::tabs::{self, TabListLayoutOptions, TabListProps};
+use mui_material::Theme;
+
+fn sample_state(orientation: TabsOrientation) -> TabsState {
+    TabsState::new(
+        3,
+        Some(1),
+        ActivationMode::Automatic,
+        orientation,
+        unsafe { std::mem::transmute(1u8) },
+        unsafe { std::mem::transmute(1u8) },
+    )
+}
+
+fn build_props<'a>(
+    state: &'a TabsState,
+    layout: &'a TabListLayoutOptions,
+    theme: &'a Theme,
+    viewport: u32,
+) -> TabListProps<'a> {
+    TabListProps {
+        state,
+        attributes: state.list_attributes().id("tabs"),
+        children: "<button role=\"tab\">One</button>",
+        layout,
+        theme,
+        viewport: Some(viewport),
+        on_activate_event: Some("activate-tab"),
+    }
+}
+
+#[test]
+fn react_adapter_renders_wrapped_tab_list() {
+    let layout = TabListLayoutOptions::default();
+    let theme = Theme::default();
+    let state = sample_state(TabsOrientation::Horizontal);
+    let html = tabs::react::render_tab_list(build_props(&state, &layout, &theme, 640));
+
+    assert!(html.starts_with("<div class=\""));
+    assert!(html.contains("data-on-activate=\"activate-tab\""));
+    assert!(html.contains("role=\"tablist\""));
+    assert!(html.contains("data-orientation=\"horizontal\""));
+}
+
+#[test]
+fn react_adapter_honours_vertical_breakpoint() {
+    let layout = TabListLayoutOptions::default();
+    let theme = Theme::default();
+    let state = sample_state(TabsOrientation::Vertical);
+    let html = tabs::react::render_tab_list(build_props(&state, &layout, &theme, 1200));
+
+    assert!(html.contains("data-orientation=\"vertical\""));
+}
+
+#[cfg(feature = "yew")]
+mod yew_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = TabListLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(TabsOrientation::Horizontal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = tabs::react::render_tab_list(props.clone());
+        let yew = tabs::yew::render_tab_list(props);
+        assert_eq!(yew, react);
+    }
+}
+
+#[cfg(feature = "leptos")]
+mod leptos_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = TabListLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(TabsOrientation::Horizontal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = tabs::react::render_tab_list(props.clone());
+        let leptos = tabs::leptos::render_tab_list(props);
+        assert_eq!(leptos, react);
+    }
+}
+
+#[cfg(feature = "sycamore")]
+mod sycamore_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = TabListLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(TabsOrientation::Horizontal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = tabs::react::render_tab_list(props.clone());
+        let sycamore = tabs::sycamore::render_tab_list(props);
+        assert_eq!(sycamore, react);
+    }
+}
+
+#[cfg(feature = "dioxus")]
+mod dioxus_tests {
+    use super::*;
+
+    #[test]
+    fn matches_react_output() {
+        let layout = TabListLayoutOptions::default();
+        let theme = Theme::default();
+        let state = sample_state(TabsOrientation::Horizontal);
+        let props = build_props(&state, &layout, &theme, 640);
+        let react = tabs::react::render_tab_list(props.clone());
+        let dioxus = tabs::dioxus::render_tab_list(props);
+        assert_eq!(dioxus, react);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `TabListLayoutOptions`/`TabListProps` to drive responsive orientation via mui-system stack helpers and expose React/Yew/Leptos/Sycamore/Dioxus adapters that wrap the shared tab list renderer
- add `DrawerLayoutOptions`, `DrawerProps`, and `DrawerRenderResult` that reuse mui-system box primitives for responsive anchoring while emitting consistent markup for every supported framework
- extend the adapter integration suite with tabs and drawer coverage to confirm React behaviour and parity across the remaining frameworks

## Testing
- `cargo test -p mui-material`


------
https://chatgpt.com/codex/tasks/task_e_68ce0094ffb8832e970d48475c48ce47