### PR TITLE
feat(headless): add tooltip and chip state machines

### DIFF
--- a/crates/mui-headless/src/aria.rs
+++ b/crates/mui-headless/src/aria.rs
@@ -51,6 +51,12 @@ pub const fn role_menuitem() -> &'static str {
     "menuitem"
 }
 
+/// Returns the ARIA role for tooltip surfaces.
+#[inline]
+pub const fn role_tooltip() -> &'static str {
+    "tooltip"
+}
+
 /// Returns the ARIA role for tablist containers.
 #[inline]
 pub const fn role_tablist() -> &'static str {
@@ -139,4 +145,10 @@ pub const fn aria_orientation(orientation: &'static str) -> (&'static str, &'sta
 #[inline]
 pub const fn aria_modal(modal: bool) -> (&'static str, &'static str) {
     ("aria-modal", if modal { "true" } else { "false" })
+}
+
+/// Compute the `aria-hidden` attribute that automation tools often assert.
+#[inline]
+pub const fn aria_hidden(hidden: bool) -> (&'static str, &'static str) {
+    ("aria-hidden", if hidden { "true" } else { "false" })
 }

--- a/crates/mui-headless/src/chip.rs
+++ b/crates/mui-headless/src/chip.rs
@@ -1,0 +1,419 @@
+//! Chip state machine coordinating hover driven affordances and deletion.
+//!
+//! Similar to [`TooltipState`](crate::tooltip::TooltipState) the implementation
+//! is richly documented so framework adapters and enterprise QA automation can
+//! reason about every transition.  Chips are commonly used as filters and quick
+//! actions inside complex dashboards which means we need deterministic logic for
+//! when the trailing delete affordance appears, how long a pending deletion
+//! lingers for animations, and how keyboard driven cancellation behaves.
+
+use crate::aria;
+use crate::timing::{Clock, SystemClock, Timer};
+use std::time::Duration;
+
+/// Configuration describing how the chip behaves.
+#[derive(Debug, Clone)]
+pub struct ChipConfig {
+    /// Delay before the trailing action fades in after hover/focus.
+    pub show_delay: Duration,
+    /// Delay before the trailing action hides once no longer hovered/focused.
+    pub hide_delay: Duration,
+    /// Grace period before a deletion is committed allowing exit animations.
+    pub delete_delay: Duration,
+    /// Whether the chip exposes a delete affordance at all.
+    pub dismissible: bool,
+    /// Whether the chip starts disabled.  Disabled chips ignore interactions.
+    pub disabled: bool,
+}
+
+impl ChipConfig {
+    /// Defaults optimised for enterprise dashboards.
+    pub fn enterprise_defaults() -> Self {
+        Self {
+            show_delay: Duration::from_millis(120),
+            hide_delay: Duration::from_millis(160),
+            delete_delay: Duration::from_millis(200),
+            dismissible: true,
+            disabled: false,
+        }
+    }
+}
+
+impl Default for ChipConfig {
+    fn default() -> Self {
+        Self::enterprise_defaults()
+    }
+}
+
+/// Aggregated change information emitted from state transitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ChipChange {
+    /// `Some(true)` when the trailing affordance becomes visible.
+    pub controls_visible: Option<bool>,
+    /// Set when the chip has been logically removed.
+    pub deleted: bool,
+    /// Set when a pending deletion was cancelled (e.g. escape key).
+    pub deletion_cancelled: bool,
+}
+
+impl ChipChange {
+    fn merge(mut self, other: ChipChange) -> ChipChange {
+        if other.controls_visible.is_some() {
+            self.controls_visible = other.controls_visible;
+        }
+        self.deleted |= other.deleted;
+        self.deletion_cancelled |= other.deletion_cancelled;
+        self
+    }
+
+    fn controls(visible: bool) -> Self {
+        Self {
+            controls_visible: Some(visible),
+            ..Self::default()
+        }
+    }
+
+    fn deleted() -> Self {
+        Self {
+            deleted: true,
+            ..Self::default()
+        }
+    }
+
+    fn cancelled() -> Self {
+        Self {
+            deletion_cancelled: true,
+            ..Self::default()
+        }
+    }
+}
+
+/// Chip state machine built on top of the reusable [`Clock`] abstraction.
+#[derive(Debug, Clone)]
+pub struct ChipState<C: Clock = SystemClock> {
+    clock: C,
+    config: ChipConfig,
+    controls_visible: bool,
+    hovered: bool,
+    focused: bool,
+    deleting: bool,
+    visible: bool,
+    show_timer: Timer<C>,
+    hide_timer: Timer<C>,
+    delete_timer: Timer<C>,
+}
+
+impl ChipState<SystemClock> {
+    /// Construct a chip using the system clock.
+    pub fn new(config: ChipConfig) -> Self {
+        Self::with_clock(SystemClock, config)
+    }
+}
+
+impl<C: Clock> ChipState<C> {
+    /// Construct a chip bound to a specific clock (mock clocks for tests).
+    pub fn with_clock(clock: C, config: ChipConfig) -> Self {
+        Self {
+            clock,
+            config,
+            controls_visible: false,
+            hovered: false,
+            focused: false,
+            deleting: false,
+            visible: true,
+            show_timer: Timer::new(),
+            hide_timer: Timer::new(),
+            delete_timer: Timer::new(),
+        }
+    }
+
+    /// Returns whether the chip is currently visible (not yet deleted).
+    #[inline]
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    /// Returns whether the trailing delete affordance is visible.
+    #[inline]
+    pub fn controls_visible(&self) -> bool {
+        self.controls_visible
+    }
+
+    /// Returns whether a deletion is pending.
+    #[inline]
+    pub fn deletion_pending(&self) -> bool {
+        self.deleting
+    }
+
+    /// Returns whether the chip is disabled.
+    #[inline]
+    pub fn disabled(&self) -> bool {
+        self.config.disabled
+    }
+
+    /// Programmatically toggle the disabled flag.
+    #[inline]
+    pub fn set_disabled(&mut self, value: bool) {
+        self.config.disabled = value;
+    }
+
+    /// Pointer entered the chip surface.
+    pub fn pointer_enter(&mut self) -> ChipChange {
+        if self.config.disabled || !self.visible {
+            return ChipChange::default();
+        }
+        self.hovered = true;
+        self.queue_show_controls()
+    }
+
+    /// Pointer left the chip surface.
+    pub fn pointer_leave(&mut self) -> ChipChange {
+        if self.config.disabled || !self.visible {
+            return ChipChange::default();
+        }
+        self.hovered = false;
+        self.queue_hide_controls()
+    }
+
+    /// Focus moved to the chip (keyboard navigation).
+    pub fn focus(&mut self) -> ChipChange {
+        if self.config.disabled || !self.visible {
+            return ChipChange::default();
+        }
+        self.focused = true;
+        self.queue_show_controls()
+    }
+
+    /// Focus moved away from the chip.
+    pub fn blur(&mut self) -> ChipChange {
+        if self.config.disabled || !self.visible {
+            return ChipChange::default();
+        }
+        self.focused = false;
+        self.queue_hide_controls()
+    }
+
+    /// Request deletion (triggered by trailing icon or keyboard Delete).
+    pub fn request_delete(&mut self) -> ChipChange {
+        if self.config.disabled || !self.visible || !self.config.dismissible {
+            return ChipChange::default();
+        }
+        if self.deleting {
+            return ChipChange::default();
+        }
+        self.deleting = true;
+        self.hide_timer.cancel();
+        if self.config.delete_delay.is_zero() {
+            return self.commit_deletion();
+        }
+        self.delete_timer
+            .schedule(&self.clock, self.config.delete_delay);
+        self.resolve_timers()
+    }
+
+    /// Cancel a pending deletion (escape key or focus loss recovery).
+    pub fn cancel_delete(&mut self) -> ChipChange {
+        if !self.deleting {
+            return ChipChange::default();
+        }
+        self.deleting = false;
+        self.delete_timer.cancel();
+        ChipChange::cancelled().merge(self.queue_hide_controls())
+    }
+
+    /// Escape key is treated as a delete cancellation followed by hide logic.
+    pub fn escape(&mut self) -> ChipChange {
+        let mut change = self.cancel_delete();
+        change = change.merge(self.queue_hide_controls());
+        change
+    }
+
+    /// Poll for timer driven transitions.
+    pub fn poll(&mut self) -> ChipChange {
+        self.resolve_timers()
+    }
+
+    fn queue_show_controls(&mut self) -> ChipChange {
+        if !self.config.dismissible {
+            return ChipChange::default();
+        }
+        self.hide_timer.cancel();
+        if self.controls_visible {
+            return ChipChange::default();
+        }
+        if self.config.show_delay.is_zero() {
+            self.controls_visible = true;
+            return ChipChange::controls(true);
+        }
+        self.show_timer
+            .schedule(&self.clock, self.config.show_delay);
+        self.resolve_timers()
+    }
+
+    fn queue_hide_controls(&mut self) -> ChipChange {
+        if !self.config.dismissible {
+            return ChipChange::default();
+        }
+        if self.focused || self.hovered || self.deleting {
+            return ChipChange::default();
+        }
+        self.show_timer.cancel();
+        if !self.controls_visible {
+            self.hide_timer.cancel();
+            return ChipChange::default();
+        }
+        if self.config.hide_delay.is_zero() {
+            self.controls_visible = false;
+            return ChipChange::controls(false);
+        }
+        self.hide_timer
+            .schedule(&self.clock, self.config.hide_delay);
+        self.resolve_timers()
+    }
+
+    fn commit_deletion(&mut self) -> ChipChange {
+        self.delete_timer.cancel();
+        self.deleting = false;
+        if !self.visible {
+            return ChipChange::deleted();
+        }
+        self.visible = false;
+        self.controls_visible = false;
+        self.show_timer.cancel();
+        self.hide_timer.cancel();
+        ChipChange::controls(false).merge(ChipChange::deleted())
+    }
+
+    fn resolve_timers(&mut self) -> ChipChange {
+        let mut change = ChipChange::default();
+        if self.show_timer.fire_if_due(&self.clock) && !self.controls_visible {
+            self.controls_visible = true;
+            change = change.merge(ChipChange::controls(true));
+        }
+        if self.hide_timer.fire_if_due(&self.clock) && self.controls_visible {
+            self.controls_visible = false;
+            change = change.merge(ChipChange::controls(false));
+        }
+        if self.delete_timer.fire_if_due(&self.clock) && self.deleting {
+            change = change.merge(self.commit_deletion());
+        }
+        change
+    }
+}
+
+/// Builder for ARIA attributes on the chip root element.
+#[derive(Debug, Clone)]
+pub struct ChipAttributes<'a, C: Clock> {
+    state: &'a ChipState<C>,
+    id: Option<&'a str>,
+    labelled_by: Option<&'a str>,
+    described_by: Option<&'a str>,
+}
+
+impl<'a, C: Clock> ChipAttributes<'a, C> {
+    /// Construct a new builder for the chip root.
+    pub fn new(state: &'a ChipState<C>) -> Self {
+        Self {
+            state,
+            id: None,
+            labelled_by: None,
+            described_by: None,
+        }
+    }
+
+    /// Supply an ID for linking the chip from analytics dashboards.
+    #[inline]
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Attach an `aria-labelledby` attribute.
+    #[inline]
+    pub fn labelled_by(mut self, value: &'a str) -> Self {
+        self.labelled_by = Some(value);
+        self
+    }
+
+    /// Attach an `aria-describedby` attribute for hint copy.
+    #[inline]
+    pub fn described_by(mut self, value: &'a str) -> Self {
+        self.described_by = Some(value);
+        self
+    }
+
+    /// Returns the `role="button"` tuple which is the recommended baseline.
+    #[inline]
+    pub fn role(&self) -> &'static str {
+        aria::role_button()
+    }
+
+    /// Returns the `id` attribute when configured.
+    #[inline]
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Returns the `aria-labelledby` attribute when configured.
+    #[inline]
+    pub fn labelledby(&self) -> Option<(&'static str, &str)> {
+        self.labelled_by.map(aria::aria_labelledby)
+    }
+
+    /// Returns the `aria-describedby` attribute when configured.
+    #[inline]
+    pub fn describedby(&self) -> Option<(&'static str, &str)> {
+        self.described_by.map(aria::aria_describedby)
+    }
+
+    /// Returns the `aria-disabled` attribute based on state.
+    #[inline]
+    pub fn disabled(&self) -> (&'static str, &'static str) {
+        aria::aria_disabled(self.state.disabled())
+    }
+
+    /// Returns the `aria-hidden` attribute when the chip has been deleted.
+    #[inline]
+    pub fn hidden(&self) -> (&'static str, &'static str) {
+        aria::aria_hidden(!self.state.is_visible())
+    }
+}
+
+/// Builder for the delete button attributes.
+#[derive(Debug, Clone)]
+pub struct ChipDeleteAttributes<'a, C: Clock> {
+    state: &'a ChipState<C>,
+    label: Option<&'a str>,
+}
+
+impl<'a, C: Clock> ChipDeleteAttributes<'a, C> {
+    /// Construct a new builder.
+    pub fn new(state: &'a ChipState<C>) -> Self {
+        Self { state, label: None }
+    }
+
+    /// Provide the `aria-label` describing the delete action.
+    #[inline]
+    pub fn label(mut self, value: &'a str) -> Self {
+        self.label = Some(value);
+        self
+    }
+
+    /// Returns the `role="button"` tuple.
+    #[inline]
+    pub fn role(&self) -> &'static str {
+        aria::role_button()
+    }
+
+    /// Returns the `aria-hidden` attribute reflecting control visibility.
+    #[inline]
+    pub fn hidden(&self) -> (&'static str, &'static str) {
+        aria::aria_hidden(!self.state.controls_visible())
+    }
+
+    /// Returns the `aria-label` tuple if provided.
+    #[inline]
+    pub fn aria_label(&self) -> Option<(&'static str, &str)> {
+        self.label.map(|value| ("aria-label", value))
+    }
+}

