### PR TITLE
Add Joy component parity inventory tooling

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -143,6 +143,20 @@ jobs:
       - run: cargo xtask update-components
       # Refresh icon bindings from upstream Material icons
       - run: cargo xtask refresh-icons
+      # Capture the Joy UI component inventory so regressions surface quickly in diffs
+      - name: Generate Joy component parity report
+        run: cargo xtask joy-inventory
+      # Persist the generated markdown so subsequent jobs (and workflow runs) can diff it cheaply
+      - name: Cache Joy parity report
+        uses: actions/cache@v4
+        with:
+          path: docs/joy-component-parity.md
+          key: joy-parity-${{ github.sha }}
+          restore-keys: |
+            joy-parity-
+      # Fail fast when the inventory drifts to force contributors to commit the refreshed snapshot
+      - name: Ensure Joy parity report committed
+        run: git diff --exit-code docs/joy-component-parity.md
       # Run accessibility audits for the documentation site
       - run: cargo xtask accessibility-audit
       # Build the JavaScript documentation site for validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,23 @@ report at `docs/material-component-parity.md`. Keep this artifact up to date in
 pull requests that add or remove components so downstream teams have a reliable
 signal when planning migrations.
 
+### Joy UI inventory guardrail
+
+Joy UI follows the same automation-first strategy. Rebuild the Joy coverage
+report whenever a pull request touches Joy components or headless primitives:
+
+```bash
+cargo xtask joy-inventory
+```
+
+The xtask delegates to `tools/joy-parity`, a standalone Rust binary that walks
+`packages/mui-joy/src/**/index.ts` via SWC, normalizes aliases, and compares the
+exports with the Rust crates (`crates/mui-joy` and `crates/mui-headless`). The
+command rewrites `docs/joy-component-parity.md` with a markdown dashboard plus a
+machine-readable JSON blob embedded in the same file. Commit the refreshed
+artifact so CI stays clean and enterprise adopters can spot parity gaps without
+replicating the analysis locally.
+
 ### Theme artifact regeneration
 
 Regenerating the serialized Material theme is a fully automated flow powered by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "joy-parity"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "heck",
+ "serde",
+ "serde_json",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "walkdir",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "crates/mui-utils",
     "crates/xtask",
     "tools/material-parity",
+    "tools/joy-parity",
     "examples/feedback-tooltips",
     "examples/feedback-chips",
     "examples/data-display-avatar",

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -63,6 +63,9 @@ enum Commands {
     },
     /// Recompute the Material component parity dashboard.
     MaterialParity,
+    /// Recompute the Joy UI inventory to highlight missing Rust bindings.
+    #[command(name = "joy-inventory", alias = "joy-parity")]
+    JoyParity,
 }
 
 fn main() -> Result<()> {
@@ -81,6 +84,7 @@ fn main() -> Result<()> {
         Commands::BuildDocs => build_docs(),
         Commands::GenerateTheme { overrides, format } => generate_theme(overrides, format),
         Commands::MaterialParity => material_parity(),
+        Commands::JoyParity => joy_parity(),
     }
 }
 
@@ -427,6 +431,20 @@ fn material_parity() -> Result<()> {
         .arg("--")
         .arg("--report")
         .arg("docs/material-component-parity.md");
+    run(cmd)
+}
+
+fn joy_parity() -> Result<()> {
+    // Delegate to the dedicated Joy parity binary so the TypeScript parsing logic stays
+    // encapsulated and independently testable. Keeping xtask thin ensures we can reuse the
+    // scanner from CI, local development, or other automation entry points without code drift.
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run")
+        .arg("-p")
+        .arg("joy-parity")
+        .arg("--")
+        .arg("--report")
+        .arg("docs/joy-component-parity.md");
     run(cmd)
 }
 

