### PR TITLE
feat(headless): add optional disabled attribute builders

### DIFF
--- a/crates/mui-headless/src/checkbox.rs
+++ b/crates/mui-headless/src/checkbox.rs
@@ -131,12 +131,11 @@ impl CheckboxState {
     pub fn aria_attributes(&self) -> Vec<(&'static str, String)> {
         // The allocation size intentionally matches the number of pushed
         // attributes to avoid runtime reallocations in hot paths.
-        let mut attrs = Vec::with_capacity(7);
+        let mut attrs = Vec::with_capacity(8);
         attrs.push(("role", aria::role_checkbox().into()));
         let (k, v) = aria::aria_checked(self.checked().into());
         attrs.push((k, v.into()));
-        let (k, v) = aria::aria_disabled(self.disabled());
-        attrs.push((k, v.into()));
+        aria::extend_disabled_attributes(&mut attrs, self.disabled());
         attrs.push((
             "tabindex",
             if self.disabled() { "-1" } else { "0" }.to_string(),

--- a/crates/mui-headless/src/chip.rs
+++ b/crates/mui-headless/src/chip.rs
@@ -372,10 +372,16 @@ impl<'a, C: Clock> ChipAttributes<'a, C> {
         self.described_by.map(aria::aria_describedby)
     }
 
-    /// Returns the `aria-disabled` attribute based on state.
+    /// Returns the `aria-disabled` attribute when the chip is disabled.
     #[inline]
-    pub fn disabled(&self) -> (&'static str, &'static str) {
+    pub fn disabled(&self) -> Option<(&'static str, String)> {
         aria::aria_disabled(self.state.disabled())
+    }
+
+    /// Returns the `data-disabled` attribute when the chip is disabled.
+    #[inline]
+    pub fn data_disabled(&self) -> Option<(&'static str, String)> {
+        aria::data_disabled(self.state.disabled())
     }
 
     /// Returns the `aria-hidden` attribute when the chip has been deleted.

--- a/crates/mui-headless/src/radio.rs
+++ b/crates/mui-headless/src/radio.rs
@@ -215,17 +215,18 @@ impl RadioGroupState {
 
     /// ARIA metadata for the group container.
     pub fn group_aria_attributes(&self) -> Vec<(&'static str, String)> {
-        let mut attrs = Vec::with_capacity(3);
+        let mut attrs = Vec::with_capacity(4);
         attrs.push(("role", "radiogroup".into()));
         attrs.push(("aria-orientation", self.orientation.as_aria().into()));
-        let (k, v) = aria::aria_disabled(self.disabled);
-        attrs.push((k, v.into()));
+        if let Some((k, v)) = aria::aria_disabled(self.disabled) {
+            attrs.push((k, v));
+        }
         attrs
     }
 
     /// ARIA metadata for a specific option.
     pub fn option_aria_attributes(&self, index: usize) -> Vec<(&'static str, String)> {
-        let mut attrs = Vec::with_capacity(6);
+        let mut attrs = Vec::with_capacity(7);
         attrs.push(("role", aria::role_radio().into()));
         let checked = self.selected == Some(index);
         // Radios intentionally stay binary; mapping through `AriaChecked` keeps
@@ -233,8 +234,7 @@ impl RadioGroupState {
         // exposing unsupported intermediate values to assistive tech.
         let (k, v) = aria::aria_checked(aria::AriaChecked::from(checked));
         attrs.push((k, v.into()));
-        let (k, v) = aria::aria_disabled(self.disabled);
-        attrs.push((k, v.into()));
+        aria::extend_disabled_attributes(&mut attrs, self.disabled);
         attrs.push((
             "tabindex",
             if checked || self.selected.is_none() && index == 0 {

--- a/crates/mui-headless/src/switch.rs
+++ b/crates/mui-headless/src/switch.rs
@@ -95,8 +95,9 @@ impl SwitchState {
         attrs.push(("role", aria::role_switch().into()));
         let (k, v) = aria::aria_checked(aria::AriaChecked::from(self.inner.checked()));
         attrs.push((k, v.into()));
-        let (k, v) = aria::aria_disabled(self.disabled());
-        attrs.push((k, v.into()));
+        if let Some((k, v)) = aria::aria_disabled(self.disabled()) {
+            attrs.push((k, v));
+        }
         attrs.push((
             "tabindex",
             if self.disabled() { "-1" } else { "0" }.to_string(),

--- a/crates/mui-headless/tests/chip.rs
+++ b/crates/mui-headless/tests/chip.rs
@@ -98,11 +98,17 @@ fn aria_builders_reflect_state() {
     assert_eq!(attrs.labelledby(), Some(("aria-labelledby", "label")));
     assert_eq!(attrs.describedby(), Some(("aria-describedby", "hint")));
     assert_eq!(attrs.hidden(), ("aria-hidden", "false"));
+    assert_eq!(ChipAttributes::new(&state).disabled(), None);
+    assert_eq!(ChipAttributes::new(&state).data_disabled(), None);
 
     state.set_disabled(true);
     assert_eq!(
         ChipAttributes::new(&state).disabled(),
-        ("aria-disabled", "true")
+        Some(("aria-disabled", "true".into()))
+    );
+    assert_eq!(
+        ChipAttributes::new(&state).data_disabled(),
+        Some(("data-disabled", "true".into()))
     );
 
     let delete_attrs = ChipDeleteAttributes::new(&state).label("Remove filter");

--- a/crates/mui-material/README.md
+++ b/crates/mui-material/README.md
@@ -119,9 +119,11 @@ emit consistent ARIA/data attributes without duplicating logic:
 - Call `state.set_option_disabled(index, bool)` whenever async data or business
   rules change option availability. Uncontrolled selects automatically advance
   the highlight/selection to the next enabled entry.
-- Use `state.is_option_enabled(index)` to mirror the disabled contract into the
-  rendered HTML. The shared renderer now stamps both `aria-disabled` and
-  `data-disabled` hooks so SSR and hydration markup stay aligned.
+- Use `state.option_accessibility_attributes(index)` to pull the `role` and
+  optional disabled metadata straight from the state machine. The shared
+  renderer extends the returned vector with automation hooks so SSR and
+  hydration markup stay aligned without manual `data-disabled="false"`
+  bookkeeping.
 - Navigation helpers (`on_key`, `on_typeahead`) skip disabled islands; adapters
   only need to forward the callbacks and respond to the returned indices (for
   example to scroll newly highlighted rows into view).

--- a/crates/mui-material/src/chip.rs
+++ b/crates/mui-material/src/chip.rs
@@ -182,8 +182,9 @@ fn root_attributes(
     if let Some((key, value)) = builder.describedby() {
         attrs.push((key.into(), value.into()));
     }
-    let (disabled_key, disabled_value) = builder.disabled();
-    attrs.push((disabled_key.into(), disabled_value.into()));
+    if let Some((disabled_key, disabled_value)) = builder.disabled() {
+        attrs.push((disabled_key.into(), disabled_value));
+    }
     let (hidden_key, hidden_value) = builder.hidden();
     attrs.push((hidden_key.into(), hidden_value.into()));
     attrs.push((
@@ -200,7 +201,9 @@ fn root_attributes(
         "data-deletion-pending".into(),
         state.deletion_pending().to_string(),
     ));
-    attrs.push(("data-disabled".into(), state.disabled().to_string()));
+    if let Some((data_key, data_value)) = builder.data_disabled() {
+        attrs.push((data_key.into(), data_value));
+    }
     attrs.push(("data-dismissible".into(), props.dismissible.to_string()));
     attrs.push(("data-label-id".into(), label_id.to_string()));
     attrs.push(("data-delete-id".into(), delete_id.to_string()));

--- a/crates/mui-material/src/menu.rs
+++ b/crates/mui-material/src/menu.rs
@@ -174,12 +174,11 @@ fn surface_attributes(
 fn item_attributes(props: &MenuProps, state: &MenuState, index: usize) -> Vec<(String, String)> {
     let mut attrs = Vec::new();
     attrs.push(("id".into(), item_id(props, index)));
-    attrs.push(("role".into(), state.item_role().into()));
+    for (key, value) in state.item_accessibility_attributes(index) {
+        attrs.push((key.into(), value));
+    }
     let is_highlighted = state.highlighted() == Some(index);
     attrs.push(("data-highlighted".into(), is_highlighted.to_string()));
-    let is_disabled = state.is_item_disabled(index);
-    attrs.push(("aria-disabled".into(), is_disabled.to_string()));
-    attrs.push(("data-disabled".into(), is_disabled.to_string()));
     attrs.push(("data-index".into(), index.to_string()));
     attrs.push(("data-command".into(), props.items[index].command.clone()));
     if let Some(id) = &props.automation_id {

--- a/crates/mui-material/src/select.rs
+++ b/crates/mui-material/src/select.rs
@@ -204,15 +204,14 @@ fn option_attributes(
 ) -> Vec<(String, String)> {
     let mut attrs = Vec::new();
     attrs.push(("id".into(), option_id(props, index)));
-    attrs.push(("role".into(), state.option_role().into()));
+    for (key, value) in state.option_accessibility_attributes(index) {
+        attrs.push((key.into(), value));
+    }
     let is_selected = state.selected() == Some(index);
     let is_highlighted = state.highlighted() == Some(index);
-    let is_disabled = state.is_option_disabled(index);
     attrs.push(("aria-selected".into(), is_selected.to_string()));
-    attrs.push(("aria-disabled".into(), is_disabled.to_string()));
     attrs.push(("data-selected".into(), is_selected.to_string()));
     attrs.push(("data-highlighted".into(), is_highlighted.to_string()));
-    attrs.push(("data-disabled".into(), is_disabled.to_string()));
     attrs.push(("data-index".into(), index.to_string()));
     attrs.push(("data-value".into(), props.options[index].value.clone()));
     if let Some(id) = &props.automation_id {

--- a/crates/mui-material/tests/menu_adapters.rs
+++ b/crates/mui-material/tests/menu_adapters.rs
@@ -26,6 +26,14 @@ fn assert_portal_markup(html: &str) {
         1,
         "menu surface should only render once"
     );
+    assert!(
+        !html.contains("aria-disabled=\"false\""),
+        "enabled menu items should omit aria-disabled"
+    );
+    assert!(
+        !html.contains("data-disabled=\"false\""),
+        "enabled menu items should omit data-disabled"
+    );
 }
 
 #[cfg(feature = "yew")]

--- a/crates/mui-material/tests/select_adapters.rs
+++ b/crates/mui-material/tests/select_adapters.rs
@@ -30,9 +30,14 @@ fn assert_portal_markup(html: &str) {
         1,
         "options should only be rendered once"
     );
+    assert!(html.contains("role=\"option\""));
     assert!(
-        html.contains("aria-disabled=\"false\""),
-        "options should surface their disabled metadata"
+        !html.contains("aria-disabled=\"false\""),
+        "enabled options should omit aria-disabled metadata"
+    );
+    assert!(
+        !html.contains("data-disabled=\"false\""),
+        "enabled options should omit data-disabled metadata"
     );
 }
 

--- a/crates/mui-material/tests/wasm.rs
+++ b/crates/mui-material/tests/wasm.rs
@@ -631,6 +631,13 @@ async fn menu_disabled_items_expose_state_and_pass_axe() {
         "true"
     );
 
+    let enabled_item = mount
+        .query_selector("[data-automation-item='wasm-menu-0']")
+        .unwrap()
+        .expect("enabled menu item rendered");
+    assert!(enabled_item.get_attribute("aria-disabled").is_none());
+    assert!(enabled_item.get_attribute("data-disabled").is_none());
+
     axe_check(&mount).await;
 }
 

--- a/docs/data/material/components/menus/menus.md
+++ b/docs/data/material/components/menus/menus.md
@@ -58,9 +58,9 @@ Use the `disabled` prop on `MenuItem` to prevent pointer and keyboard activation
 For headless Rust adapters (`mui-headless` + `mui-material`), call
 `MenuState::set_item_disabled(index, true)` to toggle interactivity at runtime.
 The generated markup exposes both `aria-disabled="true"` and
-`data-disabled="true"` so automated tests, custom styling, and accessibility
-audits all observe the same state whether the menu is rendered during SSR or in
-the browser.
+`data-disabled="true"` only when an item is disabled so automated tests, custom
+styling, and accessibility audits observe the same state whether the menu is
+rendered during SSR or in the browser.
 
 ## Positioned menu
 

--- a/examples/select-menu-leptos/README.md
+++ b/examples/select-menu-leptos/README.md
@@ -33,7 +33,10 @@ state.update(|state| state.set_option_disabled(1, true));
 
 This keeps the SSR snapshot and CSR hydration path aligned because the
 underlying `SelectState` skips disabled options for keyboard/typeahead
-navigation while emitting the appropriate ARIA/data hooks for analytics.
+navigation while emitting the appropriate ARIA/data hooks for analytics via
+`SelectState::option_accessibility_attributes`. Enabled options therefore omit
+`aria-disabled="false"` noise while disabled entries reliably expose both
+attributes for styling and automation.
 
 ## Server-side rendering smoke test
 

--- a/examples/select-menu-shared/README.md
+++ b/examples/select-menu-shared/README.md
@@ -19,7 +19,10 @@ markup, expose the same `data-*` hooks, and hydrate against the same HTML shell.
 The helpers bubble the headless disabled bookkeeping through to the shared
 renderer so any framework can call `state.set_option_disabled(index, true)` and
 receive matching `aria-disabled`/`data-disabled` hooks in both SSR and CSR
-renders without patching adapter code.
+renders without patching adapter code. Internally the renderer relies on
+`SelectState::option_accessibility_attributes` so enabled options omit
+`aria-disabled="false"` noise while disabled options consistently expose both
+attributes for automation and styling.
 
 ## Running the unit tests
 

--- a/examples/select-menu-yew/README.md
+++ b/examples/select-menu-yew/README.md
@@ -34,8 +34,10 @@ state.set_option_disabled(2, true); // drop the third region from the active lis
 
 The Material renderer will automatically emit `aria-disabled="true"` and
 `data-disabled="true"` for the affected option while keyboard navigation skips
-over it. Controlled demos simply synchronize the state through the existing Yew
-signals to keep hydration and analytics in lock-step.
+over it. The implementation leans on
+`SelectState::option_accessibility_attributes` so enabled items omit noisy
+`aria-disabled="false"` tuples. Controlled demos simply synchronize the state
+through the existing Yew signals to keep hydration and analytics in lock-step.
 
 ## Server-side rendering smoke test
 


### PR DESCRIPTION
## Summary
- add optional aria/data disabled helpers and a shared extender so adapters stop emitting `false` tuples
- expose new attribute builders on SelectState/MenuState and update Rust adapters/tests/docs to consume them
- refresh developer guides and wasm regression checks to cover disabled vs enabled markup

## Testing
- cargo test -p mui-headless
- cargo test -p mui-material --features yew *(fails: mui-system yew hook compile error)*
- cargo test -p mui-material --features leptos *(fails: existing leptos component macro conflicts)*
- pnpm --filter @mui/material test -- --reporter dot --grep "aria-disabled" *(fails: Node 20.19.4 below required >=22.18.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cee310b290832eb995285e67199328