### PR TITLE
feat(headless): support tri-state checkbox toggles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,9 @@ dependencies = [
 [[package]]
 name = "mui-headless"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
 
 [[package]]
 name = "mui-icons"

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ The workspace is organized under the `crates/` directory:
 
 - `mui-system` – styling primitives (will be published as `rustic-ui-system`).
 - `mui-headless` – framework-agnostic component state machines.
+  - Checkbox primitives expose a tri-state (`Off`/`On`/`Indeterminate`) toggle
+    API with ARIA-compliant metadata (`aria-checked="mixed"` plus a
+    `data-indeterminate` hook) so adapters can animate complex selection flows
+    without reimplementing keyboard orchestration.
 - `mui-material` – Material-inspired components during the transition period.
 - `mui-icons-material` – SVG icon bindings being retooled for Rustic iconography.
 - `mui-lab` – experimental widgets under active development.

--- a/crates/mui-headless/CHANGELOG.md
+++ b/crates/mui-headless/CHANGELOG.md
@@ -6,4 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Initial release.
+### Added
+- Checkbox toggles now leverage a tri-state enum (`Off`/`On`/`Indeterminate`)
+  with helpers for programmatically setting and clearing the indeterminate
+  state while preserving controlled/uncontrolled ergonomics.
+- `aria::aria_checked` accepts the new `AriaChecked` helper so adapters emit
+  `mixed` values alongside a `data-indeterminate` flag for animation hooks.

--- a/crates/mui-headless/Cargo.toml
+++ b/crates/mui-headless/Cargo.toml
@@ -16,3 +16,6 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 # Use std only; no external dependencies beyond std.
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/mui-headless/src/aria.rs
+++ b/crates/mui-headless/src/aria.rs
@@ -2,6 +2,50 @@
 //! Keeping these utilities centralized ensures accessibility semantics
 //! stay consistent across framework adapters.
 
+use crate::toggle::ToggleCheckedState;
+
+/// Enumerates the values accepted by the `aria-checked` attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AriaChecked {
+    /// Represents an unchecked control (`false`).
+    False,
+    /// Represents a checked control (`true`).
+    True,
+    /// Represents an indeterminate control (`mixed`).
+    Mixed,
+}
+
+impl AriaChecked {
+    /// Convert the enum variant into the string expected by automation tools.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::False => "false",
+            Self::True => "true",
+            Self::Mixed => "mixed",
+        }
+    }
+}
+
+impl From<bool> for AriaChecked {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::True
+        } else {
+            Self::False
+        }
+    }
+}
+
+impl From<ToggleCheckedState> for AriaChecked {
+    fn from(value: ToggleCheckedState) -> Self {
+        match value {
+            ToggleCheckedState::Off => Self::False,
+            ToggleCheckedState::On => Self::True,
+            ToggleCheckedState::Indeterminate => Self::Mixed,
+        }
+    }
+}
+
 /// Returns the standard ARIA role for interactive buttons.
 #[inline]
 pub const fn role_button() -> &'static str {