--- a/docs/joy-component-parity.md
+++ b/docs/joy-component-parity.md
@@ -1,0 +1,1514 @@
+# Joy Component Parity
+
+_Last updated 2025-09-22T15:30:25.645732243+00:00 via `cargo xtask joy-inventory`._
+
+## Coverage snapshot
+
+- React exports analyzed: 88\n- `mui-joy` coverage: 4 (4.5%)\n- `mui-headless` coverage: 14 (15.9%)\n
+## Highest priority gaps
+
+| Rank | Component | Source |\n| --- | --- | --- |\n| 1 | Accordion | `packages/mui-joy/src/Accordion` |\n| 2 | AccordionDetails | `packages/mui-joy/src/AccordionDetails` |\n| 3 | AccordionGroup | `packages/mui-joy/src/AccordionGroup` |\n| 4 | AccordionSummary | `packages/mui-joy/src/AccordionSummary` |\n| 5 | Alert | `packages/mui-joy/src/Alert` |\n| 6 | Autocomplete | `packages/mui-joy/src/Autocomplete` |\n| 7 | AutocompleteListbox | `packages/mui-joy/src/AutocompleteListbox` |\n| 8 | AutocompleteOption | `packages/mui-joy/src/AutocompleteOption` |\n| 9 | Avatar | `packages/mui-joy/src/Avatar` |\n| 10 | AvatarGroup | `packages/mui-joy/src/AvatarGroup` |\n
+## Machine-readable snapshot
+
+```json
+{
+  "generated_at": "2025-09-22T15:30:25.645732243Z",
+  "total_components": 88,
+  "supported_in_joy": 4,
+  "supported_in_headless": 14,
+  "joy_coverage": 0.045454547,
+  "headless_coverage": 0.1590909,
+  "components": [
+    {
+      "name": "Accordion",
+      "normalized": "accordion",
+      "source": "packages/mui-joy/src/Accordion",
+      "declared_in": "packages/mui-joy/src/Accordion/index.ts"
+    },
+    {
+      "name": "AccordionDetails",
+      "normalized": "accordion_details",
+      "source": "packages/mui-joy/src/AccordionDetails",
+      "declared_in": "packages/mui-joy/src/AccordionDetails/index.ts"
+    },
+    {
+      "name": "AccordionGroup",
+      "normalized": "accordion_group",
+      "source": "packages/mui-joy/src/AccordionGroup",
+      "declared_in": "packages/mui-joy/src/AccordionGroup/index.ts"
+    },
+    {
+      "name": "AccordionSummary",
+      "normalized": "accordion_summary",
+      "source": "packages/mui-joy/src/AccordionSummary",
+      "declared_in": "packages/mui-joy/src/AccordionSummary/index.ts"
+    },
+    {
+      "name": "Alert",
+      "normalized": "alert",
+      "source": "packages/mui-joy/src/Alert",
+      "declared_in": "packages/mui-joy/src/Alert/index.ts"
+    },
+    {
+      "name": "AspectRatio",
+      "normalized": "aspect_ratio",
+      "source": "packages/mui-joy/src/AspectRatio",
+      "declared_in": "packages/mui-joy/src/AspectRatio/index.ts"
+    },
+    {
+      "name": "Autocomplete",
+      "normalized": "autocomplete",
+      "source": "packages/mui-joy/src/Autocomplete",
+      "declared_in": "packages/mui-joy/src/Autocomplete/index.ts"
+    },
+    {
+      "name": "AutocompleteListbox",
+      "normalized": "autocomplete_listbox",
+      "source": "packages/mui-joy/src/AutocompleteListbox",
+      "declared_in": "packages/mui-joy/src/AutocompleteListbox/index.ts"
+    },
+    {
+      "name": "AutocompleteOption",
+      "normalized": "autocomplete_option",
+      "source": "packages/mui-joy/src/AutocompleteOption",
+      "declared_in": "packages/mui-joy/src/AutocompleteOption/index.ts"
+    },
+    {
+      "name": "Avatar",
+      "normalized": "avatar",
+      "source": "packages/mui-joy/src/Avatar",
+      "declared_in": "packages/mui-joy/src/Avatar/index.ts"
+    },
+    {
+      "name": "AvatarGroup",
+      "normalized": "avatar_group",
+      "source": "packages/mui-joy/src/AvatarGroup",
+      "declared_in": "packages/mui-joy/src/AvatarGroup/index.ts"
+    },
+    {
+      "name": "Badge",
+      "normalized": "badge",
+      "source": "packages/mui-joy/src/Badge",
+      "declared_in": "packages/mui-joy/src/Badge/index.ts"
+    },
+    {
+      "name": "Box",
+      "normalized": "box",
+      "source": "packages/mui-joy/src/Box",
+      "declared_in": "packages/mui-joy/src/Box/index.ts"
+    },
+    {
+      "name": "Breadcrumbs",
+      "normalized": "breadcrumbs",
+      "source": "packages/mui-joy/src/Breadcrumbs",
+      "declared_in": "packages/mui-joy/src/Breadcrumbs/index.ts"
+    },
+    {
+      "name": "Button",
+      "normalized": "button",
+      "source": "packages/mui-joy/src/Button",
+      "declared_in": "packages/mui-joy/src/Button/index.ts"
+    },
+    {
+      "name": "ButtonGroup",
+      "normalized": "button_group",
+      "source": "packages/mui-joy/src/ButtonGroup",
+      "declared_in": "packages/mui-joy/src/ButtonGroup/index.ts"
+    },
+    {
+      "name": "Card",
+      "normalized": "card",
+      "source": "packages/mui-joy/src/Card",
+      "declared_in": "packages/mui-joy/src/Card/index.ts"
+    },
+    {
+      "name": "CardActions",
+      "normalized": "card_actions",
+      "source": "packages/mui-joy/src/CardActions",
+      "declared_in": "packages/mui-joy/src/CardActions/index.ts"
+    },
+    {
+      "name": "CardContent",
+      "normalized": "card_content",
+      "source": "packages/mui-joy/src/CardContent",
+      "declared_in": "packages/mui-joy/src/CardContent/index.ts"
+    },
+    {
+      "name": "CardCover",
+      "normalized": "card_cover",
+      "source": "packages/mui-joy/src/CardCover",
+      "declared_in": "packages/mui-joy/src/CardCover/index.ts"
+    },
+    {
+      "name": "CardOverflow",
+      "normalized": "card_overflow",
+      "source": "packages/mui-joy/src/CardOverflow",
+      "declared_in": "packages/mui-joy/src/CardOverflow/index.ts"
+    },
+    {
+      "name": "Checkbox",
+      "normalized": "checkbox",
+      "source": "packages/mui-joy/src/Checkbox",
+      "declared_in": "packages/mui-joy/src/Checkbox/index.ts"
+    },
+    {
+      "name": "Chip",
+      "normalized": "chip",
+      "source": "packages/mui-joy/src/Chip",
+      "declared_in": "packages/mui-joy/src/Chip/index.ts"
+    },
+    {
+      "name": "ChipDelete",
+      "normalized": "chip_delete",
+      "source": "packages/mui-joy/src/ChipDelete",
+      "declared_in": "packages/mui-joy/src/ChipDelete/index.ts"
+    },
+    {
+      "name": "CircularProgress",
+      "normalized": "circular_progress",
+      "source": "packages/mui-joy/src/CircularProgress",
+      "declared_in": "packages/mui-joy/src/CircularProgress/index.ts"
+    },
+    {
+      "name": "Colors",
+      "normalized": "colors",
+      "source": "packages/mui-joy/src/colors",
+      "declared_in": "packages/mui-joy/src/colors/index.ts"
+    },
+    {
+      "name": "Container",
+      "normalized": "container",
+      "source": "packages/mui-joy/src/Container",
+      "declared_in": "packages/mui-joy/src/Container/index.ts"
+    },
+    {
+      "name": "CssBaseline",
+      "normalized": "css_baseline",
+      "source": "packages/mui-joy/src/CssBaseline",
+      "declared_in": "packages/mui-joy/src/CssBaseline/index.ts"
+    },
+    {
+      "name": "DialogActions",
+      "normalized": "dialog_actions",
+      "source": "packages/mui-joy/src/DialogActions",
+      "declared_in": "packages/mui-joy/src/DialogActions/index.ts"
+    },
+    {
+      "name": "DialogContent",
+      "normalized": "dialog_content",
+      "source": "packages/mui-joy/src/DialogContent",
+      "declared_in": "packages/mui-joy/src/DialogContent/index.ts"
+    },
+    {
+      "name": "DialogTitle",
+      "normalized": "dialog_title",
+      "source": "packages/mui-joy/src/DialogTitle",
+      "declared_in": "packages/mui-joy/src/DialogTitle/index.ts"
+    },
+    {
+      "name": "Divider",
+      "normalized": "divider",
+      "source": "packages/mui-joy/src/Divider",
+      "declared_in": "packages/mui-joy/src/Divider/index.ts"
+    },
+    {
+      "name": "Drawer",
+      "normalized": "drawer",
+      "source": "packages/mui-joy/src/Drawer",
+      "declared_in": "packages/mui-joy/src/Drawer/index.ts"
+    },
+    {
+      "name": "Dropdown",
+      "normalized": "dropdown",
+      "source": "packages/mui-joy/src/Dropdown",
+      "declared_in": "packages/mui-joy/src/index.ts"
+    },
+    {
+      "name": "FormControl",
+      "normalized": "form_control",
+      "source": "packages/mui-joy/src/FormControl",
+      "declared_in": "packages/mui-joy/src/FormControl/index.ts"
+    },
+    {
+      "name": "FormHelperText",
+      "normalized": "form_helper_text",
+      "source": "packages/mui-joy/src/FormHelperText",
+      "declared_in": "packages/mui-joy/src/FormHelperText/index.ts"
+    },
+    {
+      "name": "FormLabel",
+      "normalized": "form_label",
+      "source": "packages/mui-joy/src/FormLabel",
+      "declared_in": "packages/mui-joy/src/FormLabel/index.ts"
+    },
+    {
+      "name": "GlobalStyles",
+      "normalized": "global_styles",
+      "source": "packages/mui-joy/src/GlobalStyles",
+      "declared_in": "packages/mui-joy/src/GlobalStyles/index.tsx"
+    },
+    {
+      "name": "Grid",
+      "normalized": "grid",
+      "source": "packages/mui-joy/src/Grid",
+      "declared_in": "packages/mui-joy/src/Grid/index.ts"
+    },
+    {
+      "name": "IconButton",
+      "normalized": "icon_button",
+      "source": "packages/mui-joy/src/IconButton",
+      "declared_in": "packages/mui-joy/src/IconButton/index.ts"
+    },
+    {
+      "name": "InitColorSchemeScript",
+      "normalized": "init_color_scheme_script",
+      "source": "packages/mui-joy/src/InitColorSchemeScript",
+      "declared_in": "packages/mui-joy/src/InitColorSchemeScript/index.ts"
+    },
+    {
+      "name": "Input",
+      "normalized": "input",
+      "source": "packages/mui-joy/src/Input",
+      "declared_in": "packages/mui-joy/src/Input/index.ts"
+    },
+    {
+      "name": "LinearProgress",
+      "normalized": "linear_progress",
+      "source": "packages/mui-joy/src/LinearProgress",
+      "declared_in": "packages/mui-joy/src/LinearProgress/index.ts"
+    },
+    {
+      "name": "Link",
+      "normalized": "link",
+      "source": "packages/mui-joy/src/Link",
+      "declared_in": "packages/mui-joy/src/Link/index.ts"
+    },
+    {
+      "name": "List",
+      "normalized": "list",
+      "source": "packages/mui-joy/src/List",
+      "declared_in": "packages/mui-joy/src/List/index.ts"
+    },
+    {
+      "name": "ListDivider",
+      "normalized": "list_divider",
+      "source": "packages/mui-joy/src/ListDivider",
+      "declared_in": "packages/mui-joy/src/ListDivider/index.ts"
+    },
+    {
+      "name": "ListItem",
+      "normalized": "list_item",
+      "source": "packages/mui-joy/src/ListItem",
+      "declared_in": "packages/mui-joy/src/ListItem/index.ts"
+    },
+    {
+      "name": "ListItemButton",
+      "normalized": "list_item_button",
+      "source": "packages/mui-joy/src/ListItemButton",
+      "declared_in": "packages/mui-joy/src/ListItemButton/index.ts"
+    },
+    {
+      "name": "ListItemContent",
+      "normalized": "list_item_content",
+      "source": "packages/mui-joy/src/ListItemContent",
+      "declared_in": "packages/mui-joy/src/ListItemContent/index.ts"
+    },
+    {
+      "name": "ListItemDecorator",
+      "normalized": "list_item_decorator",
+      "source": "packages/mui-joy/src/ListItemDecorator",
+      "declared_in": "packages/mui-joy/src/ListItemDecorator/index.ts"
+    },
+    {
+      "name": "ListSubheader",
+      "normalized": "list_subheader",
+      "source": "packages/mui-joy/src/ListSubheader",
+      "declared_in": "packages/mui-joy/src/ListSubheader/index.ts"
+    },
+    {
+      "name": "Menu",
+      "normalized": "menu",
+      "source": "packages/mui-joy/src/Menu",
+      "declared_in": "packages/mui-joy/src/Menu/index.ts"
+    },
+    {
+      "name": "MenuButton",
+      "normalized": "menu_button",
+      "source": "packages/mui-joy/src/MenuButton",
+      "declared_in": "packages/mui-joy/src/MenuButton/index.ts"
+    },
+    {
+      "name": "MenuItem",
+      "normalized": "menu_item",
+      "source": "packages/mui-joy/src/MenuItem",
+      "declared_in": "packages/mui-joy/src/MenuItem/index.ts"
+    },
+    {
+      "name": "MenuList",
+      "normalized": "menu_list",
+      "source": "packages/mui-joy/src/MenuList",
+      "declared_in": "packages/mui-joy/src/MenuList/index.ts"
+    },
+    {
+      "name": "Modal",
+      "normalized": "modal",
+      "source": "packages/mui-joy/src/Modal",
+      "declared_in": "packages/mui-joy/src/Modal/index.ts"
+    },
+    {
+      "name": "ModalClose",
+      "normalized": "modal_close",
+      "source": "packages/mui-joy/src/ModalClose",
+      "declared_in": "packages/mui-joy/src/ModalClose/index.ts"
+    },
+    {
+      "name": "ModalDialog",
+      "normalized": "modal_dialog",
+      "source": "packages/mui-joy/src/ModalDialog",
+      "declared_in": "packages/mui-joy/src/ModalDialog/index.ts"
+    },
+    {
+      "name": "ModalOverflow",
+      "normalized": "modal_overflow",
+      "source": "packages/mui-joy/src/ModalOverflow",
+      "declared_in": "packages/mui-joy/src/ModalOverflow/index.ts"
+    },
+    {
+      "name": "Option",
+      "normalized": "option",
+      "source": "packages/mui-joy/src/Option",
+      "declared_in": "packages/mui-joy/src/Option/index.ts"
+    },
+    {
+      "name": "Radio",
+      "normalized": "radio",
+      "source": "packages/mui-joy/src/Radio",
+      "declared_in": "packages/mui-joy/src/Radio/index.ts"
+    },
+    {
+      "name": "RadioGroup",
+      "normalized": "radio_group",
+      "source": "packages/mui-joy/src/RadioGroup",
+      "declared_in": "packages/mui-joy/src/RadioGroup/index.ts"
+    },
+    {
+      "name": "ScopedCssBaseline",
+      "normalized": "scoped_css_baseline",
+      "source": "packages/mui-joy/src/ScopedCssBaseline",
+      "declared_in": "packages/mui-joy/src/ScopedCssBaseline/index.ts"
+    },
+    {
+      "name": "Select",
+      "normalized": "select",
+      "source": "packages/mui-joy/src/Select",
+      "declared_in": "packages/mui-joy/src/Select/index.ts"
+    },
+    {
+      "name": "Sheet",
+      "normalized": "sheet",
+      "source": "packages/mui-joy/src/Sheet",
+      "declared_in": "packages/mui-joy/src/Sheet/index.ts"
+    },
+    {
+      "name": "Skeleton",
+      "normalized": "skeleton",
+      "source": "packages/mui-joy/src/Skeleton",
+      "declared_in": "packages/mui-joy/src/Skeleton/index.ts"
+    },
+    {
+      "name": "Slider",
+      "normalized": "slider",
+      "source": "packages/mui-joy/src/Slider",
+      "declared_in": "packages/mui-joy/src/Slider/index.ts"
+    },
+    {
+      "name": "Snackbar",
+      "normalized": "snackbar",
+      "source": "packages/mui-joy/src/Snackbar",
+      "declared_in": "packages/mui-joy/src/Snackbar/index.ts"
+    },
+    {
+      "name": "Stack",
+      "normalized": "stack",
+      "source": "packages/mui-joy/src/Stack",
+      "declared_in": "packages/mui-joy/src/Stack/index.ts"
+    },
+    {
+      "name": "Step",
+      "normalized": "step",
+      "source": "packages/mui-joy/src/Step",
+      "declared_in": "packages/mui-joy/src/Step/index.ts"
+    },
+    {
+      "name": "StepButton",
+      "normalized": "step_button",
+      "source": "packages/mui-joy/src/StepButton",
+      "declared_in": "packages/mui-joy/src/StepButton/index.ts"
+    },
+    {
+      "name": "StepIndicator",
+      "normalized": "step_indicator",
+      "source": "packages/mui-joy/src/StepIndicator",
+      "declared_in": "packages/mui-joy/src/StepIndicator/index.ts"
+    },
+    {
+      "name": "Stepper",
+      "normalized": "stepper",
+      "source": "packages/mui-joy/src/Stepper",
+      "declared_in": "packages/mui-joy/src/Stepper/index.ts"
+    },
+    {
+      "name": "StyledEngineProvider",
+      "normalized": "styled_engine_provider",
+      "source": "packages/mui-joy/src/StyledEngineProvider",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "SvgIcon",
+      "normalized": "svg_icon",
+      "source": "packages/mui-joy/src/SvgIcon",
+      "declared_in": "packages/mui-joy/src/SvgIcon/index.ts"
+    },
+    {
+      "name": "Switch",
+      "normalized": "switch",
+      "source": "packages/mui-joy/src/Switch",
+      "declared_in": "packages/mui-joy/src/Switch/index.ts"
+    },
+    {
+      "name": "Tab",
+      "normalized": "tab",
+      "source": "packages/mui-joy/src/Tab",
+      "declared_in": "packages/mui-joy/src/Tab/index.ts"
+    },
+    {
+      "name": "TabList",
+      "normalized": "tab_list",
+      "source": "packages/mui-joy/src/TabList",
+      "declared_in": "packages/mui-joy/src/TabList/index.ts"
+    },
+    {
+      "name": "TabPanel",
+      "normalized": "tab_panel",
+      "source": "packages/mui-joy/src/TabPanel",
+      "declared_in": "packages/mui-joy/src/TabPanel/index.ts"
+    },
+    {
+      "name": "Table",
+      "normalized": "table",
+      "source": "packages/mui-joy/src/Table",
+      "declared_in": "packages/mui-joy/src/Table/index.ts"
+    },
+    {
+      "name": "Tabs",
+      "normalized": "tabs",
+      "source": "packages/mui-joy/src/Tabs",
+      "declared_in": "packages/mui-joy/src/Tabs/index.ts"
+    },
+    {
+      "name": "TextField",
+      "normalized": "text_field",
+      "source": "packages/mui-joy/src/TextField",
+      "declared_in": "packages/mui-joy/src/TextField/index.ts"
+    },
+    {
+      "name": "Textarea",
+      "normalized": "textarea",
+      "source": "packages/mui-joy/src/Textarea",
+      "declared_in": "packages/mui-joy/src/Textarea/index.ts"
+    },
+    {
+      "name": "THEME_ID",
+      "normalized": "theme_id",
+      "source": "packages/mui-joy/src/identifier",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "ThemeProvider",
+      "normalized": "theme_provider",
+      "source": "packages/mui-joy/src/ThemeProvider",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "ToggleButtonGroup",
+      "normalized": "toggle_button_group",
+      "source": "packages/mui-joy/src/ToggleButtonGroup",
+      "declared_in": "packages/mui-joy/src/ToggleButtonGroup/index.ts"
+    },
+    {
+      "name": "Tooltip",
+      "normalized": "tooltip",
+      "source": "packages/mui-joy/src/Tooltip",
+      "declared_in": "packages/mui-joy/src/Tooltip/index.ts"
+    },
+    {
+      "name": "Typography",
+      "normalized": "typography",
+      "source": "packages/mui-joy/src/Typography",
+      "declared_in": "packages/mui-joy/src/Typography/index.ts"
+    }
+  ],
+  "missing_from_joy": [
+    {
+      "name": "Accordion",
+      "normalized": "accordion",
+      "source": "packages/mui-joy/src/Accordion",
+      "declared_in": "packages/mui-joy/src/Accordion/index.ts"
+    },
+    {
+      "name": "AccordionDetails",
+      "normalized": "accordion_details",
+      "source": "packages/mui-joy/src/AccordionDetails",
+      "declared_in": "packages/mui-joy/src/AccordionDetails/index.ts"
+    },
+    {
+      "name": "AccordionGroup",
+      "normalized": "accordion_group",
+      "source": "packages/mui-joy/src/AccordionGroup",
+      "declared_in": "packages/mui-joy/src/AccordionGroup/index.ts"
+    },
+    {
+      "name": "AccordionSummary",
+      "normalized": "accordion_summary",
+      "source": "packages/mui-joy/src/AccordionSummary",
+      "declared_in": "packages/mui-joy/src/AccordionSummary/index.ts"
+    },
+    {
+      "name": "Alert",
+      "normalized": "alert",
+      "source": "packages/mui-joy/src/Alert",
+      "declared_in": "packages/mui-joy/src/Alert/index.ts"
+    },
+    {
+      "name": "Autocomplete",
+      "normalized": "autocomplete",
+      "source": "packages/mui-joy/src/Autocomplete",
+      "declared_in": "packages/mui-joy/src/Autocomplete/index.ts"
+    },
+    {
+      "name": "AutocompleteListbox",
+      "normalized": "autocomplete_listbox",
+      "source": "packages/mui-joy/src/AutocompleteListbox",
+      "declared_in": "packages/mui-joy/src/AutocompleteListbox/index.ts"
+    },
+    {
+      "name": "AutocompleteOption",
+      "normalized": "autocomplete_option",
+      "source": "packages/mui-joy/src/AutocompleteOption",
+      "declared_in": "packages/mui-joy/src/AutocompleteOption/index.ts"
+    },
+    {
+      "name": "Avatar",
+      "normalized": "avatar",
+      "source": "packages/mui-joy/src/Avatar",
+      "declared_in": "packages/mui-joy/src/Avatar/index.ts"
+    },
+    {
+      "name": "AvatarGroup",
+      "normalized": "avatar_group",
+      "source": "packages/mui-joy/src/AvatarGroup",
+      "declared_in": "packages/mui-joy/src/AvatarGroup/index.ts"
+    },
+    {
+      "name": "Badge",
+      "normalized": "badge",
+      "source": "packages/mui-joy/src/Badge",
+      "declared_in": "packages/mui-joy/src/Badge/index.ts"
+    },
+    {
+      "name": "Box",
+      "normalized": "box",
+      "source": "packages/mui-joy/src/Box",
+      "declared_in": "packages/mui-joy/src/Box/index.ts"
+    },
+    {
+      "name": "Breadcrumbs",
+      "normalized": "breadcrumbs",
+      "source": "packages/mui-joy/src/Breadcrumbs",
+      "declared_in": "packages/mui-joy/src/Breadcrumbs/index.ts"
+    },
+    {
+      "name": "ButtonGroup",
+      "normalized": "button_group",
+      "source": "packages/mui-joy/src/ButtonGroup",
+      "declared_in": "packages/mui-joy/src/ButtonGroup/index.ts"
+    },
+    {
+      "name": "CardActions",
+      "normalized": "card_actions",
+      "source": "packages/mui-joy/src/CardActions",
+      "declared_in": "packages/mui-joy/src/CardActions/index.ts"
+    },
+    {
+      "name": "CardContent",
+      "normalized": "card_content",
+      "source": "packages/mui-joy/src/CardContent",
+      "declared_in": "packages/mui-joy/src/CardContent/index.ts"
+    },
+    {
+      "name": "CardCover",
+      "normalized": "card_cover",
+      "source": "packages/mui-joy/src/CardCover",
+      "declared_in": "packages/mui-joy/src/CardCover/index.ts"
+    },
+    {
+      "name": "CardOverflow",
+      "normalized": "card_overflow",
+      "source": "packages/mui-joy/src/CardOverflow",
+      "declared_in": "packages/mui-joy/src/CardOverflow/index.ts"
+    },
+    {
+      "name": "Checkbox",
+      "normalized": "checkbox",
+      "source": "packages/mui-joy/src/Checkbox",
+      "declared_in": "packages/mui-joy/src/Checkbox/index.ts"
+    },
+    {
+      "name": "ChipDelete",
+      "normalized": "chip_delete",
+      "source": "packages/mui-joy/src/ChipDelete",
+      "declared_in": "packages/mui-joy/src/ChipDelete/index.ts"
+    },
+    {
+      "name": "CircularProgress",
+      "normalized": "circular_progress",
+      "source": "packages/mui-joy/src/CircularProgress",
+      "declared_in": "packages/mui-joy/src/CircularProgress/index.ts"
+    },
+    {
+      "name": "Colors",
+      "normalized": "colors",
+      "source": "packages/mui-joy/src/colors",
+      "declared_in": "packages/mui-joy/src/colors/index.ts"
+    },
+    {
+      "name": "Container",
+      "normalized": "container",
+      "source": "packages/mui-joy/src/Container",
+      "declared_in": "packages/mui-joy/src/Container/index.ts"
+    },
+    {
+      "name": "CssBaseline",
+      "normalized": "css_baseline",
+      "source": "packages/mui-joy/src/CssBaseline",
+      "declared_in": "packages/mui-joy/src/CssBaseline/index.ts"
+    },
+    {
+      "name": "DialogActions",
+      "normalized": "dialog_actions",
+      "source": "packages/mui-joy/src/DialogActions",
+      "declared_in": "packages/mui-joy/src/DialogActions/index.ts"
+    },
+    {
+      "name": "DialogContent",
+      "normalized": "dialog_content",
+      "source": "packages/mui-joy/src/DialogContent",
+      "declared_in": "packages/mui-joy/src/DialogContent/index.ts"
+    },
+    {
+      "name": "DialogTitle",
+      "normalized": "dialog_title",
+      "source": "packages/mui-joy/src/DialogTitle",
+      "declared_in": "packages/mui-joy/src/DialogTitle/index.ts"
+    },
+    {
+      "name": "Divider",
+      "normalized": "divider",
+      "source": "packages/mui-joy/src/Divider",
+      "declared_in": "packages/mui-joy/src/Divider/index.ts"
+    },
+    {
+      "name": "Drawer",
+      "normalized": "drawer",
+      "source": "packages/mui-joy/src/Drawer",
+      "declared_in": "packages/mui-joy/src/Drawer/index.ts"
+    },
+    {
+      "name": "Dropdown",
+      "normalized": "dropdown",
+      "source": "packages/mui-joy/src/Dropdown",
+      "declared_in": "packages/mui-joy/src/index.ts"
+    },
+    {
+      "name": "FormControl",
+      "normalized": "form_control",
+      "source": "packages/mui-joy/src/FormControl",
+      "declared_in": "packages/mui-joy/src/FormControl/index.ts"
+    },
+    {
+      "name": "FormHelperText",
+      "normalized": "form_helper_text",
+      "source": "packages/mui-joy/src/FormHelperText",
+      "declared_in": "packages/mui-joy/src/FormHelperText/index.ts"
+    },
+    {
+      "name": "FormLabel",
+      "normalized": "form_label",
+      "source": "packages/mui-joy/src/FormLabel",
+      "declared_in": "packages/mui-joy/src/FormLabel/index.ts"
+    },
+    {
+      "name": "GlobalStyles",
+      "normalized": "global_styles",
+      "source": "packages/mui-joy/src/GlobalStyles",
+      "declared_in": "packages/mui-joy/src/GlobalStyles/index.tsx"
+    },
+    {
+      "name": "Grid",
+      "normalized": "grid",
+      "source": "packages/mui-joy/src/Grid",
+      "declared_in": "packages/mui-joy/src/Grid/index.ts"
+    },
+    {
+      "name": "IconButton",
+      "normalized": "icon_button",
+      "source": "packages/mui-joy/src/IconButton",
+      "declared_in": "packages/mui-joy/src/IconButton/index.ts"
+    },
+    {
+      "name": "InitColorSchemeScript",
+      "normalized": "init_color_scheme_script",
+      "source": "packages/mui-joy/src/InitColorSchemeScript",
+      "declared_in": "packages/mui-joy/src/InitColorSchemeScript/index.ts"
+    },
+    {
+      "name": "Input",
+      "normalized": "input",
+      "source": "packages/mui-joy/src/Input",
+      "declared_in": "packages/mui-joy/src/Input/index.ts"
+    },
+    {
+      "name": "LinearProgress",
+      "normalized": "linear_progress",
+      "source": "packages/mui-joy/src/LinearProgress",
+      "declared_in": "packages/mui-joy/src/LinearProgress/index.ts"
+    },
+    {
+      "name": "Link",
+      "normalized": "link",
+      "source": "packages/mui-joy/src/Link",
+      "declared_in": "packages/mui-joy/src/Link/index.ts"
+    },
+    {
+      "name": "List",
+      "normalized": "list",
+      "source": "packages/mui-joy/src/List",
+      "declared_in": "packages/mui-joy/src/List/index.ts"
+    },
+    {
+      "name": "ListDivider",
+      "normalized": "list_divider",
+      "source": "packages/mui-joy/src/ListDivider",
+      "declared_in": "packages/mui-joy/src/ListDivider/index.ts"
+    },
+    {
+      "name": "ListItem",
+      "normalized": "list_item",
+      "source": "packages/mui-joy/src/ListItem",
+      "declared_in": "packages/mui-joy/src/ListItem/index.ts"
+    },
+    {
+      "name": "ListItemButton",
+      "normalized": "list_item_button",
+      "source": "packages/mui-joy/src/ListItemButton",
+      "declared_in": "packages/mui-joy/src/ListItemButton/index.ts"
+    },
+    {
+      "name": "ListItemContent",
+      "normalized": "list_item_content",
+      "source": "packages/mui-joy/src/ListItemContent",
+      "declared_in": "packages/mui-joy/src/ListItemContent/index.ts"
+    },
+    {
+      "name": "ListItemDecorator",
+      "normalized": "list_item_decorator",
+      "source": "packages/mui-joy/src/ListItemDecorator",
+      "declared_in": "packages/mui-joy/src/ListItemDecorator/index.ts"
+    },
+    {
+      "name": "ListSubheader",
+      "normalized": "list_subheader",
+      "source": "packages/mui-joy/src/ListSubheader",
+      "declared_in": "packages/mui-joy/src/ListSubheader/index.ts"
+    },
+    {
+      "name": "Menu",
+      "normalized": "menu",
+      "source": "packages/mui-joy/src/Menu",
+      "declared_in": "packages/mui-joy/src/Menu/index.ts"
+    },
+    {
+      "name": "MenuButton",
+      "normalized": "menu_button",
+      "source": "packages/mui-joy/src/MenuButton",
+      "declared_in": "packages/mui-joy/src/MenuButton/index.ts"
+    },
+    {
+      "name": "MenuItem",
+      "normalized": "menu_item",
+      "source": "packages/mui-joy/src/MenuItem",
+      "declared_in": "packages/mui-joy/src/MenuItem/index.ts"
+    },
+    {
+      "name": "MenuList",
+      "normalized": "menu_list",
+      "source": "packages/mui-joy/src/MenuList",
+      "declared_in": "packages/mui-joy/src/MenuList/index.ts"
+    },
+    {
+      "name": "Modal",
+      "normalized": "modal",
+      "source": "packages/mui-joy/src/Modal",
+      "declared_in": "packages/mui-joy/src/Modal/index.ts"
+    },
+    {
+      "name": "ModalClose",
+      "normalized": "modal_close",
+      "source": "packages/mui-joy/src/ModalClose",
+      "declared_in": "packages/mui-joy/src/ModalClose/index.ts"
+    },
+    {
+      "name": "ModalDialog",
+      "normalized": "modal_dialog",
+      "source": "packages/mui-joy/src/ModalDialog",
+      "declared_in": "packages/mui-joy/src/ModalDialog/index.ts"
+    },
+    {
+      "name": "ModalOverflow",
+      "normalized": "modal_overflow",
+      "source": "packages/mui-joy/src/ModalOverflow",
+      "declared_in": "packages/mui-joy/src/ModalOverflow/index.ts"
+    },
+    {
+      "name": "Option",
+      "normalized": "option",
+      "source": "packages/mui-joy/src/Option",
+      "declared_in": "packages/mui-joy/src/Option/index.ts"
+    },
+    {
+      "name": "Radio",
+      "normalized": "radio",
+      "source": "packages/mui-joy/src/Radio",
+      "declared_in": "packages/mui-joy/src/Radio/index.ts"
+    },
+    {
+      "name": "RadioGroup",
+      "normalized": "radio_group",
+      "source": "packages/mui-joy/src/RadioGroup",
+      "declared_in": "packages/mui-joy/src/RadioGroup/index.ts"
+    },
+    {
+      "name": "ScopedCssBaseline",
+      "normalized": "scoped_css_baseline",
+      "source": "packages/mui-joy/src/ScopedCssBaseline",
+      "declared_in": "packages/mui-joy/src/ScopedCssBaseline/index.ts"
+    },
+    {
+      "name": "Select",
+      "normalized": "select",
+      "source": "packages/mui-joy/src/Select",
+      "declared_in": "packages/mui-joy/src/Select/index.ts"
+    },
+    {
+      "name": "Sheet",
+      "normalized": "sheet",
+      "source": "packages/mui-joy/src/Sheet",
+      "declared_in": "packages/mui-joy/src/Sheet/index.ts"
+    },
+    {
+      "name": "Skeleton",
+      "normalized": "skeleton",
+      "source": "packages/mui-joy/src/Skeleton",
+      "declared_in": "packages/mui-joy/src/Skeleton/index.ts"
+    },
+    {
+      "name": "Slider",
+      "normalized": "slider",
+      "source": "packages/mui-joy/src/Slider",
+      "declared_in": "packages/mui-joy/src/Slider/index.ts"
+    },
+    {
+      "name": "Snackbar",
+      "normalized": "snackbar",
+      "source": "packages/mui-joy/src/Snackbar",
+      "declared_in": "packages/mui-joy/src/Snackbar/index.ts"
+    },
+    {
+      "name": "Stack",
+      "normalized": "stack",
+      "source": "packages/mui-joy/src/Stack",
+      "declared_in": "packages/mui-joy/src/Stack/index.ts"
+    },
+    {
+      "name": "Step",
+      "normalized": "step",
+      "source": "packages/mui-joy/src/Step",
+      "declared_in": "packages/mui-joy/src/Step/index.ts"
+    },
+    {
+      "name": "StepButton",
+      "normalized": "step_button",
+      "source": "packages/mui-joy/src/StepButton",
+      "declared_in": "packages/mui-joy/src/StepButton/index.ts"
+    },
+    {
+      "name": "StepIndicator",
+      "normalized": "step_indicator",
+      "source": "packages/mui-joy/src/StepIndicator",
+      "declared_in": "packages/mui-joy/src/StepIndicator/index.ts"
+    },
+    {
+      "name": "Stepper",
+      "normalized": "stepper",
+      "source": "packages/mui-joy/src/Stepper",
+      "declared_in": "packages/mui-joy/src/Stepper/index.ts"
+    },
+    {
+      "name": "StyledEngineProvider",
+      "normalized": "styled_engine_provider",
+      "source": "packages/mui-joy/src/StyledEngineProvider",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "SvgIcon",
+      "normalized": "svg_icon",
+      "source": "packages/mui-joy/src/SvgIcon",
+      "declared_in": "packages/mui-joy/src/SvgIcon/index.ts"
+    },
+    {
+      "name": "Switch",
+      "normalized": "switch",
+      "source": "packages/mui-joy/src/Switch",
+      "declared_in": "packages/mui-joy/src/Switch/index.ts"
+    },
+    {
+      "name": "Tab",
+      "normalized": "tab",
+      "source": "packages/mui-joy/src/Tab",
+      "declared_in": "packages/mui-joy/src/Tab/index.ts"
+    },
+    {
+      "name": "TabList",
+      "normalized": "tab_list",
+      "source": "packages/mui-joy/src/TabList",
+      "declared_in": "packages/mui-joy/src/TabList/index.ts"
+    },
+    {
+      "name": "TabPanel",
+      "normalized": "tab_panel",
+      "source": "packages/mui-joy/src/TabPanel",
+      "declared_in": "packages/mui-joy/src/TabPanel/index.ts"
+    },
+    {
+      "name": "Table",
+      "normalized": "table",
+      "source": "packages/mui-joy/src/Table",
+      "declared_in": "packages/mui-joy/src/Table/index.ts"
+    },
+    {
+      "name": "Tabs",
+      "normalized": "tabs",
+      "source": "packages/mui-joy/src/Tabs",
+      "declared_in": "packages/mui-joy/src/Tabs/index.ts"
+    },
+    {
+      "name": "TextField",
+      "normalized": "text_field",
+      "source": "packages/mui-joy/src/TextField",
+      "declared_in": "packages/mui-joy/src/TextField/index.ts"
+    },
+    {
+      "name": "Textarea",
+      "normalized": "textarea",
+      "source": "packages/mui-joy/src/Textarea",
+      "declared_in": "packages/mui-joy/src/Textarea/index.ts"
+    },
+    {
+      "name": "THEME_ID",
+      "normalized": "theme_id",
+      "source": "packages/mui-joy/src/identifier",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "ThemeProvider",
+      "normalized": "theme_provider",
+      "source": "packages/mui-joy/src/ThemeProvider",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "ToggleButtonGroup",
+      "normalized": "toggle_button_group",
+      "source": "packages/mui-joy/src/ToggleButtonGroup",
+      "declared_in": "packages/mui-joy/src/ToggleButtonGroup/index.ts"
+    },
+    {
+      "name": "Tooltip",
+      "normalized": "tooltip",
+      "source": "packages/mui-joy/src/Tooltip",
+      "declared_in": "packages/mui-joy/src/Tooltip/index.ts"
+    },
+    {
+      "name": "Typography",
+      "normalized": "typography",
+      "source": "packages/mui-joy/src/Typography",
+      "declared_in": "packages/mui-joy/src/Typography/index.ts"
+    }
+  ],
+  "missing_from_headless": [
+    {
+      "name": "Accordion",
+      "normalized": "accordion",
+      "source": "packages/mui-joy/src/Accordion",
+      "declared_in": "packages/mui-joy/src/Accordion/index.ts"
+    },
+    {
+      "name": "AccordionDetails",
+      "normalized": "accordion_details",
+      "source": "packages/mui-joy/src/AccordionDetails",
+      "declared_in": "packages/mui-joy/src/AccordionDetails/index.ts"
+    },
+    {
+      "name": "AccordionGroup",
+      "normalized": "accordion_group",
+      "source": "packages/mui-joy/src/AccordionGroup",
+      "declared_in": "packages/mui-joy/src/AccordionGroup/index.ts"
+    },
+    {
+      "name": "AccordionSummary",
+      "normalized": "accordion_summary",
+      "source": "packages/mui-joy/src/AccordionSummary",
+      "declared_in": "packages/mui-joy/src/AccordionSummary/index.ts"
+    },
+    {
+      "name": "Alert",
+      "normalized": "alert",
+      "source": "packages/mui-joy/src/Alert",
+      "declared_in": "packages/mui-joy/src/Alert/index.ts"
+    },
+    {
+      "name": "AspectRatio",
+      "normalized": "aspect_ratio",
+      "source": "packages/mui-joy/src/AspectRatio",
+      "declared_in": "packages/mui-joy/src/AspectRatio/index.ts"
+    },
+    {
+      "name": "Autocomplete",
+      "normalized": "autocomplete",
+      "source": "packages/mui-joy/src/Autocomplete",
+      "declared_in": "packages/mui-joy/src/Autocomplete/index.ts"
+    },
+    {
+      "name": "AutocompleteListbox",
+      "normalized": "autocomplete_listbox",
+      "source": "packages/mui-joy/src/AutocompleteListbox",
+      "declared_in": "packages/mui-joy/src/AutocompleteListbox/index.ts"
+    },
+    {
+      "name": "AutocompleteOption",
+      "normalized": "autocomplete_option",
+      "source": "packages/mui-joy/src/AutocompleteOption",
+      "declared_in": "packages/mui-joy/src/AutocompleteOption/index.ts"
+    },
+    {
+      "name": "Avatar",
+      "normalized": "avatar",
+      "source": "packages/mui-joy/src/Avatar",
+      "declared_in": "packages/mui-joy/src/Avatar/index.ts"
+    },
+    {
+      "name": "AvatarGroup",
+      "normalized": "avatar_group",
+      "source": "packages/mui-joy/src/AvatarGroup",
+      "declared_in": "packages/mui-joy/src/AvatarGroup/index.ts"
+    },
+    {
+      "name": "Badge",
+      "normalized": "badge",
+      "source": "packages/mui-joy/src/Badge",
+      "declared_in": "packages/mui-joy/src/Badge/index.ts"
+    },
+    {
+      "name": "Box",
+      "normalized": "box",
+      "source": "packages/mui-joy/src/Box",
+      "declared_in": "packages/mui-joy/src/Box/index.ts"
+    },
+    {
+      "name": "Breadcrumbs",
+      "normalized": "breadcrumbs",
+      "source": "packages/mui-joy/src/Breadcrumbs",
+      "declared_in": "packages/mui-joy/src/Breadcrumbs/index.ts"
+    },
+    {
+      "name": "ButtonGroup",
+      "normalized": "button_group",
+      "source": "packages/mui-joy/src/ButtonGroup",
+      "declared_in": "packages/mui-joy/src/ButtonGroup/index.ts"
+    },
+    {
+      "name": "Card",
+      "normalized": "card",
+      "source": "packages/mui-joy/src/Card",
+      "declared_in": "packages/mui-joy/src/Card/index.ts"
+    },
+    {
+      "name": "CardActions",
+      "normalized": "card_actions",
+      "source": "packages/mui-joy/src/CardActions",
+      "declared_in": "packages/mui-joy/src/CardActions/index.ts"
+    },
+    {
+      "name": "CardContent",
+      "normalized": "card_content",
+      "source": "packages/mui-joy/src/CardContent",
+      "declared_in": "packages/mui-joy/src/CardContent/index.ts"
+    },
+    {
+      "name": "CardCover",
+      "normalized": "card_cover",
+      "source": "packages/mui-joy/src/CardCover",
+      "declared_in": "packages/mui-joy/src/CardCover/index.ts"
+    },
+    {
+      "name": "CardOverflow",
+      "normalized": "card_overflow",
+      "source": "packages/mui-joy/src/CardOverflow",
+      "declared_in": "packages/mui-joy/src/CardOverflow/index.ts"
+    },
+    {
+      "name": "ChipDelete",
+      "normalized": "chip_delete",
+      "source": "packages/mui-joy/src/ChipDelete",
+      "declared_in": "packages/mui-joy/src/ChipDelete/index.ts"
+    },
+    {
+      "name": "CircularProgress",
+      "normalized": "circular_progress",
+      "source": "packages/mui-joy/src/CircularProgress",
+      "declared_in": "packages/mui-joy/src/CircularProgress/index.ts"
+    },
+    {
+      "name": "Colors",
+      "normalized": "colors",
+      "source": "packages/mui-joy/src/colors",
+      "declared_in": "packages/mui-joy/src/colors/index.ts"
+    },
+    {
+      "name": "Container",
+      "normalized": "container",
+      "source": "packages/mui-joy/src/Container",
+      "declared_in": "packages/mui-joy/src/Container/index.ts"
+    },
+    {
+      "name": "CssBaseline",
+      "normalized": "css_baseline",
+      "source": "packages/mui-joy/src/CssBaseline",
+      "declared_in": "packages/mui-joy/src/CssBaseline/index.ts"
+    },
+    {
+      "name": "DialogActions",
+      "normalized": "dialog_actions",
+      "source": "packages/mui-joy/src/DialogActions",
+      "declared_in": "packages/mui-joy/src/DialogActions/index.ts"
+    },
+    {
+      "name": "DialogContent",
+      "normalized": "dialog_content",
+      "source": "packages/mui-joy/src/DialogContent",
+      "declared_in": "packages/mui-joy/src/DialogContent/index.ts"
+    },
+    {
+      "name": "DialogTitle",
+      "normalized": "dialog_title",
+      "source": "packages/mui-joy/src/DialogTitle",
+      "declared_in": "packages/mui-joy/src/DialogTitle/index.ts"
+    },
+    {
+      "name": "Divider",
+      "normalized": "divider",
+      "source": "packages/mui-joy/src/Divider",
+      "declared_in": "packages/mui-joy/src/Divider/index.ts"
+    },
+    {
+      "name": "Dropdown",
+      "normalized": "dropdown",
+      "source": "packages/mui-joy/src/Dropdown",
+      "declared_in": "packages/mui-joy/src/index.ts"
+    },
+    {
+      "name": "FormControl",
+      "normalized": "form_control",
+      "source": "packages/mui-joy/src/FormControl",
+      "declared_in": "packages/mui-joy/src/FormControl/index.ts"
+    },
+    {
+      "name": "FormHelperText",
+      "normalized": "form_helper_text",
+      "source": "packages/mui-joy/src/FormHelperText",
+      "declared_in": "packages/mui-joy/src/FormHelperText/index.ts"
+    },
+    {
+      "name": "FormLabel",
+      "normalized": "form_label",
+      "source": "packages/mui-joy/src/FormLabel",
+      "declared_in": "packages/mui-joy/src/FormLabel/index.ts"
+    },
+    {
+      "name": "GlobalStyles",
+      "normalized": "global_styles",
+      "source": "packages/mui-joy/src/GlobalStyles",
+      "declared_in": "packages/mui-joy/src/GlobalStyles/index.tsx"
+    },
+    {
+      "name": "Grid",
+      "normalized": "grid",
+      "source": "packages/mui-joy/src/Grid",
+      "declared_in": "packages/mui-joy/src/Grid/index.ts"
+    },
+    {
+      "name": "IconButton",
+      "normalized": "icon_button",
+      "source": "packages/mui-joy/src/IconButton",
+      "declared_in": "packages/mui-joy/src/IconButton/index.ts"
+    },
+    {
+      "name": "InitColorSchemeScript",
+      "normalized": "init_color_scheme_script",
+      "source": "packages/mui-joy/src/InitColorSchemeScript",
+      "declared_in": "packages/mui-joy/src/InitColorSchemeScript/index.ts"
+    },
+    {
+      "name": "Input",
+      "normalized": "input",
+      "source": "packages/mui-joy/src/Input",
+      "declared_in": "packages/mui-joy/src/Input/index.ts"
+    },
+    {
+      "name": "LinearProgress",
+      "normalized": "linear_progress",
+      "source": "packages/mui-joy/src/LinearProgress",
+      "declared_in": "packages/mui-joy/src/LinearProgress/index.ts"
+    },
+    {
+      "name": "Link",
+      "normalized": "link",
+      "source": "packages/mui-joy/src/Link",
+      "declared_in": "packages/mui-joy/src/Link/index.ts"
+    },
+    {
+      "name": "ListDivider",
+      "normalized": "list_divider",
+      "source": "packages/mui-joy/src/ListDivider",
+      "declared_in": "packages/mui-joy/src/ListDivider/index.ts"
+    },
+    {
+      "name": "ListItem",
+      "normalized": "list_item",
+      "source": "packages/mui-joy/src/ListItem",
+      "declared_in": "packages/mui-joy/src/ListItem/index.ts"
+    },
+    {
+      "name": "ListItemButton",
+      "normalized": "list_item_button",
+      "source": "packages/mui-joy/src/ListItemButton",
+      "declared_in": "packages/mui-joy/src/ListItemButton/index.ts"
+    },
+    {
+      "name": "ListItemContent",
+      "normalized": "list_item_content",
+      "source": "packages/mui-joy/src/ListItemContent",
+      "declared_in": "packages/mui-joy/src/ListItemContent/index.ts"
+    },
+    {
+      "name": "ListItemDecorator",
+      "normalized": "list_item_decorator",
+      "source": "packages/mui-joy/src/ListItemDecorator",
+      "declared_in": "packages/mui-joy/src/ListItemDecorator/index.ts"
+    },
+    {
+      "name": "ListSubheader",
+      "normalized": "list_subheader",
+      "source": "packages/mui-joy/src/ListSubheader",
+      "declared_in": "packages/mui-joy/src/ListSubheader/index.ts"
+    },
+    {
+      "name": "MenuButton",
+      "normalized": "menu_button",
+      "source": "packages/mui-joy/src/MenuButton",
+      "declared_in": "packages/mui-joy/src/MenuButton/index.ts"
+    },
+    {
+      "name": "MenuItem",
+      "normalized": "menu_item",
+      "source": "packages/mui-joy/src/MenuItem",
+      "declared_in": "packages/mui-joy/src/MenuItem/index.ts"
+    },
+    {
+      "name": "MenuList",
+      "normalized": "menu_list",
+      "source": "packages/mui-joy/src/MenuList",
+      "declared_in": "packages/mui-joy/src/MenuList/index.ts"
+    },
+    {
+      "name": "Modal",
+      "normalized": "modal",
+      "source": "packages/mui-joy/src/Modal",
+      "declared_in": "packages/mui-joy/src/Modal/index.ts"
+    },
+    {
+      "name": "ModalClose",
+      "normalized": "modal_close",
+      "source": "packages/mui-joy/src/ModalClose",
+      "declared_in": "packages/mui-joy/src/ModalClose/index.ts"
+    },
+    {
+      "name": "ModalDialog",
+      "normalized": "modal_dialog",
+      "source": "packages/mui-joy/src/ModalDialog",
+      "declared_in": "packages/mui-joy/src/ModalDialog/index.ts"
+    },
+    {
+      "name": "ModalOverflow",
+      "normalized": "modal_overflow",
+      "source": "packages/mui-joy/src/ModalOverflow",
+      "declared_in": "packages/mui-joy/src/ModalOverflow/index.ts"
+    },
+    {
+      "name": "Option",
+      "normalized": "option",
+      "source": "packages/mui-joy/src/Option",
+      "declared_in": "packages/mui-joy/src/Option/index.ts"
+    },
+    {
+      "name": "RadioGroup",
+      "normalized": "radio_group",
+      "source": "packages/mui-joy/src/RadioGroup",
+      "declared_in": "packages/mui-joy/src/RadioGroup/index.ts"
+    },
+    {
+      "name": "ScopedCssBaseline",
+      "normalized": "scoped_css_baseline",
+      "source": "packages/mui-joy/src/ScopedCssBaseline",
+      "declared_in": "packages/mui-joy/src/ScopedCssBaseline/index.ts"
+    },
+    {
+      "name": "Sheet",
+      "normalized": "sheet",
+      "source": "packages/mui-joy/src/Sheet",
+      "declared_in": "packages/mui-joy/src/Sheet/index.ts"
+    },
+    {
+      "name": "Skeleton",
+      "normalized": "skeleton",
+      "source": "packages/mui-joy/src/Skeleton",
+      "declared_in": "packages/mui-joy/src/Skeleton/index.ts"
+    },
+    {
+      "name": "Slider",
+      "normalized": "slider",
+      "source": "packages/mui-joy/src/Slider",
+      "declared_in": "packages/mui-joy/src/Slider/index.ts"
+    },
+    {
+      "name": "Snackbar",
+      "normalized": "snackbar",
+      "source": "packages/mui-joy/src/Snackbar",
+      "declared_in": "packages/mui-joy/src/Snackbar/index.ts"
+    },
+    {
+      "name": "Stack",
+      "normalized": "stack",
+      "source": "packages/mui-joy/src/Stack",
+      "declared_in": "packages/mui-joy/src/Stack/index.ts"
+    },
+    {
+      "name": "Step",
+      "normalized": "step",
+      "source": "packages/mui-joy/src/Step",
+      "declared_in": "packages/mui-joy/src/Step/index.ts"
+    },
+    {
+      "name": "StepButton",
+      "normalized": "step_button",
+      "source": "packages/mui-joy/src/StepButton",
+      "declared_in": "packages/mui-joy/src/StepButton/index.ts"
+    },
+    {
+      "name": "StepIndicator",
+      "normalized": "step_indicator",
+      "source": "packages/mui-joy/src/StepIndicator",
+      "declared_in": "packages/mui-joy/src/StepIndicator/index.ts"
+    },
+    {
+      "name": "Stepper",
+      "normalized": "stepper",
+      "source": "packages/mui-joy/src/Stepper",
+      "declared_in": "packages/mui-joy/src/Stepper/index.ts"
+    },
+    {
+      "name": "StyledEngineProvider",
+      "normalized": "styled_engine_provider",
+      "source": "packages/mui-joy/src/StyledEngineProvider",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "SvgIcon",
+      "normalized": "svg_icon",
+      "source": "packages/mui-joy/src/SvgIcon",
+      "declared_in": "packages/mui-joy/src/SvgIcon/index.ts"
+    },
+    {
+      "name": "TabList",
+      "normalized": "tab_list",
+      "source": "packages/mui-joy/src/TabList",
+      "declared_in": "packages/mui-joy/src/TabList/index.ts"
+    },
+    {
+      "name": "Table",
+      "normalized": "table",
+      "source": "packages/mui-joy/src/Table",
+      "declared_in": "packages/mui-joy/src/Table/index.ts"
+    },
+    {
+      "name": "Textarea",
+      "normalized": "textarea",
+      "source": "packages/mui-joy/src/Textarea",
+      "declared_in": "packages/mui-joy/src/Textarea/index.ts"
+    },
+    {
+      "name": "THEME_ID",
+      "normalized": "theme_id",
+      "source": "packages/mui-joy/src/identifier",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "ThemeProvider",
+      "normalized": "theme_provider",
+      "source": "packages/mui-joy/src/ThemeProvider",
+      "declared_in": "packages/mui-joy/src/styles/index.ts"
+    },
+    {
+      "name": "ToggleButtonGroup",
+      "normalized": "toggle_button_group",
+      "source": "packages/mui-joy/src/ToggleButtonGroup",
+      "declared_in": "packages/mui-joy/src/ToggleButtonGroup/index.ts"
+    },
+    {
+      "name": "Typography",
+      "normalized": "typography",
+      "source": "packages/mui-joy/src/Typography",
+      "declared_in": "packages/mui-joy/src/Typography/index.ts"
+    }
+  ],
+  "extra_in_joy": [],
+  "extra_in_headless": [
+    "aria",
+    "dialog",
+    "interaction",
+    "popover",
+    "selection",
+    "timing",
+    "toggle"
+  ]
+}
+```

