### PR TITLE
feat: add disabled item tracking to headless menu

### DIFF
--- a/crates/mui-material/src/menu.rs
+++ b/crates/mui-material/src/menu.rs
@@ -177,6 +177,9 @@ fn item_attributes(props: &MenuProps, state: &MenuState, index: usize) -> Vec<(S
     attrs.push(("role".into(), state.item_role().into()));
     let is_highlighted = state.highlighted() == Some(index);
     attrs.push(("data-highlighted".into(), is_highlighted.to_string()));
+    let is_disabled = state.is_item_disabled(index);
+    attrs.push(("aria-disabled".into(), is_disabled.to_string()));
+    attrs.push(("data-disabled".into(), is_disabled.to_string()));
     attrs.push(("data-index".into(), index.to_string()));
     attrs.push(("data-command".into(), props.items[index].command.clone()));
     if let Some(id) = &props.automation_id {
@@ -418,5 +421,19 @@ mod tests {
             "menu surface should only render once"
         );
         assert!(html.contains("data-portal-layer=\"popover\""));
+    }
+
+    #[test]
+    fn item_attributes_reflect_disabled_flags() {
+        let props = sample_props();
+        let mut state = build_state(props.items.len());
+        state.set_item_disabled(1, true);
+        let attrs = item_attributes(&props, &state, 1);
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == "aria-disabled" && v == "true"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == "data-disabled" && v == "true"));
     }
 }

--- a/crates/mui-material/tests/menu_adapters.rs
+++ b/crates/mui-material/tests/menu_adapters.rs
@@ -40,6 +40,16 @@ mod yew_tests {
         assert!(html.contains("data-automation-id=\"adapter-menu\""));
         assert_portal_markup(&html);
     }
+
+    #[test]
+    fn yew_render_marks_disabled_items() {
+        let props = sample_props();
+        let mut state = build_state(props.items.len());
+        state.set_item_disabled(1, true);
+        let html = menu::yew::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
+    }
 }
 
 #[cfg(feature = "leptos")]
@@ -53,6 +63,16 @@ mod leptos_tests {
         let html = menu::leptos::render(&props, &state);
         assert!(html.contains("data-automation-id=\"adapter-menu\""));
         assert_portal_markup(&html);
+    }
+
+    #[test]
+    fn leptos_render_marks_disabled_items() {
+        let props = sample_props();
+        let mut state = build_state(props.items.len());
+        state.set_item_disabled(1, true);
+        let html = menu::leptos::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
     }
 }
 
@@ -68,6 +88,16 @@ mod dioxus_tests {
         assert!(html.contains("data-automation-id=\"adapter-menu\""));
         assert_portal_markup(&html);
     }
+
+    #[test]
+    fn dioxus_render_marks_disabled_items() {
+        let props = sample_props();
+        let mut state = build_state(props.items.len());
+        state.set_item_disabled(1, true);
+        let html = menu::dioxus::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
+    }
 }
 
 #[cfg(feature = "sycamore")]
@@ -81,5 +111,15 @@ mod sycamore_tests {
         let html = menu::sycamore::render(&props, &state);
         assert!(html.contains("data-component=\"mui-menu\""));
         assert_portal_markup(&html);
+    }
+
+    #[test]
+    fn sycamore_render_marks_disabled_items() {
+        let props = sample_props();
+        let mut state = build_state(props.items.len());
+        state.set_item_disabled(1, true);
+        let html = menu::sycamore::render(&props, &state);
+        assert!(html.contains("aria-disabled=\"true\""));
+        assert!(html.contains("data-disabled=\"true\""));
     }
 }

--- a/docs/data/material/components/menus/menus.md
+++ b/docs/data/material/components/menus/menus.md
@@ -52,6 +52,16 @@ To use a selected menu item without impacting the initial focus, set the `varian
 
 {{"demo": "SimpleListMenu.js"}}
 
+## Disabled menu items
+
+Use the `disabled` prop on `MenuItem` to prevent pointer and keyboard activation.
+For headless Rust adapters (`mui-headless` + `mui-material`), call
+`MenuState::set_item_disabled(index, true)` to toggle interactivity at runtime.
+The generated markup exposes both `aria-disabled="true"` and
+`data-disabled="true"` so automated tests, custom styling, and accessibility
+audits all observe the same state whether the menu is rendered during SSR or in
+the browser.
+
 ## Positioned menu
 
 Because the `Menu` component uses the `Popover` component to position itself, you can use the same [positioning props](/material-ui/react-popover/#anchor-playground) to position it.


### PR DESCRIPTION
## Summary
- extend `MenuState` with disabled bookkeeping, helper APIs, and navigation safeguards so inert entries are skipped during keyboard/typeahead
- surface `aria-disabled`/`data-disabled` in the material menu renderer and ensure every adapter honours the new state
- document the disabled workflow for headless consumers and the menu guide, and backfill unit/wasm tests that prove the behaviour

## Testing
- make fmt
- cargo test -p mui-headless
- cargo test -p mui-material --tests

------
https://chatgpt.com/codex/tasks/task_e_68cedb56761c832e9193ce2ab13be636