### PR TITLE
feat(xtask): support configurable theme generation formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4174,6 +4174,7 @@ dependencies = [
  "clap",
  "mui-system",
  "serde_json",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ sycamore = { version = "0.9" }
 tokio = { version = "1.37", default-features = false, features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0"
+toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 wasm-bindgen-test = "0.3"
 # Tooling dependencies powering `cargo xtask`.
 clap = { version = "4.5", features = ["derive", "std"], default-features = false }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -8,4 +8,5 @@ publish = false
 clap = { workspace = true, features = ["derive", "std"] }
 anyhow = { workspace = true }
 serde_json.workspace = true
+toml.workspace = true
 mui-system = { path = "../mui-system" }


### PR DESCRIPTION
## Summary
- teach the `generate-theme` task to accept optional override fixtures and a configurable output format
- merge overrides into the canonical Material theme before emitting JSON or TOML along with a matching CSS baseline
- wire up the `toml` dependency in the workspace so automation can serialize the new format

## Testing
- cargo xtask generate-theme --overrides /tmp/theme_override.json --format json
- cargo xtask generate-theme --overrides /tmp/theme_override.toml --format toml

------
https://chatgpt.com/codex/tasks/task_e_68d0798814ac832ea46530e90070164a