### PR TITLE
Finish dual scheme integration

### DIFF
--- a/crates/mui-styled-engine/src/lib.rs
+++ b/crates/mui-styled-engine/src/lib.rs
@@ -19,10 +19,10 @@
 
 pub use mui_system::theme::{Breakpoints, Palette, Theme, TypographyScheme};
 pub use mui_system::theme_provider::use_theme;
+#[cfg(all(not(feature = "yew"), feature = "leptos"))]
+pub use mui_system::theme_provider::ThemeProviderLeptos as ThemeProvider;
 #[cfg(feature = "yew")]
-pub use mui_system::theme_provider::ThemeProvider;
-#[cfg(feature = "leptos")]
-pub use mui_system::theme_provider::ThemeProvider;
+pub use mui_system::theme_provider::ThemeProviderYew as ThemeProvider;
 // Re-export procedural macros so crate users only depend on one package.
 pub use mui_styled_engine_macros::{css_with_theme, styled_component, Theme};
 // Ensure procedural macros can reference this crate as `mui_styled_engine` even

--- a/crates/mui-system/src/box.rs
+++ b/crates/mui-system/src/box.rs
@@ -67,15 +67,19 @@ pub fn build_box_style(
     let mut style_map = Map::new();
 
     // Spacing ----------------------------------------------------------------
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.margin, |value| {
-        style::margin(value)
-    });
+    apply_responsive_style(
+        &mut style_map,
+        width,
+        breakpoints,
+        inputs.margin,
+        style::margin,
+    );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.padding,
-        |value| style::padding(value),
+        style::padding,
     );
 
     // Typography -------------------------------------------------------------
@@ -84,76 +88,88 @@ pub fn build_box_style(
         width,
         breakpoints,
         inputs.font_size,
-        |value| style::font_size(value),
+        style::font_size,
     );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.font_weight,
-        |value| style::font_weight(value),
+        style::font_weight,
     );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.line_height,
-        |value| style::line_height(value),
+        style::line_height,
     );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.letter_spacing,
-        |value| style::letter_spacing(value),
+        style::letter_spacing,
     );
 
     // Sizing -----------------------------------------------------------------
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.width, |value| {
-        style::width(value)
-    });
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.height, |value| {
-        style::height(value)
-    });
+    apply_responsive_style(
+        &mut style_map,
+        width,
+        breakpoints,
+        inputs.width,
+        style::width,
+    );
+    apply_responsive_style(
+        &mut style_map,
+        width,
+        breakpoints,
+        inputs.height,
+        style::height,
+    );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.min_width,
-        |value| style::min_width(value),
+        style::min_width,
     );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.max_width,
-        |value| style::max_width(value),
+        style::max_width,
     );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.min_height,
-        |value| style::min_height(value),
+        style::min_height,
     );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.max_height,
-        |value| style::max_height(value),
+        style::max_height,
     );
 
     // Color ------------------------------------------------------------------
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.color, |value| {
-        style::color(value)
-    });
+    apply_responsive_style(
+        &mut style_map,
+        width,
+        breakpoints,
+        inputs.color,
+        style::color,
+    );
     apply_responsive_style(
         &mut style_map,
         width,
         breakpoints,
         inputs.background_color,
-        |value| style::background_color(value),
+        style::background_color,
     );
 
     // Positioning ------------------------------------------------------------
