### PR TITLE
Add disabled option support to SelectState and update docs

### DIFF
--- a/crates/mui-headless/README.md
+++ b/crates/mui-headless/README.md
@@ -1,0 +1,76 @@
+# mui-headless
+
+Deterministic component state machines designed for SSR friendly rendering,
+enterprise automation hooks, and ergonomic framework adapters. Every public API
+is extensively documented so portal renderers, hydration pipelines, and QA
+suites can share the same mental model without reverse engineering internal
+callbacks.
+
+## Select state machine quick reference
+
+`SelectState` powers listbox-style widgets (selects, combo boxes, virtualized
+menus). The state machine now tracks which options are disabled alongside the
+open/selected/highlighted bookkeeping so adapters can declaratively toggle
+interactivity during SSR and client renders.
+
+- `SelectState::set_option_disabled(index, bool)` updates the internal
+  `Vec<bool>` that mirrors `option_count`. The helper automatically advances the
+  highlight/selection to the nearest enabled option in uncontrolled mode so end
+  users never land on inert entries.
+- `SelectState::is_option_enabled(index)` and
+  `SelectState::is_option_disabled(index)` expose read access for renderers that
+  want to emit `aria-disabled` or `data-disabled` attributes without reimplementing
+  the toggle logic.
+- `SelectState::set_option_count(count)` keeps the disabled vector in sync with
+  dynamic collections and clamps out-of-range indices. This avoids panics when
+  async data loaders swap entire result sets.
+- Navigation (`on_key`, `on_typeahead`) and selection (`select`,
+  `select_highlighted`) helpers automatically skip disabled options and suppress
+  callbacks so analytics hooks do not receive impossible interactions.
+
+### Example (framework agnostic)
+
+```rust
+use mui_headless::select::SelectState;
+use mui_headless::interaction::ControlKey;
+use mui_headless::selection::ControlStrategy;
+
+let mut state = SelectState::new(
+    4,             // options rendered
+    Some(0),       // initial selection
+    false,         // popover closed by default
+    ControlStrategy::Uncontrolled,
+    ControlStrategy::Uncontrolled,
+);
+
+// Disable the third option (index 2) and rely on the state machine to advance
+// highlight/selection without firing callbacks.
+state.set_option_disabled(2, true);
+assert!(state.is_option_disabled(2));
+
+// Keyboard navigation skips disabled entries automatically.
+let next = state.on_key(ControlKey::ArrowDown, |_| {});
+assert_eq!(next, Some(3));
+```
+
+### Testing strategy
+
+Unit tests live alongside the implementations (`src/select.rs`) and document how
+navigation, typeahead fallback, and controlled/uncontrolled sync behave when
+options are disabled. Integration tests in `mui-material` assert that every
+framework adapter emits `aria-disabled`/`data-disabled` attributes so SSR output
+stays deterministic. Run the workspace suites with:
+
+```bash
+cargo test -p mui-headless
+cargo test -p mui-material --all-features
+```
+
+### Automation-friendly design notes
+
+- State machines prefer `Vec<bool>` bookkeeping over closures so they remain
+  `Clone` for deterministic SSR snapshots.
+- Methods never panic on out-of-bounds indices; instead they clamp and early
+  return, making them safe to call from generated UI code.
+- Callbacks are invoked only for enabled options ensuring analytics pipelines
+  do not log interactions end users never saw.