--- a/crates/mui-headless/src/lib.rs
+++ b/crates/mui-headless/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod aria;
 pub mod button;
 pub mod checkbox;
+pub mod chip;
 pub mod drawer;
 pub mod interaction;
 pub mod list;
@@ -24,6 +25,8 @@ pub mod switch;
 pub mod tab;
 pub mod tab_panel;
 pub mod tabs;
+pub mod timing;
+pub mod tooltip;
 
 mod selection;
 mod toggle;

--- a/crates/mui-headless/src/timing.rs
+++ b/crates/mui-headless/src/timing.rs
@@ -1,0 +1,185 @@
+//! Time management primitives shared by advanced state machines.
+//!
+//! Enterprise applications frequently require deterministic time control so
+//! that complex state charts can be validated in isolation.  Instead of
+//! sprinkling ad-hoc `Instant::now()` calls throughout each component we expose
+//! a tiny abstraction layer which can be backed by real wall clock time in
+//! production and mocked clocks inside integration tests or automation suites.
+//! This keeps business logic completely deterministic and dramatically reduces
+//! the amount of manual QA required before releasing builds.
+
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+/// Minimal trait capturing the behaviour required by the timer helpers.
+///
+/// The trait keeps the API intentionally small so we can use it across
+/// state machines without complicating their generics.  Implementations should
+/// guarantee monotonically increasing instants which makes the schedulers
+/// robust even when reused by long running services.
+pub trait Clock: Clone {
+    /// Concrete instant representation used by the clock implementation.
+    type Instant: Copy + PartialOrd + fmt::Debug;
+
+    /// Returns the current moment according to the clock.
+    fn now(&self) -> Self::Instant;
+
+    /// Adds the provided duration to an instant.
+    fn add(&self, instant: Self::Instant, duration: Duration) -> Self::Instant;
+
+    /// Returns the duration between two instants.
+    fn duration_between(&self, earlier: Self::Instant, later: Self::Instant) -> Duration;
+}
+
+/// Real wall clock backed [`Clock`] implementation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    type Instant = Instant;
+
+    #[inline]
+    fn now(&self) -> Self::Instant {
+        Instant::now()
+    }
+
+    #[inline]
+    fn add(&self, instant: Self::Instant, duration: Duration) -> Self::Instant {
+        instant
+            .checked_add(duration)
+            .expect("system clock overflowed while scheduling timer")
+    }
+
+    #[inline]
+    fn duration_between(&self, earlier: Self::Instant, later: Self::Instant) -> Duration {
+        later.saturating_duration_since(earlier)
+    }
+}
+
+/// Deterministic clock used by unit tests and automation fixtures.
+///
+/// The clock shares its offset across clones which allows state machines and
+/// tests to tick time forward without passing around mutable references.
+#[derive(Debug, Clone)]
+pub struct MockClock {
+    base: Instant,
+    offset: Rc<RefCell<Duration>>,
+}
+
+impl MockClock {
+    /// Construct a new mock clock.
+    pub fn new() -> Self {
+        Self {
+            base: Instant::now(),
+            offset: Rc::new(RefCell::new(Duration::ZERO)),
+        }
+    }
+
+    /// Advance the clock by the requested delta.
+    pub fn advance(&self, delta: Duration) {
+        *self.offset.borrow_mut() += delta;
+    }
+}
+
+impl Default for MockClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for MockClock {
+    type Instant = Instant;
+
+    #[inline]
+    fn now(&self) -> Self::Instant {
+        self.base
+            .checked_add(*self.offset.borrow())
+            .expect("mock clock overflow while advancing time")
+    }
+
+    #[inline]
+    fn add(&self, instant: Self::Instant, duration: Duration) -> Self::Instant {
+        instant
+            .checked_add(duration)
+            .expect("mock clock overflow while scheduling timer")
+    }
+
+    #[inline]
+    fn duration_between(&self, earlier: Self::Instant, later: Self::Instant) -> Duration {
+        later.saturating_duration_since(earlier)
+    }
+}
+
+/// Small helper struct encapsulating deadline handling.
+#[derive(Clone, Default)]
+pub struct Timer<C: Clock> {
+    deadline: Option<C::Instant>,
+    _marker: std::marker::PhantomData<C>,
+}
+
+impl<C> fmt::Debug for Timer<C>
+where
+    C: Clock,
+    C::Instant: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Timer")
+            .field("deadline", &self.deadline)
+            .finish()
+    }
+}
+
+impl<C: Clock> Timer<C> {
+    /// Create an empty timer.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            deadline: None,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Returns whether a deadline is currently scheduled.
+    #[inline]
+    pub fn is_scheduled(&self) -> bool {
+        self.deadline.is_some()
+    }
+
+    /// Schedule the timer to fire after the supplied delay.
+    #[inline]
+    pub fn schedule(&mut self, clock: &C, delay: Duration) {
+        self.deadline = Some(clock.add(clock.now(), delay));
+    }
+
+    /// Cancel the timer if a deadline existed.
+    #[inline]
+    pub fn cancel(&mut self) {
+        self.deadline = None;
+    }
+
+    /// Returns whether the timer should fire at the current instant.
+    #[inline]
+    pub fn should_fire(&self, clock: &C) -> bool {
+        matches!(self.deadline, Some(deadline) if clock.now() >= deadline)
+    }
+
+    /// Consume the deadline if it is due.
+    #[inline]
+    pub fn fire_if_due(&mut self, clock: &C) -> bool {
+        if self.should_fire(clock) {
+            self.deadline = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the remaining time until the deadline if one exists.
+    #[inline]
+    pub fn remaining(&self, clock: &C) -> Option<Duration> {
+        self.deadline
+            .map(|deadline| clock.duration_between(clock.now(), deadline))
+    }
+}

--- a/crates/mui-headless/src/tooltip.rs
+++ b/crates/mui-headless/src/tooltip.rs
@@ -1,0 +1,348 @@
+//! Tooltip orchestration state machine with deterministic timing.
+//!
+//! The implementation is intentionally verbose and heavily documented.  Enterprise
+//! adopters frequently need to integrate with centralized automation platforms
+//! where deterministic behaviour, rich instrumentation and ARIA compliant
+//! attributes are mandatory.  The state machine therefore exposes explicit
+//! events for hover/focus coordination, configurable show/hide timers and a
+//! predictable polling API which adapters can call from `requestAnimationFrame`
+//! or their rendering loop.  Framework bindings simply forward DOM events and
+//! mirror the derived attributes which keeps the UI layer essentially
+//! stateless.
+
+use crate::aria;
+use crate::timing::{Clock, SystemClock, Timer};
+use std::time::Duration;
+
+/// Configuration describing how the tooltip reacts to interactions.
+#[derive(Debug, Clone)]
+pub struct TooltipConfig {
+    /// Delay before the tooltip becomes visible after focus/hover.
+    pub show_delay: Duration,
+    /// Delay before the tooltip hides once the trigger is no longer active.
+    pub hide_delay: Duration,
+    /// Whether escape or programmatic dismiss calls should immediately hide.
+    pub dismissible: bool,
+    /// When `true` the tooltip remains visible while the pointer hovers the
+    /// surface.  This mirrors the behaviour of interactive tooltips in MUI.
+    pub interactive: bool,
+}
+
+impl TooltipConfig {
+    /// Enterprise friendly defaults that mirror the behaviour of Material UI
+    /// while giving enough breathing room for telemetry.
+    pub fn enterprise_defaults() -> Self {
+        Self {
+            show_delay: Duration::from_millis(150),
+            hide_delay: Duration::from_millis(100),
+            dismissible: true,
+            interactive: true,
+        }
+    }
+}
+
+impl Default for TooltipConfig {
+    fn default() -> Self {
+        Self::enterprise_defaults()
+    }
+}
+
+/// Outcome of processing timer driven transitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TooltipChange {
+    /// `Some(true)` when visibility toggled on, `Some(false)` when hidden.
+    pub visibility_changed: Option<bool>,
+}
+
+impl TooltipChange {
+    fn merge(self, other: TooltipChange) -> TooltipChange {
+        TooltipChange {
+            visibility_changed: other.visibility_changed.or(self.visibility_changed),
+        }
+    }
+
+    fn from_visibility(visible: bool) -> Self {
+        Self {
+            visibility_changed: Some(visible),
+        }
+    }
+}
+
+/// Tooltip state machine parameterised over a [`Clock`].
+#[derive(Debug, Clone)]
+pub struct TooltipState<C: Clock = SystemClock> {
+    clock: C,
+    config: TooltipConfig,
+    visible: bool,
+    anchor_focused: bool,
+    anchor_hovered: bool,
+    surface_hovered: bool,
+    show_timer: Timer<C>,
+    hide_timer: Timer<C>,
+}
+
+impl TooltipState<SystemClock> {
+    /// Construct a tooltip using the real system clock.
+    pub fn new(config: TooltipConfig) -> Self {
+        Self::with_clock(SystemClock, config)
+    }
+}
+
+impl<C: Clock> TooltipState<C> {
+    /// Construct a tooltip using a custom clock (handy for tests and playback).
+    pub fn with_clock(clock: C, config: TooltipConfig) -> Self {
+        Self {
+            clock,
+            config,
+            visible: false,
+            anchor_focused: false,
+            anchor_hovered: false,
+            surface_hovered: false,
+            show_timer: Timer::new(),
+            hide_timer: Timer::new(),
+        }
+    }
+
+    /// Returns whether the tooltip surface is currently visible.
+    #[inline]
+    pub fn visible(&self) -> bool {
+        self.visible
+    }
+
+    /// Returns the configuration backing the tooltip.
+    #[inline]
+    pub fn config(&self) -> &TooltipConfig {
+        &self.config
+    }
+
+    /// Event fired when the anchor element receives focus.
+    pub fn focus_anchor(&mut self) -> TooltipChange {
+        self.anchor_focused = true;
+        self.queue_show()
+    }
+
+    /// Event fired when the anchor element loses focus.
+    pub fn blur_anchor(&mut self) -> TooltipChange {
+        self.anchor_focused = false;
+        self.queue_hide()
+    }
+
+    /// Event fired when the pointer enters the anchor.
+    pub fn pointer_enter_anchor(&mut self) -> TooltipChange {
+        self.anchor_hovered = true;
+        self.queue_show()
+    }
+
+    /// Event fired when the pointer leaves the anchor.
+    pub fn pointer_leave_anchor(&mut self) -> TooltipChange {
+        self.anchor_hovered = false;
+        self.queue_hide()
+    }
+
+    /// Event fired when the pointer enters the tooltip surface.
+    pub fn pointer_enter_tooltip(&mut self) -> TooltipChange {
+        if self.config.interactive {
+            self.surface_hovered = true;
+            self.hide_timer.cancel();
+        }
+        self.resolve_timers()
+    }
+
+    /// Event fired when the pointer leaves the tooltip surface.
+    pub fn pointer_leave_tooltip(&mut self) -> TooltipChange {
+        if self.config.interactive {
+            self.surface_hovered = false;
+            return self.queue_hide();
+        }
+        TooltipChange::default()
+    }
+
+    /// Dismiss the tooltip due to escape key or automation command.
+    pub fn dismiss(&mut self) -> TooltipChange {
+        if !self.config.dismissible || !self.visible {
+            return TooltipChange::default();
+        }
+        self.show_timer.cancel();
+        self.hide_timer.cancel();
+        self.visible = false;
+        TooltipChange::from_visibility(false)
+    }
+
+    /// Poll for timer driven changes.  Frameworks call this from animation
+    /// frames or async tasks to drive visibility transitions.
+    pub fn poll(&mut self) -> TooltipChange {
+        self.resolve_timers()
+    }
+
+    fn queue_show(&mut self) -> TooltipChange {
+        self.hide_timer.cancel();
+        if self.visible {
+            self.show_timer.cancel();
+            return TooltipChange::default();
+        }
+        if self.config.show_delay.is_zero() {
+            self.visible = true;
+            return TooltipChange::from_visibility(true);
+        }
+        self.show_timer
+            .schedule(&self.clock, self.config.show_delay);
+        self.resolve_timers()
+    }
+
+    fn queue_hide(&mut self) -> TooltipChange {
+        if self.anchor_focused
+            || self.anchor_hovered
+            || (self.config.interactive && self.surface_hovered)
+        {
+            return TooltipChange::default();
+        }
+        self.show_timer.cancel();
+        if !self.visible {
+            self.hide_timer.cancel();
+            return TooltipChange::default();
+        }
+        if self.config.hide_delay.is_zero() {
+            self.visible = false;
+            return TooltipChange::from_visibility(false);
+        }
+        self.hide_timer
+            .schedule(&self.clock, self.config.hide_delay);
+        self.resolve_timers()
+    }
+
+    fn resolve_timers(&mut self) -> TooltipChange {
+        let mut change = TooltipChange::default();
+        if self.show_timer.fire_if_due(&self.clock) && !self.visible {
+            self.visible = true;
+            change = change.merge(TooltipChange::from_visibility(true));
+        }
+        if self.hide_timer.fire_if_due(&self.clock) && self.visible {
+            self.visible = false;
+            change = change.merge(TooltipChange::from_visibility(false));
+        }
+        change
+    }
+}
+
+/// Builder for trigger element attributes.
+#[derive(Debug, Clone)]
+pub struct TooltipTriggerAttributes<'a, C: Clock> {
+    state: &'a TooltipState<C>,
+    id: Option<&'a str>,
+    described_by: Option<&'a str>,
+    has_popup: Option<&'static str>,
+}
+
+impl<'a, C: Clock> TooltipTriggerAttributes<'a, C> {
+    /// Construct a new attribute builder.
+    pub fn new(state: &'a TooltipState<C>) -> Self {
+        Self {
+            state,
+            id: None,
+            described_by: None,
+            has_popup: None,
+        }
+    }
+
+    /// Provide an explicit ID for the trigger element.
+    #[inline]
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Link the trigger to the tooltip using `aria-describedby`.
+    #[inline]
+    pub fn described_by(mut self, value: &'a str) -> Self {
+        self.described_by = Some(value);
+        self
+    }
+
+    /// Advertise a richer popup relationship such as `dialog` or `menu`.
+    #[inline]
+    pub fn has_popup(mut self, kind: &'static str) -> Self {
+        self.has_popup = Some(kind);
+        self
+    }
+
+    /// Returns the `id` attribute if configured.
+    #[inline]
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Returns the `aria-describedby` attribute.
+    #[inline]
+    pub fn describedby(&self) -> Option<(&'static str, &str)> {
+        self.described_by.map(aria::aria_describedby)
+    }
+
+    /// Returns the `aria-haspopup` attribute.
+    #[inline]
+    pub fn haspopup(&self) -> Option<(&'static str, &'static str)> {
+        self.has_popup.map(aria::aria_haspopup)
+    }
+
+    /// Returns the `aria-expanded` attribute reflecting visibility.
+    #[inline]
+    pub fn expanded(&self) -> (&'static str, &'static str) {
+        aria::aria_expanded(self.state.visible())
+    }
+}
+
+/// Builder for tooltip surface attributes.
+#[derive(Debug, Clone)]
+pub struct TooltipSurfaceAttributes<'a, C: Clock> {
+    state: &'a TooltipState<C>,
+    id: Option<&'a str>,
+    labelled_by: Option<&'a str>,
+}
+
+impl<'a, C: Clock> TooltipSurfaceAttributes<'a, C> {
+    /// Construct a new builder referencing the tooltip state.
+    pub fn new(state: &'a TooltipState<C>) -> Self {
+        Self {
+            state,
+            id: None,
+            labelled_by: None,
+        }
+    }
+
+    /// Assign an ID so that triggers can reference this tooltip.
+    #[inline]
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Provide an `aria-labelledby` relationship for automation.
+    #[inline]
+    pub fn labelled_by(mut self, value: &'a str) -> Self {
+        self.labelled_by = Some(value);
+        self
+    }
+
+    /// Returns the `role="tooltip"` tuple.
+    #[inline]
+    pub fn role(&self) -> &'static str {
+        aria::role_tooltip()
+    }
+
+    /// Returns the `id` attribute if configured.
+    #[inline]
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Returns the `aria-labelledby` attribute if configured.
+    #[inline]
+    pub fn labelledby(&self) -> Option<(&'static str, &str)> {
+        self.labelled_by.map(aria::aria_labelledby)
+    }
+
+    /// Returns `aria-hidden` reflecting the surface visibility.
+    #[inline]
+    pub fn hidden(&self) -> (&'static str, &'static str) {
+        aria::aria_hidden(!self.state.visible())
+    }
+}