--- a/tools/joy-parity/Cargo.toml
+++ b/tools/joy-parity/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "joy-parity"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+walkdir = { workspace = true }
+heck = { workspace = true }
+swc_common = { version = "14.0.4" }
+swc_ecma_ast = { version = "15.0.0", features = ["serde"] }
+swc_ecma_parser = { version = "24.0.1", features = ["typescript"] }

--- a/tools/joy-parity/src/main.rs
+++ b/tools/joy-parity/src/main.rs
@@ -1,0 +1,488 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use heck::ToSnakeCase;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use swc_common::{sync::Lrc, Globals, SourceMap, GLOBALS};
+use swc_ecma_ast::{ExportSpecifier, Ident, Module, ModuleDecl, ModuleExportName, ModuleItem};
+use swc_ecma_parser::lexer::Lexer;
+use swc_ecma_parser::{EsSyntax, Parser as SwcParser, StringInput, Syntax, TsSyntax};
+use walkdir::WalkDir;
+
+/// Command line contract for the Joy component inventory scanner.
+///
+/// The CLI mirrors `tools/material-parity` so that automation can treat
+/// both reports uniformly.  Defaults intentionally point at the
+/// canonical upstream sources so local developers and CI run the exact
+/// same code paths without remembering flags.
+#[derive(Parser, Debug)]
+#[command(
+    name = "joy-parity",
+    about = "Scans Joy UI exports and compares them with the Rust crates.",
+    version
+)]
+struct Cli {
+    /// Root of the Joy UI TypeScript sources (authoritative implementation).
+    #[arg(long, default_value = "packages/mui-joy/src")]
+    joy_src: PathBuf,
+
+    /// Location of the Rust Joy crate that should mirror the React API surface.
+    #[arg(long, default_value = "crates/mui-joy/src")]
+    rust_joy: PathBuf,
+
+    /// Location of the shared headless primitives for parity comparisons.
+    #[arg(long, default_value = "crates/mui-headless/src")]
+    rust_headless: PathBuf,
+
+    /// Destination markdown report path.  The artifact blends narrative and
+    /// machine-readable JSON so diffs surface regressions immediately.
+    #[arg(long, default_value = "docs/joy-component-parity.md")]
+    report: PathBuf,
+
+    /// Optional JSON-only export that mirrors the embedded report payload.
+    #[arg(long)]
+    json: Option<PathBuf>,
+
+    /// Number of backlog items to highlight in the markdown dashboard.
+    #[arg(long, default_value_t = 10)]
+    top_n: usize,
+}
+
+/// Canonical representation of a component export discovered in the Joy UI sources.
+#[derive(Debug, Clone, Serialize)]
+struct ComponentEntry {
+    /// Display name re-exported from the TypeScript index file.
+    name: String,
+    /// Normalized identifier (snake_case) for comparisons against Rust modules.
+    normalized: String,
+    /// Relative module specifier captured in the export statement.
+    source: String,
+    /// The concrete `index.ts` file that declared the export. Useful for troubleshooting duplicates.
+    declared_in: String,
+}
+
+/// Snapshot capturing end-to-end coverage statistics for Joy UI.
+#[derive(Debug, Serialize)]
+struct CoverageReport {
+    generated_at: DateTime<Utc>,
+    total_components: usize,
+    supported_in_joy: usize,
+    supported_in_headless: usize,
+    joy_coverage: f32,
+    headless_coverage: f32,
+    components: Vec<ComponentEntry>,
+    missing_from_joy: Vec<ComponentEntry>,
+    missing_from_headless: Vec<ComponentEntry>,
+    extra_in_joy: Vec<String>,
+    extra_in_headless: Vec<String>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // Perform the heavy lifting up-front so command invocations remain single-purpose.
+    let report = build_report(&cli)?;
+    write_markdown_report(&report, &cli.report, cli.top_n)?;
+
+    if let Some(json_path) = &cli.json {
+        let json_blob = serde_json::to_string_pretty(&report)?;
+        fs::write(json_path, format!("{json_blob}\n"))
+            .with_context(|| format!("failed to write JSON report to {}", json_path.display()))?;
+    }
+
+    println!(
+        "[joy-parity] wrote {} (React exports: {}, Rust coverage: Joy {:.1}% / Headless {:.1}%)",
+        cli.report.display(),
+        report.total_components,
+        report.joy_coverage * 100.0,
+        report.headless_coverage * 100.0,
+    );
+
+    Ok(())
+}
+
+/// Orchestrates the scanning flow: enumerate React exports, normalize names,
+/// and compare them against Rust module inventories.
+fn build_report(cli: &Cli) -> Result<CoverageReport> {
+    let js_components = scan_joy_components(&cli.joy_src)?;
+    let js_component_list: Vec<ComponentEntry> = js_components.values().cloned().collect();
+    let js_keys: BTreeSet<String> = js_components.keys().cloned().collect();
+
+    let joy_modules = discover_rust_modules(&cli.rust_joy)?;
+    let headless_modules = discover_rust_modules(&cli.rust_headless)?;
+
+    let mut supported_in_joy = 0usize;
+    let mut supported_in_headless = 0usize;
+    let mut missing_from_joy = Vec::new();
+    let mut missing_from_headless = Vec::new();
+
+    for entry in &js_component_list {
+        if joy_modules.contains(&entry.normalized) {
+            supported_in_joy += 1;
+        } else {
+            missing_from_joy.push(entry.clone());
+        }
+
+        if headless_modules.contains(&entry.normalized) {
+            supported_in_headless += 1;
+        } else {
+            missing_from_headless.push(entry.clone());
+        }
+    }
+
+    let extra_in_joy: Vec<String> = joy_modules.difference(&js_keys).cloned().collect();
+    let extra_in_headless: Vec<String> = headless_modules.difference(&js_keys).cloned().collect();
+
+    let total = js_component_list.len();
+    let joy_coverage = if total == 0 {
+        0.0
+    } else {
+        supported_in_joy as f32 / total as f32
+    };
+    let headless_coverage = if total == 0 {
+        0.0
+    } else {
+        supported_in_headless as f32 / total as f32
+    };
+
+    Ok(CoverageReport {
+        generated_at: Utc::now(),
+        total_components: total,
+        supported_in_joy,
+        supported_in_headless,
+        joy_coverage,
+        headless_coverage,
+        components: js_component_list,
+        missing_from_joy,
+        missing_from_headless,
+        extra_in_joy,
+        extra_in_headless,
+    })
+}
+
+/// Parse the Joy UI source tree and build a deduplicated component export inventory.
+fn scan_joy_components(joy_src: &Path) -> Result<BTreeMap<String, ComponentEntry>> {
+    let cm: Lrc<SourceMap> = Lrc::new(SourceMap::default());
+    let globals = Globals::new();
+
+    GLOBALS.set(&globals, || -> Result<BTreeMap<String, ComponentEntry>> {
+        let mut entries: BTreeMap<String, ComponentEntry> = BTreeMap::new();
+
+        for entry in WalkDir::new(joy_src).sort_by_file_name() {
+            let entry = entry?;
+            if !entry.file_type().is_file() {
+                continue;
+            }
+
+            let path = entry.path();
+            if !is_index_file(path) {
+                continue;
+            }
+
+            let module = parse_module(&cm, path)?;
+            for export in extract_component_exports(&module, path, joy_src) {
+                // Preserve the first occurrence. Duplicate exports can occur if packages expose
+                // both default and themed variants; we only need one canonical record for parity.
+                entries.entry(export.normalized.clone()).or_insert(export);
+            }
+        }
+
+        Ok(entries)
+    })
+}
+
+/// Determines whether a file path is an `index` module worth parsing for exports.
+fn is_index_file(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+
+    matches!(
+        file_name,
+        "index.ts" | "index.tsx" | "index.js" | "index.mjs" | "index.cjs"
+    )
+}
+
+/// Parse a module using SWC so we can reason about export statements structurally.
+fn parse_module(cm: &Lrc<SourceMap>, path: &Path) -> Result<Module> {
+    let fm = cm
+        .load_file(path)
+        .with_context(|| format!("failed to load {}", path.display()))?;
+
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase());
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+
+    let is_jsx = matches!(
+        extension.as_deref(),
+        Some("tsx") | Some("jsx") | Some("mjsx") | Some("cjsx")
+    );
+    let is_ts = matches!(
+        extension.as_deref(),
+        Some("ts") | Some("tsx") | Some("mts") | Some("cts")
+    );
+    let is_d_ts = file_name.ends_with(".d.ts") || file_name.ends_with(".d.tsx");
+
+    let syntax = if is_ts {
+        Syntax::Typescript(TsSyntax {
+            tsx: is_jsx,
+            dts: is_d_ts,
+            ..Default::default()
+        })
+    } else {
+        Syntax::Es(EsSyntax {
+            jsx: is_jsx,
+            ..Default::default()
+        })
+    };
+
+    let lexer = Lexer::new(syntax, Default::default(), StringInput::from(&*fm), None);
+    let mut parser = SwcParser::new_from(lexer);
+    let module = parser
+        .parse_module()
+        .map_err(|err| anyhow!("{:?}", err))
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    let errors: Vec<_> = parser.take_errors();
+    if !errors.is_empty() {
+        let joined = errors
+            .into_iter()
+            .map(|err| format!("{:?}", err))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(anyhow!("{}", joined))
+            .with_context(|| format!("syntax errors in {}", path.display()));
+    }
+
+    Ok(module)
+}
+
+/// Extract re-exported component entry points from a parsed module.
+fn extract_component_exports(
+    module: &Module,
+    module_path: &Path,
+    joy_root: &Path,
+) -> Vec<ComponentEntry> {
+    let mut components = Vec::new();
+
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
+            continue;
+        };
+
+        let Some(src) = &named.src else {
+            // Skip exports that simply re-surface identifiers from the same file.
+            continue;
+        };
+
+        let specifier_path = src.value.to_string();
+        if !specifier_path.starts_with('.') {
+            // Ignore third-party package re-exports; they are not Joy components.
+            continue;
+        }
+
+        for specifier in &named.specifiers {
+            if let Some(entry) =
+                build_component_entry(specifier, &specifier_path, module_path, joy_root)
+            {
+                components.push(entry);
+            }
+        }
+    }
+
+    components
+}
+
+/// Convert an export specifier into a [`ComponentEntry`] when it represents a component default export.
+fn build_component_entry(
+    specifier: &ExportSpecifier,
+    specifier_path: &str,
+    module_path: &Path,
+    joy_root: &Path,
+) -> Option<ComponentEntry> {
+    let exported_name = match specifier {
+        ExportSpecifier::Named(named) => {
+            let orig = export_name_to_string(&named.orig)?;
+            if orig != "default" {
+                // Only treat default exports as components; named exports generally expose hooks or helpers.
+                return None;
+            }
+            named
+                .exported
+                .as_ref()
+                .and_then(export_name_to_string)
+                .unwrap_or_else(|| derive_name_from_specifier(specifier_path))
+        }
+        ExportSpecifier::Default(default_spec) => ident_to_string(&default_spec.exported),
+        ExportSpecifier::Namespace(_) => return None,
+    };
+
+    if !exported_name
+        .chars()
+        .next()
+        .map(|c| c.is_uppercase())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let normalized = normalize_component_name(&exported_name);
+    let source = joy_root
+        .join(specifier_path.trim_start_matches("./"))
+        .display()
+        .to_string()
+        .replace('\\', "/");
+
+    Some(ComponentEntry {
+        name: exported_name,
+        normalized,
+        source: source.replace('\r', ""),
+        declared_in: module_path.display().to_string(),
+    })
+}
+
+/// Convert a [`ModuleExportName`] into a human-readable string.
+fn export_name_to_string(name: &ModuleExportName) -> Option<String> {
+    match name {
+        ModuleExportName::Ident(ident) => Some(ident.sym.to_string()),
+        ModuleExportName::Str(str_lit) => Some(str_lit.value.to_string()),
+    }
+}
+
+fn ident_to_string(ident: &Ident) -> String {
+    ident.sym.to_string()
+}
+
+/// Derive a PascalCase component name from a relative module specifier.
+fn derive_name_from_specifier(specifier: &str) -> String {
+    let without_dots = specifier.trim_start_matches("./");
+    let candidate = without_dots.rsplit('/').next().unwrap_or(without_dots);
+
+    let mut chars = candidate.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => candidate.to_string(),
+    }
+}
+
+/// Normalize component identifiers so `JoyAccordion` and `Accordion` resolve to the same module slot.
+fn normalize_component_name(name: &str) -> String {
+    let mut snake = name.to_snake_case();
+    // Strip well-known prefixes that appear in alias exports. Apply repeatedly in case aliases combine them.
+    let prefixes = ["joy_", "mui_", "mui_joy_", "unstable_", "experimental_"];
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for prefix in prefixes {
+            if let Some(stripped) = snake.strip_prefix(prefix) {
+                snake = stripped.to_string();
+                changed = true;
+                break;
+            }
+        }
+    }
+    snake
+}
+
+/// Scan a Rust crate directory for module files that map to components.
+fn discover_rust_modules(root: &Path) -> Result<BTreeSet<String>> {
+    let mut modules = BTreeSet::new();
+
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            continue;
+        }
+
+        let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+            continue;
+        };
+        if ext != "rs" {
+            continue;
+        }
+
+        let file_stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(stem)
+                if stem != "lib"
+                    && stem != "mod"
+                    && stem != "macros"
+                    && stem != "style_helpers" =>
+            {
+                stem.to_string()
+            }
+            _ => continue,
+        };
+
+        modules.insert(file_stem);
+    }
+
+    Ok(modules)
+}
+
+/// Render the combined markdown and JSON artifact to disk.
+fn write_markdown_report(report: &CoverageReport, path: &Path, top_n: usize) -> Result<()> {
+    let json_blob = serde_json::to_string_pretty(report)?;
+    let mut markdown = String::new();
+
+    markdown.push_str("# Joy Component Parity\n\n");
+    markdown.push_str(&format!(
+        "_Last updated {} via `cargo xtask joy-inventory`._\n\n",
+        report.generated_at.to_rfc3339()
+    ));
+
+    markdown.push_str("## Coverage snapshot\n\n");
+    markdown.push_str(&format!(
+        "- React exports analyzed: {}\\n",
+        report.total_components
+    ));
+    markdown.push_str(&format!(
+        "- `mui-joy` coverage: {} ({:.1}%)\\n",
+        report.supported_in_joy,
+        report.joy_coverage * 100.0
+    ));
+    markdown.push_str(&format!(
+        "- `mui-headless` coverage: {} ({:.1}%)\\n\n",
+        report.supported_in_headless,
+        report.headless_coverage * 100.0
+    ));
+
+    markdown.push_str("## Highest priority gaps\n\n");
+    markdown.push_str("| Rank | Component | Source |\\n");
+    markdown.push_str("| --- | --- | --- |\\n");
+
+    for (idx, component) in report.missing_from_joy.iter().take(top_n).enumerate() {
+        markdown.push_str(&format!(
+            "| {} | {} | `{}` |\\n",
+            idx + 1,
+            component.name,
+            component.source
+        ));
+    }
+
+    if report.missing_from_joy.is_empty() {
+        markdown.push_str("| – | All caught up! | – |\\n");
+    }
+
+    markdown.push_str("\n## Machine-readable snapshot\n\n");
+    markdown.push_str("```json\n");
+    markdown.push_str(&json_blob);
+    markdown.push_str("\n```\n");
+
+    fs::create_dir_all(
+        path.parent()
+            .ok_or_else(|| anyhow::anyhow!("report path has no parent"))?,
+    )?;
+    fs::write(path, markdown)
+        .with_context(|| format!("failed to write report to {}", path.display()))?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a `joy-inventory` xtask subcommand that delegates to a dedicated Joy parity scanner binary
- implement the `joy-parity` tool to compare Joy UI exports with Rust modules and publish a markdown+JSON parity dashboard
- wire the new report into CI automation and contributor documentation to fail on drift

## Testing
- cargo xtask joy-inventory
- cargo test -p joy-parity

------
https://chatgpt.com/codex/tasks/task_e_68d167d1366c832e8513a6f984ba1106