### PR TITLE
Add integration tests for xtask theme generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ast_node"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +234,17 @@ name = "boolinator"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -548,6 +575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dioxus"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +615,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "drain_filter_polyfill"
@@ -667,6 +706,15 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -1979,6 +2027,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2284,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp 0.10.0",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3003,7 +3087,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
- "float-cmp",
+ "float-cmp 0.9.0",
 ]
 
 [[package]]
@@ -3362,6 +3446,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -4171,8 +4261,10 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "mui-system",
+ "predicates",
  "serde_json",
  "toml 0.8.23",
 ]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,3 +10,7 @@ anyhow = { workspace = true }
 serde_json.workspace = true
 toml.workspace = true
 mui-system = { path = "../mui-system" }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/crates/xtask/tests/fixtures/material_overrides.json
+++ b/crates/xtask/tests/fixtures/material_overrides.json
@@ -1,0 +1,25 @@
+{
+  "typography": {
+    "font_family": "Corporate Sans, Arial, sans-serif",
+    "font_family_monospace": "Corporate Mono, Menlo, monospace",
+    "font_size": 16,
+    "html_font_size": 18,
+    "font_weight_bold": 910
+  },
+  "schemes": {
+    "light": {
+      "palette": {
+        "primary": "#0057b7",
+        "background_default": "#f4f6fb",
+        "text_primary": "#0f172a"
+      }
+    },
+    "dark": {
+      "palette": {
+        "primary": "#ffd700",
+        "background_default": "#020617",
+        "text_primary": "#e2e8f0"
+      }
+    }
+  }
+}