--- a/crates/mui-headless/tests/chip.rs
+++ b/crates/mui-headless/tests/chip.rs
@@ -1,0 +1,115 @@
+use std::time::Duration;
+
+use mui_headless::chip::{ChipAttributes, ChipConfig, ChipDeleteAttributes, ChipState};
+use mui_headless::timing::MockClock;
+
+fn bootstrap_state(clock: MockClock) -> ChipState<MockClock> {
+    ChipState::with_clock(clock, ChipConfig::default())
+}
+
+#[test]
+fn controls_follow_hover_timing() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+
+    assert_eq!(state.pointer_enter().controls_visible, None);
+    clock.advance(Duration::from_millis(119));
+    assert_eq!(state.poll().controls_visible, None);
+    clock.advance(Duration::from_millis(1));
+    assert_eq!(state.poll().controls_visible, Some(true));
+    assert!(state.controls_visible());
+
+    assert_eq!(state.pointer_leave().controls_visible, None);
+    clock.advance(Duration::from_millis(159));
+    assert_eq!(state.poll().controls_visible, None);
+    clock.advance(Duration::from_millis(1));
+    assert_eq!(state.poll().controls_visible, Some(false));
+    assert!(!state.controls_visible());
+}
+
+#[test]
+fn deletion_commits_after_delay() {
+    let clock = MockClock::new();
+    let mut state = ChipState::with_clock(
+        clock.clone(),
+        ChipConfig {
+            delete_delay: Duration::from_millis(80),
+            ..ChipConfig::default()
+        },
+    );
+
+    state.pointer_enter();
+    clock.advance(Duration::from_millis(120));
+    state.poll();
+    assert!(state.controls_visible());
+
+    state.request_delete();
+    assert!(state.deletion_pending());
+    clock.advance(Duration::from_millis(79));
+    assert_eq!(state.poll().deleted, false);
+    clock.advance(Duration::from_millis(1));
+    let change = state.poll();
+    assert!(change.deleted);
+    assert!(!state.is_visible());
+    assert!(!state.controls_visible());
+}
+
+#[test]
+fn escape_cancels_pending_delete() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+
+    state.pointer_enter();
+    clock.advance(Duration::from_millis(120));
+    state.poll();
+
+    state.request_delete();
+    let change = state.escape();
+    assert!(change.deletion_cancelled);
+    assert!(!state.deletion_pending());
+
+    clock.advance(Duration::from_millis(500));
+    assert_eq!(state.poll().deleted, false);
+    assert!(state.is_visible());
+}
+
+#[test]
+fn disabled_chips_ignore_interaction() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+    state.set_disabled(true);
+
+    let change = state.pointer_enter();
+    assert_eq!(change.controls_visible, None);
+    assert!(!state.controls_visible());
+}
+
+#[test]
+fn aria_builders_reflect_state() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+
+    let attrs = ChipAttributes::new(&state)
+        .id("chip")
+        .labelled_by("label")
+        .described_by("hint");
+    assert_eq!(attrs.role(), "button");
+    assert_eq!(attrs.id_attr(), Some(("id", "chip")));
+    assert_eq!(attrs.labelledby(), Some(("aria-labelledby", "label")));
+    assert_eq!(attrs.describedby(), Some(("aria-describedby", "hint")));
+    assert_eq!(attrs.hidden(), ("aria-hidden", "false"));
+
+    state.set_disabled(true);
+    assert_eq!(
+        ChipAttributes::new(&state).disabled(),
+        ("aria-disabled", "true")
+    );
+
+    let delete_attrs = ChipDeleteAttributes::new(&state).label("Remove filter");
+    assert_eq!(delete_attrs.role(), "button");
+    assert_eq!(delete_attrs.hidden(), ("aria-hidden", "true"));
+    assert_eq!(
+        delete_attrs.aria_label(),
+        Some(("aria-label", "Remove filter"))
+    );
+}