@@ -162,20 +178,24 @@ pub fn build_box_style(
         width,
         breakpoints,
         inputs.position,
-        |value| style::position(value),
+        style::position,
     );
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.top, |value| {
-        style::top(value)
-    });
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.right, |value| {
-        style::right(value)
-    });
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.bottom, |value| {
-        style::bottom(value)
-    });
-    apply_responsive_style(&mut style_map, width, breakpoints, inputs.left, |value| {
-        style::left(value)
-    });
+    apply_responsive_style(&mut style_map, width, breakpoints, inputs.top, style::top);
+    apply_responsive_style(
+        &mut style_map,
+        width,
+        breakpoints,
+        inputs.right,
+        style::right,
+    );
+    apply_responsive_style(
+        &mut style_map,
+        width,
+        breakpoints,
+        inputs.bottom,
+        style::bottom,
+    );
+    apply_responsive_style(&mut style_map, width, breakpoints, inputs.left, style::left);
 
     // Layout toggles that remain non-responsive for now ----------------------
     if let Some(display) = inputs.display {
@@ -201,7 +221,7 @@ pub fn build_box_style(
 #[cfg(feature = "yew")]
 mod yew_impl {
     use super::*;
-    use crate::theme_provider::use_theme;
+    use crate::theme_provider::use_theme_yew as use_theme;
     use yew::prelude::*;
 
     /// Properties for the [`Box`] component when targeting Yew.
@@ -330,7 +350,7 @@ pub use yew_impl::{Box, BoxProps};
 #[cfg(feature = "leptos")]
 mod leptos_impl {
     use super::*;
-    use crate::theme_provider::use_theme;
+    use crate::theme_provider::use_theme_leptos as use_theme;
     use leptos::*;
 
     /// Leptos version of [`Box`] sharing the same responsive props as the Yew variant.

--- a/crates/mui-system/src/container.rs
+++ b/crates/mui-system/src/container.rs
@@ -51,6 +51,7 @@ pub fn build_container_style(
 #[cfg(feature = "yew")]
 mod yew_impl {
     use super::*;
+    use crate::theme_provider::use_theme_yew as use_theme;
     use yew::prelude::*;
 
     /// Properties for the [`Container`] component.
@@ -70,7 +71,7 @@ mod yew_impl {
     /// Centers content with an optional maximum width.
     #[function_component(Container)]
     pub fn container(props: &ContainerProps) -> Html {
-        let theme = crate::theme_provider::use_theme();
+        let theme = use_theme();
         let width = crate::responsive::viewport_width();
         let style_rules = build_container_style(
             width,
@@ -99,6 +100,7 @@ pub use yew_impl::{Container, ContainerProps};
 #[cfg(feature = "leptos")]
 mod leptos_impl {
     use super::*;
+    use crate::theme_provider::use_theme_leptos as use_theme;
     use leptos::*;
 
     /// Leptos variant of [`Container`].
@@ -108,7 +110,7 @@ mod leptos_impl {
         #[prop(optional)] sx: Option<Value>,
         children: Children,
     ) -> impl IntoView {
-        let theme = crate::theme_provider::use_theme();
+        let theme = use_theme();
         let width = crate::responsive::viewport_width();
         let style_rules = build_container_style(
             width,

--- a/crates/mui-system/src/grid.rs
+++ b/crates/mui-system/src/grid.rs
@@ -79,6 +79,7 @@ pub fn build_grid_style(
 #[cfg(feature = "yew")]
 mod yew_impl {
     use super::*;
+    use crate::theme_provider::use_theme_yew as use_theme;
     use yew::prelude::*;
 
     /// Simple grid item that computes its own width based on `span` and `columns`.
@@ -108,7 +109,7 @@ mod yew_impl {
     /// Render a grid item as a `<div>` with a calculated percentage width.
     #[function_component(Grid)]
     pub fn grid(props: &GridProps) -> Html {
-        let theme = crate::theme_provider::use_theme();
+        let theme = use_theme();
         let width = crate::responsive::viewport_width();
         let style_rules = build_grid_style(
             width,
@@ -137,6 +138,7 @@ pub use yew_impl::{Grid, GridProps};
 #[cfg(feature = "leptos")]
 mod leptos_impl {
     use super::*;
+    use crate::theme_provider::use_theme_leptos as use_theme;
     use leptos::*;
 
     /// Leptos implementation of [`Grid`].
@@ -149,7 +151,7 @@ mod leptos_impl {
         #[prop(optional)] sx: Option<Value>,
         children: Children,
     ) -> impl IntoView {
-        let theme = crate::theme_provider::use_theme();
+        let theme = use_theme();
         let width_px = crate::responsive::viewport_width();
         let style_rules = build_grid_style(
             width_px,

--- a/crates/mui-system/src/lib.rs
+++ b/crates/mui-system/src/lib.rs
@@ -45,10 +45,10 @@ pub use style::*;
 pub use stylist::{css, Style};
 pub use theme::{Breakpoints, Palette, Theme};
 extern crate self as mui_styled_engine;
+#[cfg(all(not(feature = "yew"), feature = "leptos"))]
+pub use theme_provider::ThemeProviderLeptos as ThemeProvider;
 #[cfg(feature = "yew")]
-pub use theme_provider::ThemeProvider;
-#[cfg(all(feature = "leptos", not(feature = "yew")))]
-pub use theme_provider::ThemeProvider;
+pub use theme_provider::ThemeProviderYew as ThemeProvider;
 pub use themed_element::{ThemedProps, Variant};
 #[cfg(any(feature = "yew", feature = "leptos"))]
 pub use typography::{Typography, TypographyVariant};

--- a/crates/mui-system/src/stack.rs
+++ b/crates/mui-system/src/stack.rs
@@ -84,6 +84,7 @@ pub fn build_stack_style(
 #[cfg(feature = "yew")]
 mod yew_impl {
     use super::*;
+    use crate::theme_provider::use_theme_yew as use_theme;
     use yew::prelude::*;
 
     /// Properties for the [`Stack`] component.
@@ -112,7 +113,7 @@ mod yew_impl {
     /// Minimal flexbox based stack layout.
     #[function_component(Stack)]
     pub fn stack(props: &StackProps) -> Html {
-        let theme = crate::theme_provider::use_theme();
+        let theme = use_theme();
         let width = crate::responsive::viewport_width();
         let style_rules = build_stack_style(
             width,
@@ -141,6 +142,7 @@ pub use yew_impl::{Stack, StackProps};
 #[cfg(feature = "leptos")]
 mod leptos_impl {
     use super::*;
+    use crate::theme_provider::use_theme_leptos as use_theme;
     use leptos::*;
 
     /// Leptos implementation of [`Stack`].
@@ -153,7 +155,7 @@ mod leptos_impl {
         #[prop(optional)] sx: Option<Value>,
         children: Children,
     ) -> impl IntoView {
-        let theme = crate::theme_provider::use_theme();
+        let theme = use_theme();
         let width = crate::responsive::viewport_width();
         let style_rules = build_stack_style(
             width,

--- a/crates/mui-system/src/theme_provider.rs
+++ b/crates/mui-system/src/theme_provider.rs
@@ -1,4 +1,4 @@
-use crate::theme::Theme;
+use crate::theme::{ColorScheme, Theme};
 #[cfg(any(feature = "yew", feature = "leptos"))]
 use mui_styled_engine_macros::css_with_theme;
 
@@ -9,6 +9,34 @@ use mui_styled_engine_macros::css_with_theme;
 /// of palette, typography and spacing tokens exposed to applications.
 pub fn material_theme() -> Theme {
     Theme::default()
+}
+
+/// Returns the Material theme pre-configured for light mode.
+pub fn material_theme_light() -> Theme {
+    material_theme_for_scheme(ColorScheme::Light)
+}
+
+/// Returns the Material theme pre-configured for dark mode.
+pub fn material_theme_dark() -> Theme {
+    material_theme_for_scheme(ColorScheme::Dark)
+}
+
+/// Builds the canonical Material theme but forces the initial color scheme to
+/// the supplied mode.  This helper is the recommended entrypoint for
+/// automated pipelines that need to render artifacts for each scheme without
+/// duplicating override logic.
+pub fn material_theme_for_scheme(scheme: ColorScheme) -> Theme {
+    let mut theme = material_theme();
+    theme.palette.initial_color_scheme = scheme;
+    theme
+}
+
+/// Updates the provided [`Theme`] in-place so its active color scheme switches
+/// to the requested variant.  Returning the same handle keeps builder style
+/// flows ergonomic.
+pub fn theme_with_color_scheme(mut theme: Theme, scheme: ColorScheme) -> Theme {
+    theme.palette.initial_color_scheme = scheme;
+    theme
 }
 
 /// Produces a [`Theme`] from overrides created via `#[derive(Theme)]`.
@@ -60,27 +88,104 @@ pub fn material_css_baseline_from_theme(theme: &Theme) -> String {
     let body_font_size = fmt_num(theme.typography.font_size);
     let line_height = fmt_num(theme.typography.line_height);
 
+    let active_scheme = theme.palette.initial_color_scheme;
+    let active_palette = theme.palette.active();
+    let light_palette = &theme.palette.light;
+    let dark_palette = &theme.palette.dark;
+
     format!(
-        "html {{\n    box-sizing: border-box;\n    font-family: {};\n    font-size: {}px;\n    -webkit-font-smoothing: antialiased;\n    -moz-osx-font-smoothing: grayscale;\n    background-color: {};\n    color: {};\n}}\n\n*, *::before, *::after {{\n    box-sizing: inherit;\n}}\n\nbody {{\n    margin: 0;\n    min-height: 100vh;\n    font-family: {};\n    font-size: {}px;\n    line-height: {};\n    background-color: {};\n    color: {};\n}}\n\nstrong, b {{\n    font-weight: {};\n}}\n\ncode, pre {{\n    font-family: {};\n}}\n",
+        "/* Global baseline generated from the strongly typed Material theme.\n   Enterprise operators: adjust the `data-mui-color-scheme` attribute on the document element to flip between modes without rebuilding CSS. */\nhtml {{\n    box-sizing: border-box;\n    font-family: {};\n    font-size: {}px;\n    -webkit-font-smoothing: antialiased;\n    -moz-osx-font-smoothing: grayscale;\n    color-scheme: {};\n    background-color: {};\n    color: {};\n}}\n\n*, *::before, *::after {{\n    box-sizing: inherit;\n}}\n\n:root {{\n    color-scheme: {};\n}}\n\nbody {{\n    margin: 0;\n    min-height: 100vh;\n    font-family: {};\n    font-size: {}px;\n    line-height: {};\n    background-color: {};\n    color: {};\n}}\n\nstrong, b {{\n    font-weight: {};\n}}\n\ncode, pre {{\n    font-family: {};\n}}\n\n/* Data attribute selectors keep automated deployments deterministic by allowing infrastructure to force a mode before JS boots. */\n[data-mui-color-scheme='light'] html,\n[data-mui-color-scheme='light'] body {{\n    background-color: {};\n    color: {};\n}}\n\n[data-mui-color-scheme='light'] :root {{\n    color-scheme: light;\n}}\n\n[data-mui-color-scheme='dark'] html,\n[data-mui-color-scheme='dark'] body {{\n    background-color: {};\n    color: {};\n}}\n\n[data-mui-color-scheme='dark'] :root {{\n    color-scheme: dark;\n}}\n\n/* Respect end-user preference media queries so SSR output automatically matches OS settings even before hydration. */\n@media (prefers-color-scheme: dark) {{\n    :root {{\n        color-scheme: dark;\n    }}\n\n    html, body {{\n        background-color: {};\n        color: {};\n    }}\n}}\n\n@media (prefers-color-scheme: light) {{\n    :root {{\n        color-scheme: light;\n    }}\n\n    html, body {{\n        background-color: {};\n        color: {};\n    }}\n}}\n",
         theme.typography.font_family,
         html_font_size,
-        theme.palette.background_default,
-        theme.palette.text_primary,
+        active_scheme.as_str(),
+        active_palette.background_default,
+        active_palette.text_primary,
+        active_scheme.as_str(),
         theme.typography.font_family,
         body_font_size,
         line_height,
-        theme.palette.background_default,
-        theme.palette.text_primary,
+        active_palette.background_default,
+        active_palette.text_primary,
         theme.typography.font_weight_bold,
-        theme.typography.font_family_monospace
+        theme.typography.font_family_monospace,
+        light_palette.background_default,
+        light_palette.text_primary,
+        dark_palette.background_default,
+        dark_palette.text_primary,
+        dark_palette.background_default,
+        dark_palette.text_primary,
+        light_palette.background_default,
+        light_palette.text_primary,
     )
 }
+
+#[cfg(target_arch = "wasm32")]
+fn detect_user_prefers_dark() -> Option<bool> {
+    web_sys::window()
+        .and_then(|window| window.match_media("(prefers-color-scheme: dark)").ok())
+        .flatten()
+        .map(|media| media.matches())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn detect_user_prefers_dark() -> Option<bool> {
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn push_color_scheme_to_dom(scheme: ColorScheme) {
+    if let Some(document) = web_sys::window().and_then(|window| window.document()) {
+        if let Some(root) = document.document_element() {
+            let _ = root.set_attribute("data-mui-color-scheme", scheme.as_str());
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn push_color_scheme_to_dom(_scheme: ColorScheme) {}
 
 #[cfg(feature = "yew")]
 mod yew_impl {
     use super::*;
     use stylist::yew::Global;
     use yew::prelude::*;
+
+    /// Rich handle returned by [`use_material_color_scheme`] offering helpers to
+    /// synchronise UI state, CSS baselines and theme overrides.
+    #[derive(Clone)]
+    pub struct UseMaterialColorScheme {
+        state: UseStateHandle<ColorScheme>,
+    }
+
+    impl UseMaterialColorScheme {
+        /// Returns the currently resolved [`ColorScheme`].
+        pub fn scheme(&self) -> ColorScheme {
+            *self.state
+        }
+
+        /// Overwrite the active scheme.
+        pub fn set(&self, scheme: ColorScheme) {
+            self.state.set(scheme);
+        }
+
+        /// Convenience helper returning a [`Callback`] that can be passed to
+        /// buttons or switches.
+        pub fn setter(&self) -> Callback<ColorScheme> {
+            let state = self.state.clone();
+            Callback::from(move |scheme| state.set(scheme))
+        }
+
+        /// Flip between light and dark.
+        pub fn toggle(&self) {
+            self.state.set(self.scheme().toggled());
+        }
+
+        /// Applies the currently selected scheme to the provided [`Theme`]
+        /// returning a cloned instance with the correct mode encoded.
+        pub fn apply_to(&self, theme: Theme) -> Theme {
+            theme_with_color_scheme(theme, self.scheme())
+        }
+    }
 
     /// Provides the current [`Theme`] to descendant components via Yew's
     /// context system.
@@ -111,6 +216,39 @@ mod yew_impl {
         use_context::<Theme>().unwrap_or_else(material_theme)
     }
 
+    /// Manages the document level colour scheme attribute while exposing a
+    /// state handle applications can bind to toggles or store in persistence
+    /// layers.  The hook honours user preferences via `matchMedia` on the
+    /// initial render and keeps the DOM attribute in sync so CSS selectors flip
+    /// immediately even before the component tree re-renders.
+    #[hook]
+    pub fn use_material_color_scheme() -> UseMaterialColorScheme {
+        let theme = use_theme();
+        let initial = detect_user_prefers_dark()
+            .map(|prefers_dark| {
+                if prefers_dark {
+                    ColorScheme::Dark
+                } else {
+                    ColorScheme::Light
+                }
+            })
+            .unwrap_or(theme.palette.initial_color_scheme);
+
+        let state = use_state(|| initial);
+
+        // Ensure the DOM attribute mirrors the current scheme so the CSS reset
+        // can rely on `[data-mui-color-scheme]` selectors.
+        {
+            let state = state.clone();
+            use_effect_with(*state, move |scheme: &ColorScheme| {
+                push_color_scheme_to_dom(*scheme);
+                || ()
+            });
+        }
+
+        UseMaterialColorScheme { state }
+    }
+
     /// Properties accepted by [`CssBaseline`].
     #[derive(Properties, PartialEq, Default)]
     pub struct CssBaselineProps {
@@ -128,11 +266,12 @@ mod yew_impl {
         // though the final string is formatted manually. We unregister the
         // temporary style immediately to avoid side-effects while still
         // exercising the macro expansion.
+        let preview_color = material_theme().palette.active().text_primary.clone();
         let sentinel = css_with_theme!(
             r#"
                 color: ${text_color};
             "#,
-            text_color = theme.palette.text_primary.clone()
+            text_color = preview_color.clone()
         );
         sentinel.unregister();
 
@@ -151,13 +290,56 @@ mod yew_impl {
 
 #[cfg(feature = "yew")]
 pub use yew_impl::{
-    use_theme, CssBaseline, CssBaselineProps, GlobalStyles, ThemeProvider, ThemeProviderProps,
+    use_material_color_scheme, use_theme, CssBaseline, CssBaselineProps, GlobalStyles,
+    ThemeProvider, ThemeProviderProps, UseMaterialColorScheme,
+};
+
+#[cfg(feature = "yew")]
+pub use yew_impl::{
+    use_material_color_scheme as use_material_color_scheme_yew, use_theme as use_theme_yew,
+    CssBaseline as CssBaselineYew, CssBaselineProps as CssBaselinePropsYew,
+    GlobalStyles as GlobalStylesYew, ThemeProvider as ThemeProviderYew,
+    ThemeProviderProps as ThemeProviderPropsYew,
+    UseMaterialColorScheme as UseMaterialColorSchemeYew,
 };
 
 #[cfg(feature = "leptos")]
 mod leptos_impl {
     use super::*;
     use leptos::*;
+
+    /// Handle returned by [`use_material_color_scheme`] for Leptos adapters.
+    #[derive(Clone, Copy)]
+    pub struct MaterialColorSchemeHandle {
+        scheme: RwSignal<ColorScheme>,
+    }
+
+    impl MaterialColorSchemeHandle {
+        /// Current colour scheme.
+        pub fn scheme(&self) -> ColorScheme {
+            self.scheme.get()
+        }
+
+        /// Expose a read-only signal for UI bindings.
+        pub fn signal(&self) -> ReadSignal<ColorScheme> {
+            self.scheme.read_only()
+        }
+
+        /// Imperatively update the active scheme.
+        pub fn set(&self, scheme: ColorScheme) {
+            self.scheme.set(scheme);
+        }
+
+        /// Toggle helper mirroring the Yew implementation.
+        pub fn toggle(&self) {
+            self.scheme.update(|current| *current = current.toggled());
+        }
+
+        /// Apply the scheme to a cloned [`Theme`].
+        pub fn apply_to(&self, theme: Theme) -> Theme {
+            theme_with_color_scheme(theme, self.scheme())
+        }
+    }
 
     /// Leptos variant of the [`ThemeProvider`].
     #[component]
@@ -175,11 +357,12 @@ mod leptos_impl {
     /// `<style>` tag so the framework can insert it into the document head.
     #[component]
     pub fn CssBaseline(#[prop(optional)] additional_css: Option<String>) -> impl IntoView {
+        let preview_color = material_theme().palette.active().text_primary.clone();
         let sentinel = css_with_theme!(
             r#"
                 color: ${text_color};
             "#,
-            text_color = theme.palette.text_primary.clone()
+            text_color = preview_color.clone()
         );
         sentinel.unregister();
 
@@ -191,12 +374,48 @@ mod leptos_impl {
         view! { <style>{css}</style> }
     }
 
+    /// Leptos hook mirroring [`use_material_color_scheme`] for Yew.  Returns a
+    /// handle that drives UI elements and keeps the DOM attribute in sync for
+    /// the generated CSS selectors.
+    pub fn use_material_color_scheme() -> MaterialColorSchemeHandle {
+        let theme = use_theme();
+        let initial = detect_user_prefers_dark()
+            .map(|prefers_dark| {
+                if prefers_dark {
+                    ColorScheme::Dark
+                } else {
+                    ColorScheme::Light
+                }
+            })
+            .unwrap_or(theme.palette.initial_color_scheme);
+
+        let scheme = create_rw_signal(initial);
+
+        create_effect(move |_| {
+            push_color_scheme_to_dom(scheme.get());
+        });
+
+        MaterialColorSchemeHandle { scheme }
+    }
+
     /// Alias kept for API parity between frameworks.
     pub use CssBaseline as GlobalStyles;
 }
 
 #[cfg(feature = "leptos")]
-pub use leptos_impl::{use_theme, CssBaseline, GlobalStyles, ThemeProvider};
+pub use leptos_impl::MaterialColorSchemeHandle;
+
+#[cfg(all(feature = "leptos", not(feature = "yew")))]
+pub use leptos_impl::{
+    use_material_color_scheme, use_theme, CssBaseline, GlobalStyles, ThemeProvider,
+};
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::{
+    use_material_color_scheme as use_material_color_scheme_leptos, use_theme as use_theme_leptos,
+    CssBaseline as CssBaselineLeptos, GlobalStyles as GlobalStylesLeptos,
+    ThemeProvider as ThemeProviderLeptos,
+};
 
 #[cfg(any(feature = "dioxus", feature = "sycamore"))]
 mod other_impl {

--- a/crates/mui-system/templates/material_css_baseline.dark.css
+++ b/crates/mui-system/templates/material_css_baseline.dark.css
@@ -1,15 +1,22 @@
+/* Global baseline generated from the strongly typed Material theme.
+   Enterprise operators: adjust the `data-mui-color-scheme` attribute on the document element to flip between modes without rebuilding CSS. */
 html {
     box-sizing: border-box;
     font-family: Roboto, Helvetica, Arial, sans-serif;
     font-size: 16px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background-color: #fafafa;
-    color: #1f2933;
+    color-scheme: dark;
+    background-color: #121212;
+    color: #ffffff;
 }
 
 *, *::before, *::after {
     box-sizing: inherit;
+}
+
+:root {
+    color-scheme: dark;
 }
 
 body {
@@ -18,8 +25,8 @@ body {
     font-family: Roboto, Helvetica, Arial, sans-serif;
     font-size: 14px;
     line-height: 1.5;
-    background-color: #fafafa;
-    color: #1f2933;
+    background-color: #121212;
+    color: #ffffff;
 }
 
 strong, b {
@@ -28,4 +35,48 @@ strong, b {
 
 code, pre {
     font-family: Roboto Mono, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+/* Data attribute selectors keep automated deployments deterministic by allowing infrastructure to force a mode before JS boots. */
+[data-mui-color-scheme='light'] html,
+[data-mui-color-scheme='light'] body {
+    background-color: #fafafa;
+    color: #1f2933;
+}
+
+[data-mui-color-scheme='light'] :root {
+    color-scheme: light;
+}
+
+[data-mui-color-scheme='dark'] html,
+[data-mui-color-scheme='dark'] body {
+    background-color: #121212;
+    color: #ffffff;
+}
+
+[data-mui-color-scheme='dark'] :root {
+    color-scheme: dark;
+}
+
+/* Respect end-user preference media queries so SSR output automatically matches OS settings even before hydration. */
+@media (prefers-color-scheme: dark) {
+    :root {
+        color-scheme: dark;
+    }
+
+    html, body {
+        background-color: #121212;
+        color: #ffffff;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        color-scheme: light;
+    }
+
+    html, body {
+        background-color: #fafafa;
+        color: #1f2933;
+    }
 }

--- a/crates/mui-system/templates/material_css_baseline.light.css
+++ b/crates/mui-system/templates/material_css_baseline.light.css
@@ -1,15 +1,22 @@
+/* Global baseline generated from the strongly typed Material theme.
+   Enterprise operators: adjust the `data-mui-color-scheme` attribute on the document element to flip between modes without rebuilding CSS. */
 html {
     box-sizing: border-box;
     font-family: Roboto, Helvetica, Arial, sans-serif;
     font-size: 16px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    color-scheme: light;
     background-color: #fafafa;
     color: #1f2933;
 }
 
 *, *::before, *::after {
     box-sizing: inherit;
+}
+
+:root {
+    color-scheme: light;
 }
 
 body {
@@ -28,4 +35,48 @@ strong, b {
 
 code, pre {
     font-family: Roboto Mono, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+/* Data attribute selectors keep automated deployments deterministic by allowing infrastructure to force a mode before JS boots. */
+[data-mui-color-scheme='light'] html,
+[data-mui-color-scheme='light'] body {
+    background-color: #fafafa;
+    color: #1f2933;
+}
+
+[data-mui-color-scheme='light'] :root {
+    color-scheme: light;
+}
+
+[data-mui-color-scheme='dark'] html,
+[data-mui-color-scheme='dark'] body {
+    background-color: #121212;
+    color: #ffffff;
+}
+
+[data-mui-color-scheme='dark'] :root {
+    color-scheme: dark;
+}
+
+/* Respect end-user preference media queries so SSR output automatically matches OS settings even before hydration. */
+@media (prefers-color-scheme: dark) {
+    :root {
+        color-scheme: dark;
+    }
+
+    html, body {
+        background-color: #121212;
+        color: #ffffff;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        color-scheme: light;
+    }
+
+    html, body {
+        background-color: #fafafa;
+        color: #1f2933;
+    }
 }

--- a/crates/mui-system/templates/material_theme.dark.json
+++ b/crates/mui-system/templates/material_theme.dark.json
@@ -8,14 +8,27 @@
     "xl": 1536
   },
   "palette": {
-    "primary": "#1976d2",
-    "secondary": "#dc004e",
-    "neutral": "#64748b",
-    "danger": "#d32f2f",
-    "background_default": "#fafafa",
-    "background_paper": "#ffffff",
-    "text_primary": "#1f2933",
-    "text_secondary": "#52606d"
+    "light": {
+      "primary": "#1976d2",
+      "secondary": "#dc004e",
+      "neutral": "#64748b",
+      "danger": "#d32f2f",
+      "background_default": "#fafafa",
+      "background_paper": "#ffffff",
+      "text_primary": "#1f2933",
+      "text_secondary": "#52606d"
+    },
+    "dark": {
+      "primary": "#90caf9",
+      "secondary": "#f48fb1",
+      "neutral": "#94a3b8",
+      "danger": "#f44336",
+      "background_default": "#121212",
+      "background_paper": "#1e1e1e",
+      "text_primary": "#ffffff",
+      "text_secondary": "#cbd5f5"
+    },
+    "initial_color_scheme": "dark"
   },
   "typography": {
     "font_family": "Roboto, Helvetica, Arial, sans-serif",

--- a/crates/mui-system/templates/material_theme.light.json
+++ b/crates/mui-system/templates/material_theme.light.json
@@ -8,14 +8,27 @@
     "xl": 1536
   },
   "palette": {
-    "primary": "#1976d2",
-    "secondary": "#dc004e",
-    "neutral": "#64748b",
-    "danger": "#d32f2f",
-    "background_default": "#fafafa",
-    "background_paper": "#ffffff",
-    "text_primary": "#1f2933",
-    "text_secondary": "#52606d"
+    "light": {
+      "primary": "#1976d2",
+      "secondary": "#dc004e",
+      "neutral": "#64748b",
+      "danger": "#d32f2f",
+      "background_default": "#fafafa",
+      "background_paper": "#ffffff",
+      "text_primary": "#1f2933",
+      "text_secondary": "#52606d"
+    },
+    "dark": {
+      "primary": "#90caf9",
+      "secondary": "#f48fb1",
+      "neutral": "#94a3b8",
+      "danger": "#f44336",
+      "background_default": "#121212",
+      "background_paper": "#1e1e1e",
+      "text_primary": "#ffffff",
+      "text_secondary": "#cbd5f5"
+    },
+    "initial_color_scheme": "light"
   },
   "typography": {
     "font_family": "Roboto, Helvetica, Arial, sans-serif",

--- a/crates/mui-system/tests/theme_provider.rs
+++ b/crates/mui-system/tests/theme_provider.rs
@@ -1,9 +1,10 @@
 use mui_styled_engine_macros::Theme as ThemeOverride;
 extern crate mui_system as mui_styled_engine;
 
-use mui_system::theme::Palette;
+use mui_system::theme::{ColorScheme, Palette};
 use mui_system::theme_provider::{
-    material_css_baseline, material_theme, material_theme_with_optional_overrides,
+    material_css_baseline, material_css_baseline_from_theme, material_theme, material_theme_dark,
+    material_theme_for_scheme, material_theme_light, material_theme_with_optional_overrides,
     material_theme_with_overrides,
 };
 
@@ -15,11 +16,12 @@ struct PaletteOverrides {
 
 impl From<PaletteOverrides> for Palette {
     fn from(value: PaletteOverrides) -> Self {
-        Palette {
-            primary: value.primary,
-            secondary: value.secondary,
-            ..Palette::default()
-        }
+        let mut palette = Palette::default();
+        palette.light.primary = value.primary.clone();
+        palette.light.secondary = value.secondary.clone();
+        palette.dark.primary = value.primary;
+        palette.dark.secondary = value.secondary;
+        palette
     }
 }
 
@@ -42,12 +44,17 @@ fn derived_overrides_merge_with_material_defaults() {
         },
     });
 
-    assert_eq!(theme.palette.primary, "#102030");
-    assert_eq!(theme.palette.secondary, "#405060");
+    assert_eq!(theme.palette.light.primary, "#102030");
+    assert_eq!(theme.palette.light.secondary, "#405060");
+    assert_eq!(theme.palette.dark.primary, "#102030");
+    assert_eq!(theme.palette.dark.secondary, "#405060");
     // Fields not supplied by the overrides fall back to Material defaults.
     assert_eq!(
-        theme.palette.background_default,
-        material_theme().palette.background_default
+        theme.palette.scheme(ColorScheme::Light).background_default,
+        material_theme()
+            .palette
+            .scheme(ColorScheme::Light)
+            .background_default
     );
     assert_eq!(
         theme.typography.font_family,
@@ -65,8 +72,8 @@ fn optional_overrides_are_respected_when_present() {
     });
 
     let theme = material_theme_with_optional_overrides(overrides);
-    assert_eq!(theme.palette.primary, "#abcdef");
-    assert_eq!(theme.palette.secondary, "#123456");
+    assert_eq!(theme.palette.light.primary, "#abcdef");
+    assert_eq!(theme.palette.light.secondary, "#123456");
 }
 
 #[test]
@@ -74,5 +81,50 @@ fn baseline_injection_uses_theme_tokens() {
     let css = material_css_baseline();
     assert!(css.contains("box-sizing: border-box"));
     assert!(css.contains(&material_theme().typography.font_family));
-    assert!(css.contains(&material_theme().palette.background_default));
+    assert!(css.contains(
+        &material_theme()
+            .palette
+            .scheme(ColorScheme::Light)
+            .background_default
+    ));
+    assert!(css.contains("color-scheme"));
+}
+
+#[test]
+fn css_baseline_includes_both_schemes() {
+    let theme = material_theme();
+    let css = material_css_baseline_from_theme(&theme);
+    assert!(css.contains(&theme.palette.light.background_default));
+    assert!(css.contains(&theme.palette.dark.background_default));
+    assert!(css.contains("@media (prefers-color-scheme: dark)"));
+    assert!(css.contains("[data-mui-color-scheme='dark']"));
+}
+
+#[test]
+fn scheme_specific_helpers_adjust_initial_mode() {
+    assert_eq!(
+        material_theme_light().palette.initial_color_scheme,
+        ColorScheme::Light
+    );
+    assert_eq!(
+        material_theme_dark().palette.initial_color_scheme,
+        ColorScheme::Dark
+    );
+
+    let forced = material_theme_for_scheme(ColorScheme::Dark);
+    assert_eq!(forced.palette.initial_color_scheme, ColorScheme::Dark);
+}
+
+#[test]
+fn css_differs_between_light_and_dark_templates() {
+    let light_theme = material_theme_light();
+    let dark_theme = material_theme_dark();
+
+    let css_light = material_css_baseline_from_theme(&light_theme);
+    let css_dark = material_css_baseline_from_theme(&dark_theme);
+
+    assert_ne!(css_light, css_dark);
+    assert!(css_light.contains(&light_theme.palette.light.background_default));
+    assert!(css_dark.contains(&dark_theme.palette.dark.background_default));
+    assert!(css_dark.contains("color-scheme: dark"));
 }

--- a/crates/mui-system/tests/theming.rs
+++ b/crates/mui-system/tests/theming.rs
@@ -5,5 +5,10 @@ use mui_system::Theme;
 fn theme_defaults() {
     let theme = Theme::default();
     assert_eq!(theme.spacing(3), 24);
-    assert_eq!(theme.palette.primary, "#1976d2");
+    assert_eq!(theme.palette.light.primary, "#1976d2");
+    assert_eq!(
+        theme.palette.initial_color_scheme,
+        mui_system::theme::ColorScheme::Light
+    );
+    assert_eq!(theme.palette.dark.background_default, "#121212");
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -8,7 +8,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
-use mui_system::theme::Theme;
+use mui_system::theme::{ColorScheme, Theme};
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -353,8 +353,15 @@ fn generate_theme(overrides: Option<PathBuf>, format: ThemeFormat) -> Result<()>
                 "failed to convert merged theme representation into Theme struct for `{scheme}`"
             )
         })?;
-        let theme =
+        let mut theme =
             mui_system::theme_provider::material_theme_with_optional_overrides(Some(merged_theme));
+        if let Some(color_scheme) = match scheme.as_str() {
+            "light" => Some(ColorScheme::Light),
+            "dark" => Some(ColorScheme::Dark),
+            _ => None,
+        } {
+            theme.palette.initial_color_scheme = color_scheme;
+        }
 
         let output_path = match format {
             ThemeFormat::Json => output_dir.join(format!("material_theme.{scheme}.json")),

--- a/examples/data-display-avatar/src/lib.rs
+++ b/examples/data-display-avatar/src/lib.rs
@@ -101,8 +101,14 @@ fn wrap_markup(automation_id: &str, chip_html: &str, tooltip_html: &str) -> Stri
 
 fn enterprise_theme() -> Theme {
     let mut theme = Theme::default();
-    theme.palette.background_paper = "#0F172A".into();
-    theme.palette.text_primary = "#E2E8F0".into();
+    for scheme in [
+        mui_system::theme::ColorScheme::Light,
+        mui_system::theme::ColorScheme::Dark,
+    ] {
+        let palette = theme.palette.scheme_mut(scheme);
+        palette.background_paper = "#0F172A".into();
+        palette.text_primary = "#E2E8F0".into();
+    }
     theme.typography.body1 = 0.9375;
     theme
 }

--- a/examples/feedback-chips/src/lib.rs
+++ b/examples/feedback-chips/src/lib.rs
@@ -79,8 +79,14 @@ pub fn enterprise_story() -> ChipStory {
 
 fn enterprise_theme() -> Theme {
     let mut theme = Theme::default();
-    theme.palette.primary = "#334155".into();
-    theme.palette.neutral = "#1E293B".into();
+    for scheme in [
+        mui_system::theme::ColorScheme::Light,
+        mui_system::theme::ColorScheme::Dark,
+    ] {
+        let palette = theme.palette.scheme_mut(scheme);
+        palette.primary = "#334155".into();
+        palette.neutral = "#1E293B".into();
+    }
     theme.typography.body2 = 0.875;
     theme
 }

--- a/examples/feedback-tooltips/src/lib.rs
+++ b/examples/feedback-tooltips/src/lib.rs
@@ -56,8 +56,14 @@ pub fn enterprise_story() -> TooltipStory {
 
 fn enterprise_theme() -> Theme {
     let mut theme = Theme::default();
-    theme.palette.primary = "#0057B7".into();
-    theme.palette.secondary = "#F59E0B".into();
+    for scheme in [
+        mui_system::theme::ColorScheme::Light,
+        mui_system::theme::ColorScheme::Dark,
+    ] {
+        let palette = theme.palette.scheme_mut(scheme);
+        palette.primary = "#0057B7".into();
+        palette.secondary = "#F59E0B".into();
+    }
     theme.typography.caption = 0.8125;
     theme
 }

--- a/examples/select-menu-leptos/src/main.rs
+++ b/examples/select-menu-leptos/src/main.rs
@@ -13,18 +13,19 @@ use select_menu_shared::ssr_shell;
 #[component]
 pub fn App() -> impl IntoView {
     let theme = enterprise_theme();
+    let palette = theme.palette.active().clone();
     let container_style = move || {
         format!(
             "min-height:100vh;display:flex;align-items:center;justify-content:center;background:{};padding:32px;",
-            theme.palette.background_default
+            palette.background_default
         )
     };
     let panel_style = move || {
         format!(
             "max-width:720px;display:flex;flex-direction:column;gap:16px;background:{};padding:24px;border-radius:{}px;box-shadow:0 18px 60px rgba(0,0,0,0.35);color:{};",
-            theme.palette.background_paper,
+            palette.background_paper,
             theme.joy.radius,
-            theme.palette.text_primary
+            palette.text_primary
         )
     };
     let options = create_rw_signal::<Vec<SelectOption>>(Vec::new());

--- a/examples/select-menu-shared/src/lib.rs
+++ b/examples/select-menu-shared/src/lib.rs
@@ -7,7 +7,7 @@
 //! enterprises can share core behaviour across SSR and CSR entry points.
 
 use mui_material::select::{SelectOption, SelectProps};
-use mui_system::theme::Theme;
+use mui_system::theme::{ColorScheme, Theme};
 
 /// Stable automation identifier applied to every DOM node we render.
 ///
@@ -54,12 +54,16 @@ pub fn props_from_options(label: &str, automation_id: &str, options: &[SelectOpt
 /// Produce a high contrast enterprise theme used across the demos.
 pub fn enterprise_theme() -> Theme {
     let mut theme = Theme::default();
-    theme.palette.primary = "#003366".into();
-    theme.palette.secondary = "#f97316".into();
-    theme.palette.background_default = "#0b1120".into();
-    theme.palette.background_paper = "#111c3a".into();
-    theme.palette.text_primary = "#f8fafc".into();
-    theme.palette.text_secondary = "#cbd5f5".into();
+    for scheme in [ColorScheme::Light, ColorScheme::Dark] {
+        let palette = theme.palette.scheme_mut(scheme);
+        palette.primary = "#003366".into();
+        palette.secondary = "#f97316".into();
+        palette.background_default = "#0b1120".into();
+        palette.background_paper = "#111c3a".into();
+        palette.text_primary = "#f8fafc".into();
+        palette.text_secondary = "#cbd5f5".into();
+    }
+    theme.palette.initial_color_scheme = ColorScheme::Dark;
     theme.typography.font_family = "'IBM Plex Sans', 'Segoe UI', sans-serif".into();
     theme.joy.radius = 8;
     theme
@@ -131,10 +135,11 @@ pub fn selection_summary(props: &SelectProps, selected: Option<usize>) -> String
 /// The wrapper injects basic typography and background colours so the
 /// pre-rendered output mirrors the client experience even before hydration.
 pub fn ssr_shell(select_markup: &str, theme: &Theme) -> String {
+    let palette = theme.palette.active();
     format!(
         "<!DOCTYPE html><html><head><meta charset=\"utf-8\"/><title>RusticUI Select Menu</title></head><body style=\"margin:0;background:{};color:{};font-family:{};min-height:100vh;display:flex;align-items:center;justify-content:center;\"><main data-automation=\"{}-shell\" style=\"padding:32px;max-width:720px;\"><h1 style=\"margin-top:0;font-size:1.75rem;\">RusticUI Select Menu</h1>{}</main></body></html>",
-        theme.palette.background_default,
-        theme.palette.text_primary,
+        palette.background_default,
+        palette.text_primary,
         theme.typography.font_family,
         AUTOMATION_ID,
         select_markup

--- a/examples/select-menu-yew/src/main.rs
+++ b/examples/select-menu-yew/src/main.rs
@@ -89,15 +89,16 @@ fn app() -> Html {
 
     let theme = enterprise_theme();
     let summary_text = summary_handle.clone();
+    let palette = theme.palette.active();
     let container_style = format!(
         "min-height:100vh;display:flex;align-items:center;justify-content:center;background:{};padding:32px;",
-        theme.palette.background_default
+        palette.background_default
     );
     let panel_style = format!(
         "max-width:720px;display:flex;flex-direction:column;gap:16px;background:{};padding:24px;border-radius:{}px;box-shadow:0 12px 40px rgba(0,0,0,0.35);color:{};",
-        theme.palette.background_paper,
+        palette.background_paper,
         theme.joy.radius,
-        theme.palette.text_primary
+        palette.text_primary
     );
 
     html! {

--- a/examples/shared-dialog-state-core/src/lib.rs
+++ b/examples/shared-dialog-state-core/src/lib.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use mui_headless::dialog::{DialogPhase, DialogState, DialogTransition};
 use mui_headless::popover::{AnchorGeometry, CollisionOutcome, PopoverPlacement, PopoverState};
-use mui_headless::text_field::{TextFieldState};
+use mui_headless::text_field::TextFieldState;
 
 /// ASCII anchor/floating surface illustration rendered in each example README
 /// to explain how the shared state tracks geometry between SSR and hydration.
@@ -141,7 +141,7 @@ impl SharedOverlayState {
         );
 
         let text_field = TextFieldState::controlled(
-            "Automation ready company", 
+            "Automation ready company",
             Some(Duration::from_millis(250)),
         );
 
@@ -241,7 +241,10 @@ impl SharedOverlayState {
         let mut desired = None;
         self.popover.toggle(|next| {
             desired = Some(next);
-            log.record(format!("popover requested {}", if next { "open" } else { "close" }));
+            log.record(format!(
+                "popover requested {}",
+                if next { "open" } else { "close" }
+            ));
         });
         if let Some(open) = desired {
             self.popover.sync_open(open);
@@ -303,9 +306,7 @@ impl SharedOverlayState {
         self.text_field.commit(|snapshot| {
             log.record(format!(
                 "text commit -> '{}' (visited before: {}, errors present: {})",
-                snapshot.value,
-                snapshot.previously_visited,
-                snapshot.has_errors
+                snapshot.value, snapshot.previously_visited, snapshot.has_errors
             ));
         });
         if let Some(message) = validation {
@@ -322,8 +323,7 @@ impl SharedOverlayState {
         self.text_field.reset(|snapshot| {
             log.record(format!(
                 "text reset -> '{}' (cleared errors: {})",
-                snapshot.value,
-                snapshot.cleared_errors
+                snapshot.value, snapshot.cleared_errors
             ));
         });
         (self, log)
@@ -385,7 +385,10 @@ mod tests {
         let (state, _) = state.toggle_popover();
         let snapshot = state.snapshot();
         assert!(snapshot.popover_open);
-        assert_eq!(snapshot.popover_anchor_id.as_deref(), Some(POPOVER_ANCHOR_ID));
+        assert_eq!(
+            snapshot.popover_anchor_id.as_deref(),
+            Some(POPOVER_ANCHOR_ID)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- clean up theme provider re-exports and macro sentinels
- address clippy feedback across themed element and box helpers
- tighten theme provider tests for new palette API

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets --all-features *(fails: mui-material not yet updated for dual palette API; see logs)*
- cargo test -p mui-system

------
https://chatgpt.com/codex/tasks/task_e_68d093f1f2d4832e97df55d05be42519