--- a/crates/xtask/tests/generate_theme.rs
+++ b/crates/xtask/tests/generate_theme.rs
@@ -1,0 +1,202 @@
+//! Integration tests exercising the `cargo xtask generate-theme` automation pipeline.
+//!
+//! These tests spin up the command end-to-end to guarantee that future
+//! refactors keep producing artifacts compatible with large enterprise
+//! consumers that depend on our serialized themes and CSS baselines.
+
+use anyhow::Result;
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Captures the original state of a generated file so we can restore it once the
+/// integration test completes.
+///
+/// We snapshot the bytes instead of merely tracking a boolean because the xtask
+/// pipeline is expected to rewrite the files on every invocation. Restoring the
+/// precise contents keeps `git status` clean for developers running the tests
+/// locally and mirrors how CI should leave the repository.
+#[derive(Debug)]
+struct FileSnapshot {
+    path: PathBuf,
+    original_bytes: Option<Vec<u8>>,
+}
+
+impl FileSnapshot {
+    /// Takes a best-effort snapshot of the file located at `path`.
+    fn new(path: PathBuf) -> Self {
+        let original_bytes = fs::read(&path).ok();
+        Self {
+            path,
+            original_bytes,
+        }
+    }
+
+    /// Restores the file to its original state.
+    fn restore(&self) {
+        match &self.original_bytes {
+            Some(bytes) => {
+                if let Err(error) = fs::write(&self.path, bytes) {
+                    eprintln!("[test] failed to restore {}: {error}", self.path.display());
+                }
+            }
+            None => match fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    eprintln!(
+                        "[test] failed to remove {} during cleanup: {error}",
+                        self.path.display()
+                    );
+                }
+            },
+        }
+    }
+}
+
+impl Drop for FileSnapshot {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+/// Helper returning the repository root so we can invoke `cargo xtask` with the same
+/// working directory as human contributors.
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("xtask is nested two levels below the workspace root")
+        .to_path_buf()
+}
+
+/// Ensures that `cargo xtask generate-theme` keeps producing both light and dark
+/// artifacts when fixture overrides are supplied. The command should log helpful
+/// context for maintainers, and the generated JSON + CSS outputs must reflect the
+/// merged tokens.
+#[test]
+fn generates_light_and_dark_artifacts_with_fixtures() -> Result<()> {
+    let workspace = workspace_root();
+    let fixtures = workspace.join("crates/xtask/tests/fixtures");
+    let overrides = fixtures.join("material_overrides.json");
+    assert!(overrides.exists(), "fixture missing: {overrides:?}");
+
+    let templates_dir = workspace.join("crates/mui-system/templates");
+    let expected_outputs = [
+        templates_dir.join("material_theme.light.json"),
+        templates_dir.join("material_theme.dark.json"),
+        templates_dir.join("material_css_baseline.light.css"),
+        templates_dir.join("material_css_baseline.dark.css"),
+    ];
+
+    // Snapshot existing artifacts so the repository stays clean for local developers.
+    let _snapshots: Vec<FileSnapshot> = expected_outputs
+        .iter()
+        .cloned()
+        .map(FileSnapshot::new)
+        .collect();
+
+    // Execute the xtask command exactly like CI would.
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("xtask")
+        .arg("generate-theme")
+        .arg("--overrides")
+        .arg(&overrides);
+
+    let assertion = cmd
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "generating Material theme artifacts",
+        ))
+        .stdout(predicates::str::contains("loading overrides"));
+
+    // Verify that the log output remains descriptive for maintainers who rely on CI logs.
+    let stdout = String::from_utf8_lossy(&assertion.get_output().stdout);
+    assert!(
+        stdout.contains("[xtask] wrote crates/mui-system/templates/material_theme.light.json"),
+        "xtask output should mention the light theme artifact"
+    );
+    assert!(
+        stdout.contains("[xtask] wrote crates/mui-system/templates/material_theme.dark.json"),
+        "xtask output should mention the dark theme artifact"
+    );
+
+    // Confirm that every artifact exists so downstream tooling can consume it.
+    for path in &expected_outputs {
+        assert!(path.exists(), "expected artifact missing: {path:?}");
+    }
+
+    let light_json = fs::read_to_string(&expected_outputs[0])?;
+    let dark_json = fs::read_to_string(&expected_outputs[1])?;
+    let light_value: Value = serde_json::from_str(&light_json)?;
+    let dark_value: Value = serde_json::from_str(&dark_json)?;
+
+    // Global typography overrides should apply to all schemes.
+    assert_eq!(
+        light_value
+            .get("typography")
+            .and_then(|t| t.get("font_family"))
+            .and_then(Value::as_str),
+        Some("Corporate Sans, Arial, sans-serif")
+    );
+    assert_eq!(
+        dark_value
+            .get("typography")
+            .and_then(|t| t.get("font_family"))
+            .and_then(Value::as_str),
+        Some("Corporate Sans, Arial, sans-serif")
+    );
+    assert_eq!(
+        dark_value
+            .get("typography")
+            .and_then(|t| t.get("font_weight_bold"))
+            .and_then(Value::as_f64),
+        Some(910.0)
+    );
+
+    // Scheme-specific palette overrides should only affect their respective outputs.
+    assert_eq!(
+        light_value
+            .get("palette")
+            .and_then(|p| p.get("primary"))
+            .and_then(Value::as_str),
+        Some("#0057b7")
+    );
+    assert_eq!(
+        dark_value
+            .get("palette")
+            .and_then(|p| p.get("primary"))
+            .and_then(Value::as_str),
+        Some("#ffd700")
+    );
+
+    // CSS baselines should capture typography + palette overrides so applications render correctly.
+    let light_css = fs::read_to_string(&expected_outputs[2])?;
+    let dark_css = fs::read_to_string(&expected_outputs[3])?;
+    assert!(
+        light_css.contains("font-family: Corporate Sans, Arial, sans-serif"),
+        "Light CSS baseline should include the global typography override"
+    );
+    assert!(
+        dark_css.contains("font-family: Corporate Sans, Arial, sans-serif"),
+        "Dark CSS baseline should include the global typography override"
+    );
+    assert!(
+        light_css.contains("background-color: #f4f6fb"),
+        "Light CSS baseline should include the light scheme background color"
+    );
+    assert!(
+        dark_css.contains("background-color: #020617"),
+        "Dark CSS baseline should include the dark scheme background color"
+    );
+    assert!(
+        dark_css.contains("color: #e2e8f0"),
+        "Dark CSS baseline should include the dark scheme text color"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add integration coverage that runs `cargo xtask generate-theme` with fixture overrides and validates log output plus generated assets
- snapshot generated theme artefacts during the test to leave the repository clean while asserting merged JSON and CSS tokens
- add reusable fixture data along with `assert_cmd`/`predicates` dev dependencies for the xtask crate

## Testing
- cargo test -p xtask --all-features

------
https://chatgpt.com/codex/tasks/task_e_68d0861bc7c4832ea3661077708cf7c9