--- a/crates/mui-headless/tests/tooltip.rs
+++ b/crates/mui-headless/tests/tooltip.rs
@@ -1,0 +1,126 @@
+use std::time::Duration;
+
+use mui_headless::timing::MockClock;
+use mui_headless::tooltip::{
+    TooltipConfig, TooltipState, TooltipSurfaceAttributes, TooltipTriggerAttributes,
+};
+
+fn bootstrap_state(clock: MockClock) -> TooltipState<MockClock> {
+    TooltipState::with_clock(clock, TooltipConfig::default())
+}
+
+#[test]
+fn show_timer_is_respected() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+
+    let change = state.focus_anchor();
+    assert_eq!(
+        change.visibility_changed, None,
+        "change should be timer driven"
+    );
+
+    clock.advance(Duration::from_millis(149));
+    assert_eq!(state.poll().visibility_changed, None);
+
+    clock.advance(Duration::from_millis(1));
+    let change = state.poll();
+    assert_eq!(change.visibility_changed, Some(true));
+    assert!(state.visible());
+}
+
+#[test]
+fn hide_timer_cancels_when_surface_hovered() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+
+    state.pointer_enter_anchor();
+    clock.advance(Duration::from_millis(150));
+    state.poll();
+    assert!(state.visible());
+
+    state.pointer_leave_anchor();
+    clock.advance(Duration::from_millis(50));
+    state.pointer_enter_tooltip();
+    assert_eq!(state.poll().visibility_changed, None);
+
+    clock.advance(Duration::from_millis(200));
+    assert_eq!(
+        state.poll().visibility_changed,
+        None,
+        "tooltip should stay visible"
+    );
+
+    state.pointer_leave_tooltip();
+    clock.advance(Duration::from_millis(100));
+    assert_eq!(state.poll().visibility_changed, Some(false));
+    assert!(!state.visible());
+}
+
+#[test]
+fn dismiss_respects_configuration() {
+    let clock = MockClock::new();
+    let mut state = TooltipState::with_clock(
+        clock.clone(),
+        TooltipConfig {
+            dismissible: false,
+            ..TooltipConfig::default()
+        },
+    );
+
+    state.focus_anchor();
+    clock.advance(Duration::from_millis(150));
+    state.poll();
+    assert!(state.visible());
+
+    assert_eq!(state.dismiss().visibility_changed, None);
+    assert!(state.visible());
+}
+
+#[test]
+fn blur_does_not_hide_while_hovered() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+
+    state.pointer_enter_anchor();
+    clock.advance(Duration::from_millis(150));
+    state.poll();
+    assert!(state.visible());
+
+    state.focus_anchor();
+    state.blur_anchor();
+    clock.advance(Duration::from_millis(200));
+    assert_eq!(state.poll().visibility_changed, None);
+
+    state.pointer_leave_anchor();
+    clock.advance(Duration::from_millis(100));
+    assert_eq!(state.poll().visibility_changed, Some(false));
+}
+
+#[test]
+fn aria_builders_reflect_visibility() {
+    let clock = MockClock::new();
+    let mut state = bootstrap_state(clock.clone());
+
+    let trigger = TooltipTriggerAttributes::new(&state)
+        .id("trigger")
+        .described_by("tip");
+    assert_eq!(trigger.id_attr(), Some(("id", "trigger")));
+    assert_eq!(trigger.describedby(), Some(("aria-describedby", "tip")));
+    assert_eq!(trigger.expanded(), ("aria-expanded", "false"));
+
+    let surface = TooltipSurfaceAttributes::new(&state).id("tip");
+    assert_eq!(surface.role(), "tooltip");
+    assert_eq!(surface.id_attr(), Some(("id", "tip")));
+    assert_eq!(surface.hidden(), ("aria-hidden", "true"));
+
+    state.focus_anchor();
+    clock.advance(Duration::from_millis(150));
+    state.poll();
+
+    let trigger = TooltipTriggerAttributes::new(&state).described_by("tip");
+    assert_eq!(trigger.expanded(), ("aria-expanded", "true"));
+
+    let surface = TooltipSurfaceAttributes::new(&state).id("tip");
+    assert_eq!(surface.hidden(), ("aria-hidden", "false"));
+}