--- a/crates/mui-headless/src/list.rs
+++ b/crates/mui-headless/src/list.rs
@@ -241,7 +241,7 @@ impl ListState {
 
         let mut next = self.selection.clone();
         if matches!(self.selection_mode, SelectionMode::Single) {
-            if next.get(0).copied() == Some(index) {
+            if next.first().copied() == Some(index) {
                 next.clear();
             } else {
                 next.clear();

--- a/crates/mui-headless/src/radio.rs
+++ b/crates/mui-headless/src/radio.rs
@@ -83,6 +83,11 @@ impl RadioGroupState {
         self.options.len()
     }
 
+    /// Returns `true` when the group has no options configured.
+    pub fn is_empty(&self) -> bool {
+        self.options.is_empty()
+    }
+
     /// Whether the group is disabled.
     pub fn disabled(&self) -> bool {
         self.disabled
@@ -120,7 +125,7 @@ impl RadioGroupState {
 
     /// Apply focus to an option.
     pub fn focus(&mut self, index: usize) {
-        if self.len() == 0 {
+        if self.is_empty() {
             return;
         }
         self.focus_visible = Some(index.min(self.len() - 1));
@@ -149,7 +154,7 @@ impl RadioGroupState {
 
     /// Handle keyboard input according to the ARIA radio group guidance.
     pub fn on_key<F: FnOnce(usize)>(&mut self, key: ControlKey, callback: F) {
-        if self.disabled || self.len() == 0 {
+        if self.disabled || self.is_empty() {
             return;
         }
         let mut focus_index = self

--- a/crates/mui-material/README.md
+++ b/crates/mui-material/README.md
@@ -110,6 +110,27 @@ alongside the markup to keep hydration shells and analytics dashboards in sync.
   document broader SSR pipelines including global style flushing and automated
   accessibility checks.
 
+## Select component guide
+
+Material select adapters consume the headless [`SelectState`](../mui-headless/src/select.rs)
+directly.  Disabled bookkeeping is centralized in the state machine so renderers
+emit consistent ARIA/data attributes without duplicating logic:
+
+- Call `state.set_option_disabled(index, bool)` whenever async data or business
+  rules change option availability. Uncontrolled selects automatically advance
+  the highlight/selection to the next enabled entry.
+- Use `state.is_option_enabled(index)` to mirror the disabled contract into the
+  rendered HTML. The shared renderer now stamps both `aria-disabled` and
+  `data-disabled` hooks so SSR and hydration markup stay aligned.
+- Navigation helpers (`on_key`, `on_typeahead`) skip disabled islands; adapters
+  only need to forward the callbacks and respond to the returned indices (for
+  example to scroll newly highlighted rows into view).
+
+The framework-specific tests under `tests/select_adapters.rs` assert that Yew,
+Leptos, Dioxus, and Sycamore renders all include the disabled metadata. When
+augmenting the component ensure any additional markup preserves these hooks so
+end-to-end automation continues to function.
+
 ## Framework adapters & portal orchestration
 
 Every Material component exposes framework-specific adapter modules (`yew`,

--- a/crates/mui-material/src/select.rs
+++ b/crates/mui-material/src/select.rs
@@ -207,9 +207,12 @@ fn option_attributes(
     attrs.push(("role".into(), state.option_role().into()));
     let is_selected = state.selected() == Some(index);
     let is_highlighted = state.highlighted() == Some(index);
+    let is_disabled = state.is_option_disabled(index);
     attrs.push(("aria-selected".into(), is_selected.to_string()));
+    attrs.push(("aria-disabled".into(), is_disabled.to_string()));
     attrs.push(("data-selected".into(), is_selected.to_string()));
     attrs.push(("data-highlighted".into(), is_highlighted.to_string()));
+    attrs.push(("data-disabled".into(), is_disabled.to_string()));
     attrs.push(("data-index".into(), index.to_string()));
     attrs.push(("data-value".into(), props.options[index].value.clone()));
     if let Some(id) = &props.automation_id {

--- a/crates/mui-material/tests/select_adapters.rs
+++ b/crates/mui-material/tests/select_adapters.rs
@@ -30,6 +30,10 @@ fn assert_portal_markup(html: &str) {
         1,
         "options should only be rendered once"
     );
+    assert!(
+        html.contains("aria-disabled=\"false\""),
+        "options should surface their disabled metadata"
+    );
 }
 
 #[cfg(feature = "yew")]
@@ -43,6 +47,16 @@ mod yew_tests {
         let html = select::yew::render(&props, &state);
         assert!(html.contains("data-automation-id=\"adapter-select\""));
         assert_portal_markup(&html);
+    }
+
+    #[test]
+    fn yew_render_marks_disabled_options() {
+        let props = sample_props();
+        let mut state = build_state(props.options.len());
+        state.set_option_disabled(1, true);
+        let html = select::yew::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
     }
 }
 
@@ -58,6 +72,16 @@ mod leptos_tests {
         assert!(html.contains("data-automation-id=\"adapter-select\""));
         assert_portal_markup(&html);
     }
+
+    #[test]
+    fn leptos_render_marks_disabled_options() {
+        let props = sample_props();
+        let mut state = build_state(props.options.len());
+        state.set_option_disabled(1, true);
+        let html = select::leptos::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
+    }
 }
 
 #[cfg(feature = "dioxus")]
@@ -72,6 +96,16 @@ mod dioxus_tests {
         assert!(html.contains("data-component=\"mui-select\""));
         assert_portal_markup(&html);
     }
+
+    #[test]
+    fn dioxus_render_marks_disabled_options() {
+        let props = sample_props();
+        let mut state = build_state(props.options.len());
+        state.set_option_disabled(1, true);
+        let html = select::dioxus::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
+    }
 }
 
 #[cfg(feature = "sycamore")]
@@ -85,5 +119,15 @@ mod sycamore_tests {
         let html = select::sycamore::render(&props, &state);
         assert!(html.contains("data-automation-id=\"adapter-select\""));
         assert_portal_markup(&html);
+    }
+
+    #[test]
+    fn sycamore_render_marks_disabled_options() {
+        let props = sample_props();
+        let mut state = build_state(props.options.len());
+        state.set_option_disabled(1, true);
+        let html = select::sycamore::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
     }
 }

--- a/examples/select-menu-leptos/README.md
+++ b/examples/select-menu-leptos/README.md
@@ -24,6 +24,17 @@ The component spins up immediately with a fallback message, then updates once
 the async loader resolves. Toggle buttons demonstrate how controlled props can
 be wired into existing signals without bypassing the shared render helpers.
 
+Whenever business rules deactivate a region you can flip the headless state in
+place and let the renderer mirror the disabled affordance:
+
+```rust
+state.update(|state| state.set_option_disabled(1, true));
+```
+
+This keeps the SSR snapshot and CSR hydration path aligned because the
+underlying `SelectState` skips disabled options for keyboard/typeahead
+navigation while emitting the appropriate ARIA/data hooks for analytics.
+
 ## Server-side rendering smoke test
 
 ```bash

--- a/examples/select-menu-shared/README.md
+++ b/examples/select-menu-shared/README.md
@@ -16,6 +16,11 @@ markup, expose the same `data-*` hooks, and hydrate against the same HTML shell.
 - `selection_summary` &mdash; utility that produces a human-readable status line for
   automation and screen readers.
 
+The helpers bubble the headless disabled bookkeeping through to the shared
+renderer so any framework can call `state.set_option_disabled(index, true)` and
+receive matching `aria-disabled`/`data-disabled` hooks in both SSR and CSR
+renders without patching adapter code.
+
 ## Running the unit tests
 
 The crate currently exposes helpers only, but you can still compile the

--- a/examples/select-menu-yew/README.md
+++ b/examples/select-menu-yew/README.md
@@ -25,6 +25,18 @@ keeps the select fully controlled via Yew state hooks. Every interactive element
 exposes deterministic `data-automation` attributes so CI tooling can exercise
 the workflow without relying on brittle CSS selectors.
 
+Disabled regions can be toggled directly on the headless state machine without
+rewriting any adapter code:
+
+```rust
+state.set_option_disabled(2, true); // drop the third region from the active list
+```
+
+The Material renderer will automatically emit `aria-disabled="true"` and
+`data-disabled="true"` for the affected option while keyboard navigation skips
+over it. Controlled demos simply synchronize the state through the existing Yew
+signals to keep hydration and analytics in lock-step.
+
 ## Server-side rendering smoke test
 
 ```bash


### PR DESCRIPTION
## Summary
- track option disabled state inside `SelectState` and surface new helpers that keep highlights, selections, and typeahead navigation synchronized with enabled entries
- expose disabled metadata through Material option attributes and expand cross-framework adapter tests to cover disabled rendering
- document the disabled workflow across headless and example guides to show how adapters toggle interactivity declaratively

## Testing
- cargo test -p mui-headless
- cargo test -p mui-material
- cargo xtask clippy *(fails: mui-system yew adapter expects different hook signature and rustdoc attr style issues)*
- pnpm test *(fails: Node.js 22.18.0+ required, container ships v20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ced16f06d0832ebd999ba793ff02a0