@@ -89,8 +133,8 @@ pub const fn aria_pressed(pressed: bool) -> (&'static str, &'static str) {
 
 /// Compute the `aria-checked` attribute for selection controls.
 #[inline]
-pub const fn aria_checked(checked: bool) -> (&'static str, &'static str) {
-    ("aria-checked", if checked { "true" } else { "false" })
+pub const fn aria_checked(state: AriaChecked) -> (&'static str, &'static str) {
+    ("aria-checked", state.as_str())
 }
 
 /// Compute the `aria-disabled` attribute used across inputs.

--- a/crates/mui-headless/src/checkbox.rs
+++ b/crates/mui-headless/src/checkbox.rs
@@ -7,7 +7,11 @@
 
 use crate::aria;
 use crate::interaction::ControlKey;
-use crate::toggle::{ToggleMode, ToggleState};
+use crate::toggle::{ToggleCheckedState, ToggleMode, ToggleState};
+
+/// Public alias allowing downstream crates to type the checkbox value in a more
+/// domain-specific manner without re-exporting the internal toggle module.
+pub type CheckboxValue = ToggleCheckedState;
 
 /// Represents a Material checkbox.
 #[derive(Debug, Clone)]
@@ -18,19 +22,27 @@ pub struct CheckboxState {
 
 impl CheckboxState {
     /// Create a checkbox whose checked value is owned by the caller.
-    pub fn controlled(disabled: bool, checked: bool) -> Self {
+    ///
+    /// The helper accepts either a [`CheckboxValue`] or a plain `bool` so
+    /// existing binary call sites do not need to change while tri-state owners
+    /// can opt-in to [`CheckboxValue::Indeterminate`].
+    pub fn controlled(disabled: bool, checked: impl Into<CheckboxValue>) -> Self {
         let mode = ToggleMode::Controlled;
         Self {
-            inner: ToggleState::new(mode, disabled, checked),
+            inner: ToggleState::new(mode, disabled, checked.into()),
             mode,
         }
     }
 
     /// Create an uncontrolled checkbox that manages its own state.
-    pub fn uncontrolled(disabled: bool, default_checked: bool) -> Self {
+    ///
+    /// As with [`CheckboxState::controlled`], the initial value accepts either
+    /// the enum or a `bool`, keeping the API terse for the common two-state
+    /// cases.
+    pub fn uncontrolled(disabled: bool, default_checked: impl Into<CheckboxValue>) -> Self {
         let mode = ToggleMode::Uncontrolled;
         Self {
-            inner: ToggleState::new(mode, disabled, default_checked),
+            inner: ToggleState::new(mode, disabled, default_checked.into()),
             mode,
         }
     }
@@ -40,16 +52,42 @@ impl CheckboxState {
         matches!(self.mode, ToggleMode::Controlled)
     }
 
-    /// Returns whether the checkbox is checked.
-    pub fn checked(&self) -> bool {
+    /// Returns the full tri-state value describing the checkbox.
+    pub fn checked(&self) -> CheckboxValue {
         self.inner.checked()
+    }
+
+    /// Convenience helper mirroring the legacy two-state API while still
+    /// supporting indeterminate under the hood.
+    pub fn is_checked(&self) -> bool {
+        self.inner.is_on()
+    }
+
+    /// Whether the checkbox is currently indeterminate.
+    pub fn is_indeterminate(&self) -> bool {
+        self.inner.is_indeterminate()
     }
 
     /// Update the stored checked state.  Controlled owners should call this in
     /// response to the callback passed to [`toggle`].  Uncontrolled callers can
-    /// use it to imperatively set the value when syncing with server data.
-    pub fn sync_checked(&mut self, checked: bool) {
-        self.inner.sync(checked);
+    /// use it to imperatively set the value when syncing with server data. The
+    /// input supports either the enum or a bool for ergonomics.
+    pub fn sync_checked(&mut self, checked: impl Into<CheckboxValue>) {
+        self.inner.sync(checked.into());
+    }
+
+    /// Mark the checkbox as indeterminate regardless of the current ownership
+    /// mode. This makes it easy to drive partial selection UIs without
+    /// recreating the state machine.
+    pub fn set_indeterminate(&mut self) {
+        self.inner.sync(CheckboxValue::Indeterminate);
+    }
+
+    /// Clear the indeterminate flag, defaulting the checkbox back to `Off`.
+    /// This helper mirrors Material's recommended pattern of treating
+    /// indeterminate as a transient visual cue.
+    pub fn clear_indeterminate(&mut self) {
+        self.inner.sync(CheckboxValue::Off);
     }
 
     /// Returns whether the checkbox is disabled.
@@ -79,21 +117,23 @@ impl CheckboxState {
 
     /// Toggle the checkbox if enabled.  The callback is invoked with the
     /// desired value so controlled parents can update their copy.
-    pub fn toggle<F: FnOnce(bool)>(&mut self, callback: F) {
+    pub fn toggle<F: FnOnce(CheckboxValue)>(&mut self, callback: F) {
         self.inner.toggle(callback);
     }
 
     /// Handle keyboard interaction. Space and Enter toggle the checkbox in line
     /// with the ARIA authoring practices.
-    pub fn on_key<F: FnOnce(bool)>(&mut self, key: ControlKey, callback: F) {
+    pub fn on_key<F: FnOnce(CheckboxValue)>(&mut self, key: ControlKey, callback: F) {
         self.inner.on_key(key, callback);
     }
 
     /// Return ARIA metadata and data attributes describing the checkbox.
     pub fn aria_attributes(&self) -> Vec<(&'static str, String)> {
-        let mut attrs = Vec::with_capacity(6);
+        // The allocation size intentionally matches the number of pushed
+        // attributes to avoid runtime reallocations in hot paths.
+        let mut attrs = Vec::with_capacity(7);
         attrs.push(("role", aria::role_checkbox().into()));
-        let (k, v) = aria::aria_checked(self.checked());
+        let (k, v) = aria::aria_checked(self.checked().into());
         attrs.push((k, v.into()));
         let (k, v) = aria::aria_disabled(self.disabled());
         attrs.push((k, v.into()));
@@ -103,7 +143,16 @@ impl CheckboxState {
         ));
         attrs.push((
             "data-checked",
-            if self.checked() { "true" } else { "false" }.to_string(),
+            if self.is_checked() { "true" } else { "false" }.to_string(),
+        ));
+        attrs.push((
+            "data-indeterminate",
+            if self.is_indeterminate() {
+                "true"
+            } else {
+                "false"
+            }
+            .to_string(),
         ));
         attrs.push((
             "data-focus-visible",
@@ -121,12 +170,21 @@ impl CheckboxState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    fn expected_state_after_toggles(initial: CheckboxValue, toggles: u32) -> CheckboxValue {
+        let mut state = initial;
+        for _ in 0..toggles {
+            state = state.toggled();
+        }
+        state
+    }
 
     #[test]
     fn uncontrolled_toggle_updates_state() {
         let mut state = CheckboxState::uncontrolled(false, false);
         state.toggle(|_| {});
-        assert!(state.checked());
+        assert!(state.is_checked());
     }
 
     #[test]
@@ -134,15 +192,15 @@ mod tests {
         let mut state = CheckboxState::controlled(false, false);
         let mut received = None;
         state.toggle(|checked| received = Some(checked));
-        assert_eq!(state.checked(), false);
-        assert_eq!(received, Some(true));
+        assert!(!state.is_checked());
+        assert_eq!(received, Some(CheckboxValue::On));
     }
 
     #[test]
     fn keyboard_space_invokes_toggle() {
         let mut state = CheckboxState::uncontrolled(false, false);
         state.on_key(ControlKey::Space, |_| {});
-        assert!(state.checked());
+        assert!(state.is_checked());
     }
 
     #[test]
@@ -156,16 +214,52 @@ mod tests {
     }
 
     #[test]
+    fn indeterminate_helpers_roundtrip() {
+        let mut state = CheckboxState::uncontrolled(false, false);
+        state.set_indeterminate();
+        assert!(state.is_indeterminate());
+        state.clear_indeterminate();
+        assert!(!state.is_indeterminate());
+        assert!(!state.is_checked());
+    }
+
+    #[test]
     fn aria_attributes_reflect_state() {
-        let mut state = CheckboxState::uncontrolled(false, true);
+        let mut state = CheckboxState::uncontrolled(false, CheckboxValue::Indeterminate);
         state.focus();
         let attrs = state.aria_attributes();
         assert!(attrs.iter().any(|(k, v)| k == &"role" && v == "checkbox"));
         assert!(attrs
             .iter()
-            .any(|(k, v)| k == &"aria-checked" && v == "true"));
+            .any(|(k, v)| k == &"aria-checked" && v == "mixed"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == &"data-indeterminate" && v == "true"));
         assert!(attrs
             .iter()
             .any(|(k, v)| k == &"data-focus-visible" && v == "true"));
+    }
+
+    proptest! {
+        #[test]
+        fn uncontrolled_toggle_matches_enum(
+            start in prop_oneof![Just(CheckboxValue::Off), Just(CheckboxValue::On), Just(CheckboxValue::Indeterminate)],
+            toggles in 0u32..20
+        ) {
+            let mut state = CheckboxState::uncontrolled(false, start);
+            for _ in 0..toggles {
+                state.toggle(|_| {});
+            }
+            prop_assert_eq!(state.checked(), expected_state_after_toggles(start, toggles));
+        }
+
+        #[test]
+        fn controlled_toggle_does_not_mutate_internal_state(
+            start in prop_oneof![Just(CheckboxValue::Off), Just(CheckboxValue::On), Just(CheckboxValue::Indeterminate)],
+        ) {
+            let mut state = CheckboxState::controlled(false, start);
+            state.toggle(|_| {});
+            prop_assert_eq!(state.checked(), start);
+        }
     }
 }

--- a/crates/mui-headless/src/radio.rs
+++ b/crates/mui-headless/src/radio.rs
@@ -223,7 +223,10 @@ impl RadioGroupState {
         let mut attrs = Vec::with_capacity(6);
         attrs.push(("role", aria::role_radio().into()));
         let checked = self.selected == Some(index);
-        let (k, v) = aria::aria_checked(checked);
+        // Radios intentionally stay binary; mapping through `AriaChecked` keeps
+        // the implementation aligned with the richer toggle semantics without
+        // exposing unsupported intermediate values to assistive tech.
+        let (k, v) = aria::aria_checked(aria::AriaChecked::from(checked));
         attrs.push((k, v.into()));
         let (k, v) = aria::aria_disabled(self.disabled);
         attrs.push((k, v.into()));

--- a/crates/mui-headless/tests/checkbox.rs
+++ b/crates/mui-headless/tests/checkbox.rs
@@ -1,0 +1,71 @@
+use mui_headless::checkbox::{CheckboxState, CheckboxValue};
+use mui_headless::interaction::ControlKey;
+
+fn attr<'a>(attrs: &'a [(&'static str, String)], key: &str) -> Option<&'a str> {
+    attrs
+        .iter()
+        .find_map(|(k, v)| if *k == key { Some(v.as_str()) } else { None })
+}
+
+#[test]
+fn keyboard_space_cycles_binary_states() {
+    let mut state = CheckboxState::uncontrolled(false, CheckboxValue::Off);
+    state.on_key(ControlKey::Space, |_| {});
+    assert_eq!(state.checked(), CheckboxValue::On);
+    state.on_key(ControlKey::Space, |_| {});
+    assert_eq!(state.checked(), CheckboxValue::Off);
+}
+
+#[test]
+fn keyboard_space_promotes_indeterminate_to_on() {
+    let mut state = CheckboxState::uncontrolled(false, CheckboxValue::Indeterminate);
+    state.on_key(ControlKey::Space, |_| {});
+    assert_eq!(state.checked(), CheckboxValue::On);
+}
+
+#[test]
+fn controlled_checkbox_syncs_after_callback() {
+    let mut state = CheckboxState::controlled(false, CheckboxValue::Off);
+    let mut requested = None;
+    state.toggle(|value| requested = Some(value));
+    assert_eq!(state.checked(), CheckboxValue::Off);
+    let next = requested.expect("callback should fire");
+    assert_eq!(next, CheckboxValue::On);
+    state.sync_checked(next);
+    assert_eq!(state.checked(), CheckboxValue::On);
+    state.sync_checked(CheckboxValue::Indeterminate);
+    assert_eq!(state.checked(), CheckboxValue::Indeterminate);
+}
+
+#[test]
+fn aria_attributes_cover_three_states() {
+    let states = [
+        CheckboxValue::Off,
+        CheckboxValue::On,
+        CheckboxValue::Indeterminate,
+    ];
+    for value in states {
+        let state = CheckboxState::controlled(false, value);
+        let attrs = state.aria_attributes();
+        let aria_checked = attr(&attrs, "aria-checked").unwrap();
+        let data_checked = attr(&attrs, "data-checked").unwrap();
+        let indeterminate = attr(&attrs, "data-indeterminate").unwrap();
+        match value {
+            CheckboxValue::Off => {
+                assert_eq!(aria_checked, "false");
+                assert_eq!(data_checked, "false");
+                assert_eq!(indeterminate, "false");
+            }
+            CheckboxValue::On => {
+                assert_eq!(aria_checked, "true");
+                assert_eq!(data_checked, "true");
+                assert_eq!(indeterminate, "false");
+            }
+            CheckboxValue::Indeterminate => {
+                assert_eq!(aria_checked, "mixed");
+                assert_eq!(data_checked, "false");
+                assert_eq!(indeterminate, "true");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `ToggleCheckedState` enum so checkboxes can represent off/on/indeterminate while switches continue to surface a binary API
- upgrade the ARIA helper layer to emit `mixed` plus a `data-indeterminate` flag and document how radio/switch adapters consume the richer state
- expand checkbox unit and integration coverage and document the new contract in the crate changelog and workspace README

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features *(fails: mui-system workspace members currently do not compile under full feature matrix)*
- cargo clippy -p mui-headless --all-targets --all-features *(emits pre-existing warnings in list/select modules)*
- cargo test -p mui-headless

------
https://chatgpt.com/codex/tasks/task_e_68ce53c7ed2c832e8df2a84ce85be9cc