--- a/crates/mui-material/tests/drawer_render_tests.rs
+++ b/crates/mui-material/tests/drawer_render_tests.rs
@@ -53,7 +53,11 @@ fn react_surface_and_backdrop_expose_semantic_attributes() {
     assert!(render.surface.contains("data-variant=\"modal\""));
     assert!(render.surface.contains("data-on-toggle=\"drawer-toggle\""));
     assert!(render.surface.contains("id=\"demo-drawer\""));
-    assert!(render.backdrop.as_ref().unwrap().contains("data-variant=\"modal\""));
+    assert!(render
+        .backdrop
+        .as_ref()
+        .unwrap()
+        .contains("data-variant=\"modal\""));
 }
 
 #[test]
@@ -80,8 +84,18 @@ fn responsive_anchor_switches_at_breakpoint() {
     let start_state = build_state(DrawerAnchor::Start, DrawerVariant::Persistent, true);
     let top_state = build_state(DrawerAnchor::Top, DrawerVariant::Persistent, true);
 
-    let start_render = drawer::react::render(build_props(&start_state, &layout, &theme, theme.breakpoints.sm));
-    let top_render = drawer::react::render(build_props(&top_state, &layout, &theme, theme.breakpoints.xl));
+    let start_render = drawer::react::render(build_props(
+        &start_state,
+        &layout,
+        &theme,
+        theme.breakpoints.sm,
+    ));
+    let top_render = drawer::react::render(build_props(
+        &top_state,
+        &layout,
+        &theme,
+        theme.breakpoints.xl,
+    ));
 
     assert!(start_render.surface.contains("data-anchor=\"start\""));
     assert!(top_render.surface.contains("data-anchor=\"top\""));

--- a/crates/mui-material/tests/wasm.rs
+++ b/crates/mui-material/tests/wasm.rs
@@ -11,8 +11,8 @@ use mui_material::drawer::{self, DrawerLayoutOptions, DrawerProps};
 use mui_material::radio::{self, RadioGroupProps};
 use mui_material::switch::{self, SwitchProps};
 use mui_material::tab_panel;
-use mui_material::tabs::{self, TabListLayoutOptions, TabListProps};
 use mui_material::table::{self, TableColumn, TableProps, TableRow};
+use mui_material::tabs::{self, TabListLayoutOptions, TabListProps};
 use mui_material::{AppBar, Button, Snackbar, TextField};
 use mui_styled_engine::{Theme, ThemeProvider};
 use wasm_bindgen::{prelude::*, JsCast};
@@ -410,10 +410,7 @@ async fn tabs_orientation_and_accessibility() {
         let tabs_markup = vec![
             mui_material::tab::render_tab_html(
                 &state,
-                state
-                    .tab(0)
-                    .id("tab-overview")
-                    .controls("panel-overview"),
+                state.tab(0).id("tab-overview").controls("panel-overview"),
                 "Overview",
             ),
             mui_material::tab::render_tab_html(
@@ -479,7 +476,10 @@ async fn tabs_orientation_and_accessibility() {
         .query_selector("[role='tablist']")
         .unwrap()
         .expect("tablist rendered");
-    assert_eq!(tablist.get_attribute("data-orientation").unwrap(), "vertical");
+    assert_eq!(
+        tablist.get_attribute("data-orientation").unwrap(),
+        "vertical"
+    );
     assert_eq!(tablist.get_attribute("data-activation").unwrap(), "manual");
 
     let tabs = mount.query_selector_all("[role='tab']").unwrap();
@@ -489,10 +489,11 @@ async fn tabs_orientation_and_accessibility() {
         .query_selector("[role='tabpanel']")
         .unwrap()
         .expect("panel rendered");
-    assert_eq!(panel.get_attribute("aria-labelledby").unwrap(), "tab-overview");
-    assert!(panel
-        .inner_html()
-        .contains("data-testid=\"panel-body\""));
+    assert_eq!(
+        panel.get_attribute("aria-labelledby").unwrap(),
+        "tab-overview"
+    );
+    assert!(panel.inner_html().contains("data-testid=\"panel-body\""));
 
     axe_check(&mount).await;
 }
@@ -554,7 +555,10 @@ async fn drawer_modal_accessibility() {
         .expect("drawer surface rendered");
     assert_eq!(dialog.get_attribute("data-anchor").unwrap(), "top");
     assert_eq!(dialog.get_attribute("data-variant").unwrap(), "modal");
-    assert_eq!(dialog.get_attribute("data-on-toggle").unwrap(), "drawer-toggle");
+    assert_eq!(
+        dialog.get_attribute("data-on-toggle").unwrap(),
+        "drawer-toggle"
+    );
 
     let backdrop = mount
         .query_selector("[data-variant='modal'][aria-hidden]")


### PR DESCRIPTION
## Summary
- introduce a reusable timing module with `Clock`, `Timer`, and `MockClock` abstractions so headless state machines can share deterministic scheduling
- add richly documented tooltip and chip state machines including attribute builders, automation-friendly configuration, and timer-driven transitions
- extend the public API surface for the new modules, augment ARIA helpers, and add comprehensive tooltip/chip integration tests built on the mock clock
- run rustfmt on existing workspace tests that were touched during the change

## Testing
- `cargo fmt`
- `cargo clippy -p mui-headless --all-targets --all-features`
- `cargo test -p mui-headless`
- `cargo clippy --all-targets --all-features` *(fails: workspace currently cannot compile with every frontend feature enabled because `mui-system` re-exports `use_theme` for multiple frameworks at once)*

------
https://chatgpt.com/codex/tasks/task_e_68ce270d6f14832ebf1fa90f84651bc9