### PR TITLE
Add Joy headless scaffolding and parity mapping

### DIFF
--- a/crates/mui-headless/src/accordion.rs
+++ b/crates/mui-headless/src/accordion.rs
@@ -1,0 +1,305 @@
+//! Accordion state machine coordinating disclosure panels for Joy UI.
+//!
+//! The implementation mirrors the controlled/uncontrolled approach used across
+//! Material and Joy primitives.  Each accordion item tracks whether it is
+//! expanded and disabled while the group enforces either single-expansion or
+//! multi-expansion policies.  The API is intentionally declarative so adapters
+//! only forward interaction intents (toggle, expand, collapse) and receive a
+//! structured [`AccordionItemChange`] describing what changed.  Enterprise
+//! automation suites can inspect that change log to assert that ARIA hooks and
+//! DOM mutations fire in the expected order.
+
+use crate::aria;
+
+/// Aggregated change notification for an accordion item.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AccordionItemChange {
+    /// When set the item changed its expanded state.  Adapters typically pair
+    /// this with DOM mutations (showing or hiding the panel) and accessibility
+    /// attributes.
+    pub expanded: Option<bool>,
+}
+
+impl AccordionItemChange {
+    fn expanded(expanded: bool) -> Self {
+        Self {
+            expanded: Some(expanded),
+        }
+    }
+
+    fn merge(self, other: AccordionItemChange) -> Self {
+        if other.expanded.is_some() {
+            other
+        } else {
+            self
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AccordionItemState {
+    expanded: bool,
+    disabled: bool,
+}
+
+impl AccordionItemState {
+    fn new(expanded: bool) -> Self {
+        Self {
+            expanded,
+            disabled: false,
+        }
+    }
+}
+
+/// High level accordion orchestrator.
+#[derive(Debug, Clone)]
+pub struct AccordionGroupState {
+    allow_multiple: bool,
+    items: Vec<AccordionItemState>,
+}
+
+impl AccordionGroupState {
+    /// Build a new accordion group.
+    ///
+    /// * `item_count` — number of accordion items currently rendered.
+    /// * `allow_multiple` — whether multiple items may be expanded at once.
+    /// * `default_expanded` — optional indices that should start expanded.
+    pub fn new(item_count: usize, allow_multiple: bool, default_expanded: &[usize]) -> Self {
+        let mut items = Vec::with_capacity(item_count);
+        for index in 0..item_count {
+            let expanded = default_expanded.contains(&index);
+            items.push(AccordionItemState::new(expanded));
+        }
+        let mut state = Self {
+            allow_multiple,
+            items,
+        };
+        if !allow_multiple {
+            state.enforce_single_expansion();
+        }
+        state
+    }
+
+    /// Returns how many items the accordion currently manages.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns whether the provided index is expanded.
+    #[inline]
+    pub fn is_expanded(&self, index: usize) -> bool {
+        self.items
+            .get(index)
+            .map(|item| item.expanded)
+            .unwrap_or(false)
+    }
+
+    /// Returns whether the provided index is disabled.
+    #[inline]
+    pub fn is_disabled(&self, index: usize) -> bool {
+        self.items
+            .get(index)
+            .map(|item| item.disabled)
+            .unwrap_or(true)
+    }
+
+    /// Update the disabled flag for a specific item.
+    pub fn set_disabled(&mut self, index: usize, disabled: bool) {
+        if let Some(item) = self.items.get_mut(index) {
+            item.disabled = disabled;
+        }
+    }
+
+    /// Expand a specific accordion item.
+    pub fn expand<F: FnOnce(usize, bool)>(
+        &mut self,
+        index: usize,
+        notify: F,
+    ) -> AccordionItemChange {
+        if !self.toggleable(index) {
+            return AccordionItemChange::default();
+        }
+        let change = self.set_expanded(index, true);
+        notify(index, true);
+        change
+    }
+
+    /// Collapse a specific accordion item.
+    pub fn collapse<F: FnOnce(usize, bool)>(
+        &mut self,
+        index: usize,
+        notify: F,
+    ) -> AccordionItemChange {
+        if !self.toggleable(index) {
+            return AccordionItemChange::default();
+        }
+        let change = self.set_expanded(index, false);
+        notify(index, false);
+        change
+    }
+
+    /// Toggle a specific accordion item.
+    pub fn toggle<F: FnOnce(usize, bool)>(
+        &mut self,
+        index: usize,
+        notify: F,
+    ) -> AccordionItemChange {
+        if !self.toggleable(index) {
+            return AccordionItemChange::default();
+        }
+        let next = !self.is_expanded(index);
+        let change = self.set_expanded(index, next);
+        notify(index, next);
+        change
+    }
+
+    /// Synchronise expanded state when controlled externally.
+    pub fn sync_expanded(&mut self, index: usize, expanded: bool) {
+        if let Some(item) = self.items.get_mut(index) {
+            item.expanded = expanded;
+            if expanded && !self.allow_multiple {
+                self.collapse_others(index);
+            }
+        }
+    }
+
+    /// Ensure the internal vector has the desired size.
+    pub fn set_item_count(&mut self, count: usize) {
+        if count == self.items.len() {
+            return;
+        }
+        self.items
+            .resize_with(count, || AccordionItemState::new(false));
+        if !self.allow_multiple {
+            self.enforce_single_expansion();
+        }
+    }
+
+    /// Build the ARIA/data attributes for the summary button.
+    pub fn summary_accessibility_attributes(
+        &self,
+        index: usize,
+        panel_id: &str,
+    ) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(4);
+        attrs.push(("role", aria::role_button().into()));
+        let (expanded_key, expanded_value) = aria::aria_expanded(self.is_expanded(index));
+        attrs.push((expanded_key, expanded_value.to_string()));
+        attrs.push(("aria-controls", panel_id.to_string()));
+        aria::extend_disabled_attributes(&mut attrs, self.is_disabled(index));
+        attrs
+    }
+
+    /// Build the ARIA/data attributes for the details panel.
+    pub fn details_accessibility_attributes(
+        &self,
+        index: usize,
+        summary_id: &str,
+    ) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(4);
+        attrs.push(("role", "region".into()));
+        attrs.push(("aria-labelledby", summary_id.to_string()));
+        if !self.is_expanded(index) {
+            attrs.push(("hidden", "true".into()));
+        }
+        attrs
+    }
+
+    fn toggleable(&self, index: usize) -> bool {
+        if let Some(item) = self.items.get(index) {
+            !item.disabled
+        } else {
+            false
+        }
+    }
+
+    fn set_expanded(&mut self, index: usize, expanded: bool) -> AccordionItemChange {
+        if let Some(item) = self.items.get_mut(index) {
+            if item.expanded == expanded {
+                return AccordionItemChange::default();
+            }
+            item.expanded = expanded;
+            let mut change = AccordionItemChange::expanded(expanded);
+            if expanded && !self.allow_multiple {
+                change = change.merge(self.collapse_others(index));
+            }
+            change
+        } else {
+            AccordionItemChange::default()
+        }
+    }
+
+    fn collapse_others(&mut self, keep: usize) -> AccordionItemChange {
+        let mut change = AccordionItemChange::default();
+        for (index, item) in self.items.iter_mut().enumerate() {
+            if index == keep {
+                continue;
+            }
+            if item.expanded {
+                item.expanded = false;
+                change = change.merge(AccordionItemChange::expanded(false));
+            }
+        }
+        change
+    }
+
+    fn enforce_single_expansion(&mut self) {
+        let mut first_expanded = None;
+        for (index, item) in self.items.iter_mut().enumerate() {
+            if item.expanded {
+                if first_expanded.is_none() {
+                    first_expanded = Some(index);
+                } else {
+                    item.expanded = false;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_expansion_collapse_previous() {
+        let mut group = AccordionGroupState::new(3, false, &[0]);
+        assert!(group.is_expanded(0));
+        assert!(!group.is_expanded(1));
+        let change = group.toggle(1, |_, _| {});
+        assert!(change.expanded.is_some());
+        assert!(!group.is_expanded(0));
+        assert!(group.is_expanded(1));
+    }
+
+    #[test]
+    fn multiple_expansion_allows_parallel_panels() {
+        let mut group = AccordionGroupState::new(3, true, &[]);
+        group.expand(0, |_, _| {});
+        group.expand(1, |_, _| {});
+        assert!(group.is_expanded(0));
+        assert!(group.is_expanded(1));
+    }
+
+    #[test]
+    fn disabled_items_ignore_toggle_requests() {
+        let mut group = AccordionGroupState::new(2, false, &[]);
+        group.set_disabled(1, true);
+        let change = group.toggle(1, |_, _| panic!("should not toggle"));
+        assert_eq!(change, AccordionItemChange::default());
+        assert!(!group.is_expanded(1));
+    }
+
+    #[test]
+    fn summary_attributes_reflect_state() {
+        let group = AccordionGroupState::new(1, false, &[0]);
+        let attrs = group.summary_accessibility_attributes(0, "panel");
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| *k == "aria-controls" && v == "panel"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| *k == "aria-expanded" && v == "true"));
+    }
+}

--- a/crates/mui-headless/src/autocomplete.rs
+++ b/crates/mui-headless/src/autocomplete.rs
@@ -1,0 +1,347 @@
+//! Autocomplete state machine that combines Joy’s text field ergonomics with the
+//! shared listbox/select patterns from Material.
+//!
+//! The struct embeds [`SelectState`](crate::select::SelectState) so typeahead,
+//! highlight management, and controlled/uncontrolled behavior stay perfectly
+//! aligned with the select widget.  Adapters only need to pipe user intents into
+//! the exposed methods and apply the returned [`AutocompleteChange`] to their
+//! DOM.  Rich documentation is sprinkled throughout so large applications can
+//! audit and extend the behavior without reverse engineering hidden invariants.
+
+use crate::aria;
+use crate::select::SelectState;
+use crate::selection::ControlStrategy;
+
+/// Re-export [`ControlStrategy`] so consumers configuring the autocomplete do
+/// not need to reach into the private `selection` module.
+pub use crate::selection::ControlStrategy as AutocompleteControlStrategy;
+
+/// Declarative configuration consumed by [`AutocompleteState`].
+#[derive(Debug, Clone)]
+pub struct AutocompleteConfig {
+    /// Number of options currently rendered inside the listbox.
+    pub option_count: usize,
+    /// Optional index of the option that should start selected/highlighted.
+    pub initial_selected: Option<usize>,
+    /// Whether the popover starts open when uncontrolled.
+    pub default_open: bool,
+    /// Describes if the open state is controlled by a parent.
+    pub open_control: ControlStrategy,
+    /// Describes if the selected option is controlled by a parent.
+    pub selection_control: ControlStrategy,
+    /// When `true` the listbox opens as soon as the input receives focus.
+    pub open_on_focus: bool,
+    /// When `true` the input value is decoupled from the selected option.
+    pub free_solo: bool,
+    /// When `true` the entire widget is disabled.
+    pub disabled: bool,
+    /// Initial text rendered inside the input element.
+    pub initial_input: String,
+}
+
+impl AutocompleteConfig {
+    /// Enterprise friendly defaults mirroring Joy’s TypeScript implementation.
+    pub fn enterprise_defaults(option_count: usize) -> Self {
+        Self {
+            option_count,
+            initial_selected: None,
+            default_open: false,
+            open_control: ControlStrategy::Uncontrolled,
+            selection_control: ControlStrategy::Uncontrolled,
+            open_on_focus: true,
+            free_solo: false,
+            disabled: false,
+            initial_input: String::new(),
+        }
+    }
+}
+
+impl Default for AutocompleteConfig {
+    fn default() -> Self {
+        Self::enterprise_defaults(0)
+    }
+}
+
+/// Aggregate change notification emitted from [`AutocompleteState`] transitions.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AutocompleteChange {
+    /// Indicates whether the popover requested an open/close transition.
+    pub opened: Option<bool>,
+    /// Indicates that the input value changed as a result of an interaction.
+    pub input_value: Option<String>,
+    /// Indicates that a specific option index was selected.
+    pub selection: Option<usize>,
+}
+
+/// Headless state machine coordinating the Joy autocomplete widget.
+#[derive(Debug, Clone)]
+pub struct AutocompleteState {
+    select: SelectState,
+    config: AutocompleteConfig,
+    input_value: String,
+    focused: bool,
+}
+
+impl AutocompleteState {
+    /// Construct a new autocomplete state machine.
+    pub fn new(config: AutocompleteConfig) -> Self {
+        let select = SelectState::new(
+            config.option_count,
+            config.initial_selected,
+            config.default_open,
+            config.open_control,
+            config.selection_control,
+        );
+        Self {
+            input_value: config.initial_input.clone(),
+            select,
+            config,
+            focused: false,
+        }
+    }
+
+    /// Returns a shared reference to the internal [`SelectState`].
+    #[inline]
+    pub fn select_state(&self) -> &SelectState {
+        &self.select
+    }
+
+    /// Returns a mutable reference to the internal [`SelectState`].
+    #[inline]
+    pub fn select_state_mut(&mut self) -> &mut SelectState {
+        &mut self.select
+    }
+
+    /// Returns whether the listbox is currently open.
+    #[inline]
+    pub fn is_open(&self) -> bool {
+        self.select.is_open()
+    }
+
+    /// Returns the current input value.
+    #[inline]
+    pub fn input_value(&self) -> &str {
+        &self.input_value
+    }
+
+    /// Returns whether the widget is currently focused.
+    #[inline]
+    pub fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    /// Returns whether the widget is disabled.
+    #[inline]
+    pub fn is_disabled(&self) -> bool {
+        self.config.disabled
+    }
+
+    /// Programmatically focus the autocomplete.
+    pub fn focus(&mut self) -> AutocompleteChange {
+        self.focused = true;
+        if self.config.disabled || !self.config.open_on_focus {
+            return AutocompleteChange::default();
+        }
+        self.open_internal()
+    }
+
+    /// Programmatically blur the autocomplete.
+    pub fn blur(&mut self) -> AutocompleteChange {
+        self.focused = false;
+        if self.config.disabled {
+            return AutocompleteChange::default();
+        }
+        self.close_internal()
+    }
+
+    /// Request that the popover opens.
+    pub fn open(&mut self) -> AutocompleteChange {
+        if self.config.disabled {
+            return AutocompleteChange::default();
+        }
+        self.open_internal()
+    }
+
+    /// Request that the popover closes.
+    pub fn close(&mut self) -> AutocompleteChange {
+        if self.config.disabled {
+            return AutocompleteChange::default();
+        }
+        self.close_internal()
+    }
+
+    /// Toggle the popover visibility.
+    pub fn toggle(&mut self) -> AutocompleteChange {
+        if self.config.disabled {
+            return AutocompleteChange::default();
+        }
+        if self.is_open() {
+            self.close_internal()
+        } else {
+            self.open_internal()
+        }
+    }
+
+    /// Synchronise the open flag when controlled externally.
+    pub fn sync_open(&mut self, open: bool) {
+        self.select.sync_open(open);
+    }
+
+    /// Synchronise the selected option when controlled externally.
+    pub fn sync_selected(&mut self, selected: Option<usize>) {
+        self.select.sync_selected(selected);
+    }
+
+    /// Update the number of rendered options.
+    pub fn set_option_count(&mut self, count: usize) {
+        self.select.set_option_count(count);
+    }
+
+    /// Toggle the disabled flag for a specific option.
+    pub fn set_option_disabled(&mut self, index: usize, disabled: bool) {
+        self.select.set_option_disabled(index, disabled);
+    }
+
+    /// Mutate the input value directly.
+    pub fn set_input_value<S: Into<String>>(&mut self, value: S) -> AutocompleteChange {
+        if self.config.disabled {
+            return AutocompleteChange::default();
+        }
+        let value = value.into();
+        self.input_value = value.clone();
+        AutocompleteChange {
+            input_value: Some(value),
+            ..AutocompleteChange::default()
+        }
+    }
+
+    /// Select the provided option index.
+    ///
+    /// The closure receives the resolved index and can optionally return the
+    /// textual label that should be pushed back into the input.  Returning
+    /// `None` keeps the current input untouched which is useful when the widget
+    /// is operating in `free_solo` mode.
+    pub fn select_index<F>(&mut self, index: usize, mut on_select: F) -> AutocompleteChange
+    where
+        F: FnMut(usize) -> Option<String>,
+    {
+        if self.config.disabled {
+            return AutocompleteChange::default();
+        }
+        let mut change = AutocompleteChange::default();
+        self.select.select(index, |idx| {
+            change.selection = Some(idx);
+            if !self.config.free_solo {
+                if let Some(label) = on_select(idx) {
+                    if !self.config.selection_control.is_controlled() {
+                        self.input_value = label.clone();
+                    }
+                    change.input_value = Some(label);
+                }
+            } else {
+                // Still invoke the callback so analytics/telemetry hooks fire.
+                let _ = on_select(idx);
+            }
+        });
+        change
+    }
+
+    /// Convenience accessor for the currently highlighted option.
+    #[inline]
+    pub fn highlighted(&self) -> Option<usize> {
+        self.select.highlighted()
+    }
+
+    /// Override the highlighted option index.  Typically driven by pointer
+    /// movement.
+    #[inline]
+    pub fn set_highlighted(&mut self, index: Option<usize>) {
+        self.select.set_highlighted(index);
+    }
+
+    /// Build the ARIA/data attributes required on the `<input>` element.
+    pub fn input_accessibility_attributes(
+        &self,
+        listbox_id: &str,
+        active_id: Option<&str>,
+    ) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(6);
+        attrs.push(("role", "combobox".into()));
+        let (expanded_key, expanded_value) = aria::aria_expanded(self.is_open());
+        attrs.push((expanded_key, expanded_value.to_string()));
+        attrs.push(("aria-controls", listbox_id.to_string()));
+        let (popup_key, popup_value) = aria::aria_haspopup(aria::role_listbox());
+        attrs.push((popup_key, popup_value.to_string()));
+        attrs.push(("aria-autocomplete", "list".into()));
+        if let Some(id) = active_id {
+            attrs.push(("aria-activedescendant", id.to_string()));
+        }
+        aria::extend_disabled_attributes(&mut attrs, self.config.disabled);
+        attrs
+    }
+
+    /// Build the ARIA attributes required on the listbox container.
+    pub fn listbox_accessibility_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(2);
+        attrs.push(("role", aria::role_listbox().into()));
+        if !self.is_open() {
+            attrs.push(("hidden", "true".into()));
+        }
+        attrs
+    }
+
+    fn open_internal(&mut self) -> AutocompleteChange {
+        let mut change = AutocompleteChange::default();
+        self.select.open(|flag| change.opened = Some(flag));
+        change
+    }
+
+    fn close_internal(&mut self) -> AutocompleteChange {
+        let mut change = AutocompleteChange::default();
+        self.select.close(|flag| change.opened = Some(flag));
+        change
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn focus_opens_when_configured() {
+        let mut state = AutocompleteState::new(AutocompleteConfig {
+            option_count: 3,
+            open_on_focus: true,
+            ..AutocompleteConfig::enterprise_defaults(3)
+        });
+        let change = state.focus();
+        assert_eq!(change.opened, Some(true));
+    }
+
+    #[test]
+    fn free_solo_leaves_input_intact() {
+        let mut state = AutocompleteState::new(AutocompleteConfig {
+            option_count: 2,
+            free_solo: true,
+            initial_input: "hello".into(),
+            ..AutocompleteConfig::enterprise_defaults(2)
+        });
+        let change = state.select_index(0, |_| Some("option".into()));
+        assert_eq!(change.selection, Some(0));
+        assert!(change.input_value.is_none());
+        assert_eq!(state.input_value(), "hello");
+    }
+
+    #[test]
+    fn select_updates_input_when_not_free_solo() {
+        let mut state = AutocompleteState::new(AutocompleteConfig {
+            option_count: 2,
+            free_solo: false,
+            ..AutocompleteConfig::enterprise_defaults(2)
+        });
+        let change = state.select_index(1, |_| Some("Beta".into()));
+        assert_eq!(change.selection, Some(1));
+        assert_eq!(change.input_value, Some("Beta".into()));
+        assert_eq!(state.input_value(), "Beta");
+    }
+}

--- a/crates/mui-headless/src/lib.rs
+++ b/crates/mui-headless/src/lib.rs
@@ -9,7 +9,10 @@
 //! includes [`tab`] and [`tab_panel`] attribute builders.  Layout driven
 //! components such as [`drawer`] also reuse the centralized accessibility
 //! primitives.  The [`interaction`] primitives expose keyboard orchestration
-//! shared across each state machine.
+//! shared across each state machine.  New Joy focused primitives including
+//! [`accordion`], [`autocomplete`], [`slider`], [`snackbar`], [`stepper`] and
+//! [`toggle_button_group`] build on the same deterministic rules so Material
+//! and Joy stay aligned.
 //!
 //! The Material layer (`mui-material`) documents how these headless states are
 //! rendered with shared theming, automation identifiers, and SSR safe markup.
@@ -18,7 +21,9 @@
 //! `examples/feedback-*` blueprints that exercise them across Yew, Leptos,
 //! Dioxus, and Sycamore adapters.
 
+pub mod accordion;
 pub mod aria;
+pub mod autocomplete;
 pub mod button;
 pub mod checkbox;
 pub mod chip;
@@ -30,12 +35,16 @@ pub mod menu;
 pub mod popover;
 pub mod radio;
 pub mod select;
+pub mod slider;
+pub mod snackbar;
+pub mod stepper;
 pub mod switch;
 pub mod tab;
 pub mod tab_panel;
 pub mod tabs;
 pub mod text_field;
 pub mod timing;
+pub mod toggle_button_group;
 pub mod tooltip;
 
 mod selection;

--- a/crates/mui-headless/src/slider.rs
+++ b/crates/mui-headless/src/slider.rs
@@ -1,0 +1,262 @@
+//! Headless slider state machine shared by Joy UI components.
+//!
+//! The implementation prioritises predictability for enterprise dashboards.  The
+//! state machine clamps values, snaps to configured steps, and exposes helpers
+//! for keyboard/page interaction so automated tests can assert exact transitions
+//! without simulating DOM measurements.  Rendering adapters only need to apply
+//! the returned [`SliderChange`] data and copy the documented ARIA attributes.
+
+use crate::aria;
+
+/// Orientation of the slider track.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SliderOrientation {
+    /// Horizontal sliders grow left-to-right.
+    Horizontal,
+    /// Vertical sliders grow bottom-to-top.
+    Vertical,
+}
+
+impl SliderOrientation {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Horizontal => "horizontal",
+            Self::Vertical => "vertical",
+        }
+    }
+}
+
+/// Declarative configuration consumed by [`SliderState`].
+#[derive(Debug, Clone)]
+pub struct SliderConfig {
+    /// Minimum logical value.
+    pub min: f64,
+    /// Maximum logical value.
+    pub max: f64,
+    /// Increment applied for keyboard nudges.
+    pub step: f64,
+    /// Increment applied for PageUp/PageDown style movements.
+    pub page: f64,
+    /// Initial value used when constructing the slider.
+    pub default_value: f64,
+    /// Whether the slider starts disabled.
+    pub disabled: bool,
+    /// Orientation of the slider track.
+    pub orientation: SliderOrientation,
+}
+
+impl SliderConfig {
+    /// Enterprise defaults matching Joy’s UX guidelines.
+    pub fn enterprise_defaults(min: f64, max: f64) -> Self {
+        let range = (max - min).abs().max(1.0);
+        Self {
+            min,
+            max,
+            step: range / 100.0,
+            page: range / 10.0,
+            default_value: min,
+            disabled: false,
+            orientation: SliderOrientation::Horizontal,
+        }
+    }
+}
+
+impl Default for SliderConfig {
+    fn default() -> Self {
+        Self::enterprise_defaults(0.0, 100.0)
+    }
+}
+
+/// Change metadata returned by [`SliderState`] APIs.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SliderChange {
+    /// The new value if it changed.
+    pub value: Option<f64>,
+}
+
+impl SliderChange {
+    fn value(value: f64) -> Self {
+        Self { value: Some(value) }
+    }
+}
+
+/// Slider state machine.
+#[derive(Debug, Clone)]
+pub struct SliderState {
+    config: SliderConfig,
+    value: f64,
+    dragging: bool,
+}
+
+impl SliderState {
+    /// Construct a new slider.
+    pub fn new(config: SliderConfig) -> Self {
+        let mut state = Self {
+            value: config.default_value,
+            config,
+            dragging: false,
+        };
+        state.value = state.clamp_and_snap(state.value);
+        state
+    }
+
+    /// Returns the current logical value.
+    #[inline]
+    pub fn value(&self) -> f64 {
+        self.value
+    }
+
+    /// Returns the current value as a percentage between 0 and 100.
+    pub fn percent(&self) -> f64 {
+        let denom = (self.config.max - self.config.min).abs();
+        if denom == 0.0 {
+            return 0.0;
+        }
+        ((self.value - self.config.min) / denom).clamp(0.0, 1.0) * 100.0
+    }
+
+    /// Returns whether the slider is currently disabled.
+    #[inline]
+    pub fn is_disabled(&self) -> bool {
+        self.config.disabled
+    }
+
+    /// Update the disabled flag.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.config.disabled = disabled;
+    }
+
+    /// Returns whether a pointer drag is in progress.
+    #[inline]
+    pub fn is_dragging(&self) -> bool {
+        self.dragging
+    }
+
+    /// Mark the beginning of a drag gesture.
+    pub fn begin_drag(&mut self) {
+        if !self.config.disabled {
+            self.dragging = true;
+        }
+    }
+
+    /// Mark the end of a drag gesture.
+    pub fn end_drag(&mut self) {
+        self.dragging = false;
+    }
+
+    /// Directly set the slider value.
+    pub fn set_value(&mut self, value: f64) -> SliderChange {
+        if self.config.disabled {
+            return SliderChange::default();
+        }
+        let snapped = self.clamp_and_snap(value);
+        if (snapped - self.value).abs() < f64::EPSILON {
+            return SliderChange::default();
+        }
+        self.value = snapped;
+        SliderChange::value(self.value)
+    }
+
+    /// Increment the slider using the configured step.
+    pub fn increment(&mut self) -> SliderChange {
+        let step = self.config.step.abs().max(f64::EPSILON);
+        self.set_value(self.value + step)
+    }
+
+    /// Decrement the slider using the configured step.
+    pub fn decrement(&mut self) -> SliderChange {
+        let step = self.config.step.abs().max(f64::EPSILON);
+        self.set_value(self.value - step)
+    }
+
+    /// Increment the slider using the configured page size.
+    pub fn page_increment(&mut self) -> SliderChange {
+        let page = self.config.page.abs().max(self.config.step.abs());
+        self.set_value(self.value + page)
+    }
+
+    /// Decrement the slider using the configured page size.
+    pub fn page_decrement(&mut self) -> SliderChange {
+        let page = self.config.page.abs().max(self.config.step.abs());
+        self.set_value(self.value - page)
+    }
+
+    /// Build the ARIA/data attributes for the thumb element.
+    pub fn thumb_accessibility_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(6);
+        attrs.push(("role", "slider".into()));
+        attrs.push(("aria-valuemin", self.config.min.to_string()));
+        attrs.push(("aria-valuemax", self.config.max.to_string()));
+        attrs.push(("aria-valuenow", self.value.to_string()));
+        attrs.push(("aria-orientation", self.config.orientation.as_str().into()));
+        aria::extend_disabled_attributes(&mut attrs, self.config.disabled);
+        attrs
+    }
+
+    fn clamp_and_snap(&self, value: f64) -> f64 {
+        let mut clamped = value.clamp(self.config.min, self.config.max);
+        let step = self.config.step.abs();
+        if step > 0.0 {
+            let offset = clamped - self.config.min;
+            let steps = (offset / step).round();
+            clamped = self.config.min + steps * step;
+        }
+        clamped = clamped.clamp(self.config.min, self.config.max);
+        if clamped.is_finite() {
+            clamped
+        } else {
+            self.config.min
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapping_aligns_to_step() {
+        let mut slider = SliderState::new(SliderConfig {
+            min: 0.0,
+            max: 10.0,
+            step: 2.0,
+            page: 4.0,
+            default_value: 0.0,
+            disabled: false,
+            orientation: SliderOrientation::Horizontal,
+        });
+        let change = slider.set_value(3.3);
+        assert_eq!(change.value, Some(4.0));
+        assert_eq!(slider.value(), 4.0);
+    }
+
+    #[test]
+    fn percent_returns_expected_range() {
+        let slider = SliderState::new(SliderConfig {
+            min: 0.0,
+            max: 5.0,
+            step: 0.5,
+            page: 2.0,
+            default_value: 2.5,
+            disabled: false,
+            orientation: SliderOrientation::Horizontal,
+        });
+        assert!((slider.percent() - 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn disabled_slider_ignores_updates() {
+        let mut slider = SliderState::new(SliderConfig {
+            min: 0.0,
+            max: 10.0,
+            step: 1.0,
+            page: 3.0,
+            default_value: 5.0,
+            disabled: true,
+            orientation: SliderOrientation::Horizontal,
+        });
+        let change = slider.increment();
+        assert_eq!(change.value, None);
+        assert_eq!(slider.value(), 5.0);
+    }
+}

--- a/crates/mui-headless/src/snackbar.rs
+++ b/crates/mui-headless/src/snackbar.rs
@@ -1,0 +1,268 @@
+//! Queue based snackbar state machine shared between Material and Joy layers.
+//!
+//! The goal is to provide deterministic automation hooks for transient feedback
+//! components.  The state machine exposes precise control over queuing,
+//! auto-hide timing, pausing, and manual dismissal so large applications can run
+//! integration tests without brittle timeouts sprinkled throughout UI code.
+
+use crate::timing::{Clock, SystemClock, Timer};
+use std::collections::VecDeque;
+use std::time::Duration;
+
+/// Configuration describing how the snackbar behaves.
+#[derive(Debug, Clone)]
+pub struct SnackbarConfig {
+    /// Duration each message should remain visible.
+    pub auto_hide: Duration,
+    /// Maximum number of queued messages (excluding the currently visible one).
+    pub max_queue: usize,
+}
+
+impl SnackbarConfig {
+    /// Enterprise defaults mirroring the Material/Joy design language.
+    pub fn enterprise_defaults() -> Self {
+        Self {
+            auto_hide: Duration::from_millis(4000),
+            max_queue: 3,
+        }
+    }
+}
+
+impl Default for SnackbarConfig {
+    fn default() -> Self {
+        Self::enterprise_defaults()
+    }
+}
+
+/// Message entry managed by the snackbar queue.
+#[derive(Debug, Clone)]
+pub struct SnackbarMessage<T> {
+    /// Monotonically increasing identifier useful for automation.
+    pub id: u64,
+    /// Custom payload forwarded to adapters.
+    pub payload: T,
+}
+
+/// Change notification emitted from snackbar transitions.
+#[derive(Debug, Clone)]
+pub struct SnackbarChange<T> {
+    /// Message that became visible after the transition (if any).
+    pub shown: Option<SnackbarMessage<T>>,
+    /// Message that was dismissed as part of the transition (if any).
+    pub dismissed: Option<SnackbarMessage<T>>,
+}
+
+impl<T: Clone> SnackbarChange<T> {
+    fn merge(mut self, other: SnackbarChange<T>) -> SnackbarChange<T> {
+        if other.shown.is_some() {
+            self.shown = other.shown;
+        }
+        if other.dismissed.is_some() {
+            self.dismissed = other.dismissed;
+        }
+        self
+    }
+}
+
+impl<T> Default for SnackbarChange<T> {
+    fn default() -> Self {
+        Self {
+            shown: None,
+            dismissed: None,
+        }
+    }
+}
+
+/// Headless snackbar state machine.
+#[derive(Debug, Clone)]
+pub struct SnackbarState<T, C: Clock = SystemClock> {
+    clock: C,
+    config: SnackbarConfig,
+    queue: VecDeque<SnackbarMessage<T>>,
+    current: Option<SnackbarMessage<T>>,
+    timer: Timer<C>,
+    next_id: u64,
+    paused_remaining: Option<Duration>,
+}
+
+impl<T: Clone> SnackbarState<T, SystemClock> {
+    /// Construct a snackbar bound to the system clock.
+    pub fn new(config: SnackbarConfig) -> Self {
+        Self::with_clock(SystemClock, config)
+    }
+}
+
+impl<T: Clone, C: Clock> SnackbarState<T, C> {
+    /// Construct a snackbar bound to an arbitrary clock (mock clocks for tests).
+    pub fn with_clock(clock: C, config: SnackbarConfig) -> Self {
+        Self {
+            clock,
+            config,
+            queue: VecDeque::new(),
+            current: None,
+            timer: Timer::new(),
+            next_id: 0,
+            paused_remaining: None,
+        }
+    }
+
+    /// Returns the currently visible message (if any).
+    #[inline]
+    pub fn current(&self) -> Option<&SnackbarMessage<T>> {
+        self.current.as_ref()
+    }
+
+    /// Returns how many messages are waiting in the queue.
+    #[inline]
+    pub fn queue_len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Returns whether the snackbar is idle.
+    #[inline]
+    pub fn is_idle(&self) -> bool {
+        self.current.is_none() && self.queue.is_empty()
+    }
+
+    /// Enqueue a new message.
+    pub fn enqueue(&mut self, payload: T) -> SnackbarChange<T> {
+        let message = SnackbarMessage {
+            id: self.next_id,
+            payload,
+        };
+        self.next_id = self.next_id.wrapping_add(1);
+        if self.current.is_some() {
+            if self.queue.len() >= self.config.max_queue {
+                self.queue.pop_front();
+            }
+            self.queue.push_back(message);
+            SnackbarChange::default()
+        } else {
+            self.show_message(message)
+        }
+    }
+
+    /// Manually dismiss the current message.
+    pub fn dismiss_current(&mut self) -> SnackbarChange<T> {
+        self.dismiss_internal()
+    }
+
+    /// Remove a specific queued message by identifier.
+    pub fn remove_queued(&mut self, id: u64) {
+        if let Some(position) = self.queue.iter().position(|msg| msg.id == id) {
+            self.queue.remove(position);
+        }
+    }
+
+    /// Pause the auto-hide timer preserving the remaining duration.
+    pub fn pause(&mut self) {
+        if self.current.is_none() || self.paused_remaining.is_some() {
+            return;
+        }
+        if let Some(remaining) = self.timer.remaining(&self.clock) {
+            self.paused_remaining = Some(remaining);
+            self.timer.cancel();
+        }
+    }
+
+    /// Resume the auto-hide timer if it was paused.
+    pub fn resume(&mut self) {
+        if let Some(remaining) = self.paused_remaining.take() {
+            if remaining > Duration::ZERO {
+                self.timer.schedule(&self.clock, remaining);
+            }
+        }
+    }
+
+    /// Advance the internal clock and process timeouts.
+    pub fn tick(&mut self) -> SnackbarChange<T> {
+        if self.timer.fire_if_due(&self.clock) {
+            self.dismiss_internal()
+        } else {
+            SnackbarChange::default()
+        }
+    }
+
+    fn show_message(&mut self, message: SnackbarMessage<T>) -> SnackbarChange<T> {
+        self.current = Some(message.clone());
+        self.paused_remaining = None;
+        if self.config.auto_hide > Duration::ZERO {
+            self.timer.schedule(&self.clock, self.config.auto_hide);
+        }
+        SnackbarChange {
+            shown: Some(message),
+            ..SnackbarChange::default()
+        }
+    }
+
+    fn dismiss_internal(&mut self) -> SnackbarChange<T> {
+        if let Some(current) = self.current.take() {
+            self.timer.cancel();
+            let mut change = SnackbarChange {
+                dismissed: Some(current.clone()),
+                ..SnackbarChange::default()
+            };
+            if let Some(next) = self.queue.pop_front() {
+                change = change.merge(self.show_message(next));
+            }
+            change
+        } else {
+            SnackbarChange::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timing::MockClock;
+
+    #[test]
+    fn enqueue_immediately_shows_first_message() {
+        let mut state = SnackbarState::new(SnackbarConfig::enterprise_defaults());
+        let change = state.enqueue("hello".to_string());
+        assert_eq!(
+            change.shown.as_ref().map(|m| m.payload.clone()),
+            Some("hello".to_string())
+        );
+        assert!(state.current().is_some());
+    }
+
+    #[test]
+    fn auto_hide_advances_queue() {
+        let clock = MockClock::new();
+        let mut state = SnackbarState::with_clock(
+            clock.clone(),
+            SnackbarConfig {
+                auto_hide: Duration::from_millis(100),
+                max_queue: 5,
+            },
+        );
+        state.enqueue("first");
+        state.enqueue("second");
+        clock.advance(Duration::from_millis(120));
+        let change = state.tick();
+        assert_eq!(change.dismissed.unwrap().payload, "first");
+        assert_eq!(change.shown.unwrap().payload, "second");
+    }
+
+    #[test]
+    fn pause_and_resume_preserves_timeout() {
+        let clock = MockClock::new();
+        let mut state = SnackbarState::with_clock(
+            clock.clone(),
+            SnackbarConfig {
+                auto_hide: Duration::from_millis(200),
+                max_queue: 5,
+            },
+        );
+        state.enqueue("first");
+        state.pause();
+        clock.advance(Duration::from_millis(400));
+        assert!(state.tick().dismissed.is_none());
+        state.resume();
+        clock.advance(Duration::from_millis(200));
+        let change = state.tick();
+        assert_eq!(change.dismissed.unwrap().payload, "first");
+    }
+}

--- a/crates/mui-headless/src/stepper.rs
+++ b/crates/mui-headless/src/stepper.rs
@@ -1,0 +1,324 @@
+//! Joy stepper state machine coordinating multi-step workflows.
+//!
+//! The implementation mirrors Material’s linear/non-linear stepper semantics so
+//! enterprise experiences can reuse the same automation suites across design
+//! systems.  Every transition returns a [`StepperChange`] describing which step
+//! became active and which steps toggled their completion flag.  Framework
+//! adapters can transform that into DOM mutations, analytics events, or custom
+//! logging without duplicating the underlying rules.
+
+use crate::aria;
+
+/// Configuration describing how the stepper behaves.
+#[derive(Debug, Clone)]
+pub struct StepperConfig {
+    /// Total number of steps managed by the workflow.
+    pub step_count: usize,
+    /// Whether the stepper enforces sequential completion.
+    pub linear: bool,
+    /// Optional index of the initial active step.
+    pub initial_active: Option<usize>,
+}
+
+impl StepperConfig {
+    /// Enterprise defaults that match Joy’s TypeScript implementation.
+    pub fn enterprise_defaults(step_count: usize) -> Self {
+        Self {
+            step_count,
+            linear: true,
+            initial_active: if step_count > 0 { Some(0) } else { None },
+        }
+    }
+}
+
+impl Default for StepperConfig {
+    fn default() -> Self {
+        Self::enterprise_defaults(0)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StepState {
+    completed: bool,
+    disabled: bool,
+}
+
+impl StepState {
+    fn new() -> Self {
+        Self {
+            completed: false,
+            disabled: false,
+        }
+    }
+}
+
+/// Aggregate change metadata emitted from the stepper.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StepperChange {
+    /// New active step if it changed.
+    pub active: Option<usize>,
+    /// Index of the step whose completion flag toggled.
+    pub completed: Option<usize>,
+}
+
+impl StepperChange {
+    fn merge(mut self, other: StepperChange) -> StepperChange {
+        if other.active.is_some() {
+            self.active = other.active;
+        }
+        if other.completed.is_some() {
+            self.completed = other.completed;
+        }
+        self
+    }
+}
+
+/// High level stepper orchestrator.
+#[derive(Debug, Clone)]
+pub struct StepperState {
+    steps: Vec<StepState>,
+    linear: bool,
+    active: Option<usize>,
+}
+
+impl StepperState {
+    /// Construct a new stepper from the provided configuration.
+    pub fn new(config: StepperConfig) -> Self {
+        let mut steps = Vec::with_capacity(config.step_count);
+        steps.resize_with(config.step_count, StepState::new);
+        let active = config
+            .initial_active
+            .and_then(|index| {
+                if index < config.step_count {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
+            .or_else(|| if config.step_count > 0 { Some(0) } else { None });
+        Self {
+            steps,
+            linear: config.linear,
+            active,
+        }
+    }
+
+    /// Returns the total number of steps.
+    #[inline]
+    pub fn step_count(&self) -> usize {
+        self.steps.len()
+    }
+
+    /// Returns the index of the active step.
+    #[inline]
+    pub fn active(&self) -> Option<usize> {
+        self.active
+    }
+
+    /// Returns whether the provided step index is disabled.
+    #[inline]
+    pub fn is_disabled(&self, index: usize) -> bool {
+        self.steps
+            .get(index)
+            .map(|step| step.disabled)
+            .unwrap_or(true)
+    }
+
+    /// Returns whether the provided step is completed.
+    #[inline]
+    pub fn is_completed(&self, index: usize) -> bool {
+        self.steps
+            .get(index)
+            .map(|step| step.completed)
+            .unwrap_or(false)
+    }
+
+    /// Mark a step as disabled or enabled.
+    pub fn set_step_disabled(&mut self, index: usize, disabled: bool) {
+        if let Some(step) = self.steps.get_mut(index) {
+            step.disabled = disabled;
+            if disabled && Some(index) == self.active {
+                self.active = self
+                    .next_available(index, 1)
+                    .or_else(|| self.next_available(index, -1));
+            }
+        }
+    }
+
+    /// Mark the provided step as completed.
+    pub fn set_step_completed(&mut self, index: usize, completed: bool) -> StepperChange {
+        if let Some(step) = self.steps.get_mut(index) {
+            if step.completed == completed {
+                return StepperChange::default();
+            }
+            step.completed = completed;
+            StepperChange {
+                completed: Some(index),
+                ..StepperChange::default()
+            }
+        } else {
+            StepperChange::default()
+        }
+    }
+
+    /// Complete the active step and optionally advance.
+    pub fn complete_active(&mut self) -> StepperChange {
+        if let Some(active) = self.active {
+            let mut change = self.set_step_completed(active, true);
+            if self.linear {
+                if let Some(next) = self.next_available(active, 1) {
+                    change = change.merge(self.set_active(Some(next)));
+                }
+            }
+            change
+        } else {
+            StepperChange::default()
+        }
+    }
+
+    /// Move to the next available step.
+    pub fn next(&mut self) -> StepperChange {
+        if let Some(active) = self.active {
+            if let Some(next) = self.next_available(active, 1) {
+                return self.set_active(Some(next));
+            }
+        }
+        StepperChange::default()
+    }
+
+    /// Move to the previous available step.
+    pub fn previous(&mut self) -> StepperChange {
+        if let Some(active) = self.active {
+            if let Some(prev) = self.next_available(active, -1) {
+                return self.set_active(Some(prev));
+            }
+        }
+        StepperChange::default()
+    }
+
+    /// Set the active step explicitly.
+    pub fn set_active(&mut self, index: Option<usize>) -> StepperChange {
+        if index == self.active {
+            return StepperChange::default();
+        }
+        if let Some(index) = index {
+            if index >= self.steps.len() || self.is_disabled(index) {
+                return StepperChange::default();
+            }
+            if self.linear && !self.can_visit(index) {
+                return StepperChange::default();
+            }
+            self.active = Some(index);
+            StepperChange {
+                active: Some(index),
+                ..StepperChange::default()
+            }
+        } else {
+            self.active = None;
+            StepperChange {
+                active: None,
+                ..StepperChange::default()
+            }
+        }
+    }
+
+    /// Reset the stepper to its initial state clearing completion flags.
+    pub fn reset(&mut self) {
+        for step in &mut self.steps {
+            step.completed = false;
+            step.disabled = false;
+        }
+        self.active = if self.steps.is_empty() { None } else { Some(0) };
+    }
+
+    /// Compute the attributes for the clickable step button.
+    pub fn step_button_attributes(&self, index: usize) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(4);
+        attrs.push(("role", aria::role_button().into()));
+        let (selected_key, selected_value) = aria::aria_selected(Some(index) == self.active);
+        attrs.push((selected_key, selected_value.to_string()));
+        aria::extend_disabled_attributes(&mut attrs, self.is_disabled(index));
+        attrs
+    }
+
+    /// Returns a lightweight status descriptor for indicators.
+    pub fn step_status(&self, index: usize) -> StepStatus {
+        if self.is_disabled(index) {
+            StepStatus::Disabled
+        } else if Some(index) == self.active {
+            StepStatus::Active
+        } else if self.is_completed(index) {
+            StepStatus::Completed
+        } else {
+            StepStatus::Pending
+        }
+    }
+
+    fn next_available(&self, start: usize, delta: isize) -> Option<usize> {
+        let len = self.steps.len() as isize;
+        let mut index = start as isize + delta;
+        while index >= 0 && index < len {
+            let idx = index as usize;
+            if !self.is_disabled(idx) {
+                return Some(idx);
+            }
+            index += delta;
+        }
+        None
+    }
+
+    fn can_visit(&self, index: usize) -> bool {
+        for i in 0..index {
+            if !self.is_completed(i) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Describes the visual status of an individual step indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepStatus {
+    /// Step has not been visited yet.
+    Pending,
+    /// Step is currently active.
+    Active,
+    /// Step has been completed.
+    Completed,
+    /// Step has been disabled.
+    Disabled,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_stepper_blocks_unfinished_steps() {
+        let mut state = StepperState::new(StepperConfig::enterprise_defaults(3));
+        assert_eq!(state.set_active(Some(2)), StepperChange::default());
+        state.complete_active();
+        assert_eq!(state.active(), Some(1));
+    }
+
+    #[test]
+    fn non_linear_stepper_allows_random_access() {
+        let mut state = StepperState::new(StepperConfig {
+            step_count: 4,
+            linear: false,
+            initial_active: Some(0),
+        });
+        let change = state.set_active(Some(3));
+        assert_eq!(change.active, Some(3));
+        assert_eq!(state.active(), Some(3));
+    }
+
+    #[test]
+    fn completion_updates_status() {
+        let mut state = StepperState::new(StepperConfig::enterprise_defaults(2));
+        state.complete_active();
+        assert_eq!(state.step_status(0), StepStatus::Completed);
+        assert_eq!(state.step_status(1), StepStatus::Active);
+    }
+}

--- a/crates/mui-headless/src/toggle_button_group.rs
+++ b/crates/mui-headless/src/toggle_button_group.rs
@@ -1,0 +1,266 @@
+//! Toggle button group state machine shared across Joy and Material adapters.
+//!
+//! Joy exposes both exclusive (single selection) and non-exclusive (multi
+//! selection) toggle groups.  This headless implementation keeps track of which
+//! buttons are pressed, enforces exclusivity when requested, and exposes
+//! declarative change metadata so adapters can update their DOM without
+//! reimplementing the selection bookkeeping.
+
+use crate::aria;
+
+/// Configuration describing the toggle group.
+#[derive(Debug, Clone)]
+pub struct ToggleButtonGroupConfig {
+    /// Number of toggle buttons in the group.
+    pub button_count: usize,
+    /// When `true` only a single button may be active at a time.
+    pub exclusive: bool,
+    /// Indices that should start pressed.
+    pub initial_pressed: Vec<usize>,
+}
+
+impl ToggleButtonGroupConfig {
+    /// Enterprise defaults aligned with Joy’s design guidance.
+    pub fn enterprise_defaults(button_count: usize) -> Self {
+        Self {
+            button_count,
+            exclusive: false,
+            initial_pressed: Vec::new(),
+        }
+    }
+}
+
+impl Default for ToggleButtonGroupConfig {
+    fn default() -> Self {
+        Self::enterprise_defaults(0)
+    }
+}
+
+/// Change notification emitted after toggle interactions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToggleButtonGroupChange {
+    /// Tuple describing which button changed and whether it is now pressed.
+    pub toggled: Option<(usize, bool)>,
+    /// Snapshot of pressed button indices after the transition.
+    pub pressed: Vec<usize>,
+}
+
+impl ToggleButtonGroupChange {
+    fn new(toggled: Option<(usize, bool)>, pressed: Vec<usize>) -> Self {
+        Self { toggled, pressed }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ButtonState {
+    pressed: bool,
+    disabled: bool,
+}
+
+impl ButtonState {
+    fn new() -> Self {
+        Self {
+            pressed: false,
+            disabled: false,
+        }
+    }
+}
+
+/// Headless toggle group state machine.
+#[derive(Debug, Clone)]
+pub struct ToggleButtonGroupState {
+    buttons: Vec<ButtonState>,
+    exclusive: bool,
+}
+
+impl ToggleButtonGroupState {
+    /// Construct a new toggle group.
+    pub fn new(config: ToggleButtonGroupConfig) -> Self {
+        let mut buttons = Vec::with_capacity(config.button_count);
+        buttons.resize_with(config.button_count, ButtonState::new);
+        let mut state = Self {
+            buttons,
+            exclusive: config.exclusive,
+        };
+        state.sync_pressed(&config.initial_pressed);
+        state
+    }
+
+    /// Returns how many buttons are tracked.
+    #[inline]
+    pub fn button_count(&self) -> usize {
+        self.buttons.len()
+    }
+
+    /// Returns whether a specific button is pressed.
+    #[inline]
+    pub fn is_pressed(&self, index: usize) -> bool {
+        self.buttons
+            .get(index)
+            .map(|btn| btn.pressed)
+            .unwrap_or(false)
+    }
+
+    /// Returns whether a specific button is disabled.
+    #[inline]
+    pub fn is_disabled(&self, index: usize) -> bool {
+        self.buttons
+            .get(index)
+            .map(|btn| btn.disabled)
+            .unwrap_or(true)
+    }
+
+    /// Update the disabled flag for a button.
+    pub fn set_disabled(&mut self, index: usize, disabled: bool) {
+        if let Some(button) = self.buttons.get_mut(index) {
+            button.disabled = disabled;
+            if disabled {
+                button.pressed = false;
+            }
+        }
+    }
+
+    /// Toggle a button.
+    pub fn toggle(&mut self, index: usize) -> ToggleButtonGroupChange {
+        if index >= self.buttons.len() || self.is_disabled(index) {
+            return ToggleButtonGroupChange::new(None, self.pressed_indices());
+        }
+        if self.exclusive {
+            if self.buttons[index].pressed {
+                self.buttons[index].pressed = false;
+                return ToggleButtonGroupChange::new(Some((index, false)), self.pressed_indices());
+            }
+            for (i, button) in self.buttons.iter_mut().enumerate() {
+                if i != index {
+                    button.pressed = false;
+                }
+            }
+            self.buttons[index].pressed = true;
+            ToggleButtonGroupChange::new(Some((index, true)), self.pressed_indices())
+        } else {
+            self.buttons[index].pressed = !self.buttons[index].pressed;
+            ToggleButtonGroupChange::new(
+                Some((index, self.buttons[index].pressed)),
+                self.pressed_indices(),
+            )
+        }
+    }
+
+    /// Force a button into a pressed/unpressed state.
+    pub fn set_pressed(&mut self, index: usize, pressed: bool) -> ToggleButtonGroupChange {
+        if index >= self.buttons.len() || self.is_disabled(index) {
+            return ToggleButtonGroupChange::new(None, self.pressed_indices());
+        }
+        if self.exclusive && pressed {
+            for (i, button) in self.buttons.iter_mut().enumerate() {
+                button.pressed = i == index;
+            }
+        } else {
+            self.buttons[index].pressed = pressed;
+        }
+        ToggleButtonGroupChange::new(
+            Some((index, self.buttons[index].pressed)),
+            self.pressed_indices(),
+        )
+    }
+
+    /// Synchronise pressed buttons from an external controller.
+    pub fn sync_pressed(&mut self, pressed: &[usize]) {
+        for button in &mut self.buttons {
+            button.pressed = false;
+        }
+        if self.exclusive {
+            if let Some(first) = pressed
+                .iter()
+                .copied()
+                .find(|idx| *idx < self.buttons.len())
+            {
+                if let Some(button) = self.buttons.get_mut(first) {
+                    button.pressed = true;
+                }
+            }
+            return;
+        }
+        for &index in pressed {
+            if let Some(button) = self.buttons.get_mut(index) {
+                button.pressed = true;
+            }
+        }
+    }
+
+    /// Adjust the number of tracked buttons.
+    pub fn set_button_count(&mut self, count: usize) {
+        self.buttons.resize_with(count, ButtonState::new);
+        if self.exclusive {
+            // Ensure only a single button remains pressed.
+            let mut first = None;
+            for (index, button) in self.buttons.iter_mut().enumerate() {
+                if button.pressed {
+                    if first.is_some() {
+                        button.pressed = false;
+                    } else {
+                        first = Some(index);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns the indices of pressed buttons.
+    pub fn pressed_indices(&self) -> Vec<usize> {
+        self.buttons
+            .iter()
+            .enumerate()
+            .filter_map(|(index, button)| button.pressed.then_some(index))
+            .collect()
+    }
+
+    /// Compute ARIA attributes for a toggle button element.
+    pub fn button_attributes(&self, index: usize) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(4);
+        attrs.push(("role", aria::role_button().into()));
+        let (pressed_key, pressed_value) = aria::aria_pressed(self.is_pressed(index));
+        attrs.push((pressed_key, pressed_value.into()));
+        aria::extend_disabled_attributes(&mut attrs, self.is_disabled(index));
+        attrs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusive_group_allows_single_pressed_button() {
+        let mut state = ToggleButtonGroupState::new(ToggleButtonGroupConfig {
+            button_count: 3,
+            exclusive: true,
+            initial_pressed: vec![1],
+        });
+        let change = state.toggle(2);
+        assert_eq!(change.toggled, Some((2, true)));
+        assert_eq!(change.pressed, vec![2]);
+    }
+
+    #[test]
+    fn non_exclusive_group_supports_multiple_buttons() {
+        let mut state = ToggleButtonGroupState::new(ToggleButtonGroupConfig {
+            button_count: 3,
+            exclusive: false,
+            initial_pressed: vec![],
+        });
+        state.toggle(0);
+        let change = state.toggle(2);
+        assert_eq!(change.pressed, vec![0, 2]);
+    }
+
+    #[test]
+    fn disabled_buttons_ignore_toggles() {
+        let mut state =
+            ToggleButtonGroupState::new(ToggleButtonGroupConfig::enterprise_defaults(2));
+        state.set_disabled(1, true);
+        let change = state.toggle(1);
+        assert_eq!(change.toggled, None);
+        assert!(state.pressed_indices().is_empty());
+    }
+}

--- a/crates/mui-joy/src/accordion.rs
+++ b/crates/mui-joy/src/accordion.rs
@@ -1,0 +1,28 @@
+//! Joy accordion scaffolding that wraps the shared headless state machine.
+//!
+//! Rendering adapters can construct [`AccordionController`] and wire its
+//! [`AccordionGroupState`](mui_headless::accordion::AccordionGroupState) into
+//! component templates.  Centralising the boilerplate here keeps future Joy
+//! components focused on styling rather than state orchestration.
+
+pub use mui_headless::accordion::{
+    AccordionGroupState, AccordionItemChange,
+};
+
+/// Convenience wrapper around [`AccordionGroupState`] so Joy renderers can
+/// instantiate accordions without touching the headless crate directly.
+#[derive(Debug, Clone)]
+pub struct AccordionController {
+    /// Headless state machine powering the accordion group.
+    pub state: AccordionGroupState,
+}
+
+impl AccordionController {
+    /// Construct a new controller mirroring the `AccordionGroup` defaults from
+    /// the TypeScript implementation.
+    pub fn new(item_count: usize, allow_multiple: bool, default_expanded: &[usize]) -> Self {
+        Self {
+            state: AccordionGroupState::new(item_count, allow_multiple, default_expanded),
+        }
+    }
+}

--- a/crates/mui-joy/src/autocomplete.rs
+++ b/crates/mui-joy/src/autocomplete.rs
@@ -1,0 +1,34 @@
+//! Joy autocomplete scaffolding built on top of the shared headless state.
+//!
+//! The wrapper exposes the strongly typed configuration and change stream so
+//! renderers can focus on layout/theming.  When the visual implementation is
+//! ready we simply plug the controller into the adapter without re-threading
+//! business logic.
+
+pub use mui_headless::autocomplete::{
+    AutocompleteChange, AutocompleteConfig, AutocompleteControlStrategy,
+    AutocompleteState,
+};
+
+/// Wrapper that owns an [`AutocompleteState`] ready to be plugged into Joy
+/// renderers.
+#[derive(Debug, Clone)]
+pub struct AutocompleteController {
+    /// Headless state machine handling all interactions.
+    pub state: AutocompleteState,
+}
+
+impl AutocompleteController {
+    /// Construct a new controller using [`AutocompleteConfig::enterprise_defaults`].
+    pub fn new(config: AutocompleteConfig) -> Self {
+        Self {
+            state: AutocompleteState::new(config),
+        }
+    }
+
+    /// Convenience helper building a controller with Joy defaults for a given
+    /// option count.
+    pub fn with_option_count(option_count: usize) -> Self {
+        Self::new(AutocompleteConfig::enterprise_defaults(option_count))
+    }
+}

--- a/crates/mui-joy/src/lib.rs
+++ b/crates/mui-joy/src/lib.rs
@@ -4,14 +4,34 @@
 //! components and tokens from the Joy design system. The goal is to provide
 //! a fully typed Rust API that can scale with additional components.
 
+pub mod accordion;
 pub mod aspect_ratio;
+pub mod autocomplete;
 pub mod button;
 pub mod card;
 pub mod chip;
+pub mod slider;
+pub mod snackbar;
+pub mod stepper;
+pub mod toggle_button_group;
 pub mod macros;
 
+pub use accordion::{AccordionController, AccordionGroupState, AccordionItemChange};
 pub use aspect_ratio::{AspectRatio, AspectRatioProps};
+pub use autocomplete::{
+    AutocompleteChange, AutocompleteConfig, AutocompleteController, AutocompleteControlStrategy,
+    AutocompleteState,
+};
 pub use button::{Button, ButtonProps};
 pub use card::{Card, CardProps};
 pub use chip::{Chip, ChipProps};
 pub use macros::{Color, Variant};
+pub use slider::{
+    SliderChange, SliderConfig, SliderController, SliderOrientation, SliderState,
+};
+pub use snackbar::{SnackbarChange, SnackbarConfig, SnackbarController, SnackbarMessage, SnackbarState};
+pub use stepper::{StepStatus, StepperChange, StepperController, StepperConfig, StepperState};
+pub use toggle_button_group::{
+    ToggleButtonGroupChange, ToggleButtonGroupConfig, ToggleButtonGroupController,
+    ToggleButtonGroupState,
+};

--- a/crates/mui-joy/src/slider.rs
+++ b/crates/mui-joy/src/slider.rs
@@ -1,0 +1,31 @@
+//! Joy slider scaffolding mirroring the shared headless state machine.
+//!
+//! While the visual rendering is pending, adapters can start integrating the
+//! [`SliderController`] to wire up keyboard/pointer handling and analytics.  The
+//! controller simply wraps the reusable [`SliderState`] so state transitions stay
+//! centralised.
+
+pub use mui_headless::slider::{
+    SliderChange, SliderConfig, SliderOrientation, SliderState,
+};
+
+/// Wrapper owning a [`SliderState`] for Joy renderers.
+#[derive(Debug, Clone)]
+pub struct SliderController {
+    /// Headless state machine responsible for value updates.
+    pub state: SliderState,
+}
+
+impl SliderController {
+    /// Construct a controller using Joy friendly defaults.
+    pub fn new(config: SliderConfig) -> Self {
+        Self {
+            state: SliderState::new(config),
+        }
+    }
+
+    /// Convenience helper building a slider that spans the provided range.
+    pub fn range(min: f64, max: f64) -> Self {
+        Self::new(SliderConfig::enterprise_defaults(min, max))
+    }
+}

--- a/crates/mui-joy/src/snackbar.rs
+++ b/crates/mui-joy/src/snackbar.rs
@@ -1,0 +1,26 @@
+//! Joy snackbar scaffolding exposing the shared queue/state machine.
+//!
+//! Enterprises frequently coordinate snackbar usage across micro-frontends.  The
+//! [`SnackbarController`] centralises queue management so individual renderers
+//! simply forward events into the controller and map the emitted
+//! [`SnackbarChange`] into UI updates.
+
+pub use mui_headless::snackbar::{
+    SnackbarChange, SnackbarConfig, SnackbarMessage, SnackbarState,
+};
+
+/// Wrapper around [`SnackbarState`] that keeps the clock generic for tests.
+#[derive(Debug, Clone)]
+pub struct SnackbarController<T> {
+    /// Headless snackbar state powering Joy adapters.
+    pub state: SnackbarState<T>,
+}
+
+impl<T: Clone> SnackbarController<T> {
+    /// Construct a controller using the system clock.
+    pub fn new(config: SnackbarConfig) -> Self {
+        Self {
+            state: SnackbarState::new(config),
+        }
+    }
+}

--- a/crates/mui-joy/src/stepper.rs
+++ b/crates/mui-joy/src/stepper.rs
@@ -1,0 +1,30 @@
+//! Joy stepper scaffolding bridging the shared headless workflow engine.
+//!
+//! The [`StepperController`] exposes the same state machine used by Material so
+//! teams can consolidate automation and analytics.  Once visual components are
+//! added they simply render according to the controller’s change stream.
+
+pub use mui_headless::stepper::{
+    StepStatus, StepperChange, StepperConfig, StepperState,
+};
+
+/// Wrapper around [`StepperState`] prepared for Joy adapters.
+#[derive(Debug, Clone)]
+pub struct StepperController {
+    /// Headless state machine powering the workflow.
+    pub state: StepperState,
+}
+
+impl StepperController {
+    /// Construct a controller with Joy defaults.
+    pub fn new(config: StepperConfig) -> Self {
+        Self {
+            state: StepperState::new(config),
+        }
+    }
+
+    /// Convenience helper that builds a linear stepper with the provided count.
+    pub fn linear(step_count: usize) -> Self {
+        Self::new(StepperConfig::enterprise_defaults(step_count))
+    }
+}

--- a/crates/mui-joy/src/toggle_button_group.rs
+++ b/crates/mui-joy/src/toggle_button_group.rs
@@ -1,0 +1,30 @@
+//! Joy toggle button group scaffolding wrapping the headless implementation.
+//!
+//! Exposing the controller early lets adapters experiment with layouts while we
+//! finish the styled components.  Automation suites can hook into
+//! [`ToggleButtonGroupChange`] without depending on JSX/TSX internals.
+
+pub use mui_headless::toggle_button_group::{
+    ToggleButtonGroupChange, ToggleButtonGroupConfig, ToggleButtonGroupState,
+};
+
+/// Wrapper around [`ToggleButtonGroupState`] that mirrors Joy’s ergonomics.
+#[derive(Debug, Clone)]
+pub struct ToggleButtonGroupController {
+    /// Headless state machine powering the toggle group.
+    pub state: ToggleButtonGroupState,
+}
+
+impl ToggleButtonGroupController {
+    /// Construct a controller using Joy defaults.
+    pub fn new(config: ToggleButtonGroupConfig) -> Self {
+        Self {
+            state: ToggleButtonGroupState::new(config),
+        }
+    }
+
+    /// Helper that creates a non-exclusive group with the provided count.
+    pub fn with_button_count(button_count: usize) -> Self {
+        Self::new(ToggleButtonGroupConfig::enterprise_defaults(button_count))
+    }
+}

--- a/docs/joy-parity.md
+++ b/docs/joy-parity.md
@@ -1,0 +1,102 @@
+# Joy UI Rust Parity Audit
+
+This document enumerates the Joy UI surface exported from
+`packages/mui-joy/src/index.ts` and maps every widget to the equivalent (or
+planned) Rust support.  Interactive components — the ones that need a state
+machine rather than purely presentational markup — are called out explicitly so
+we can close gaps in `mui-headless` and keep downstream Joy adapters fully
+accessible.
+
+| Component | Interactive | Rust status | Notes |
+| --- | --- | --- | --- |
+| Accordion | ✅ | **New:** `mui_headless::accordion` | Disclosure widget coordinating expanded/collapsed panels. |
+| AccordionDetails | ❌ | Structural | Presentational container nested within accordion items. |
+| AccordionGroup | ✅ | **New:** `mui_headless::accordion` | Group manager that enforces single/multi expansion policies. |
+| AccordionSummary | ✅ | **New:** `mui_headless::accordion` | Trigger surface wired into the accordion change stream. |
+| Alert | ⚠️ | Not yet modelled | Mostly presentational; dismissal will reuse snackbar queueing later. |
+| AspectRatio | ❌ | Available (`crates/mui-joy::aspect_ratio`) | Layout helper without interactivity. |
+| Autocomplete | ✅ | **New:** `mui_headless::autocomplete` | Hybrid text input + listbox that reuses select patterns. |
+| AutocompleteListbox | ✅ | **New:** `mui_headless::autocomplete` | Popover list that mirrors Joy’s listbox styling. |
+| AutocompleteOption | ✅ | **New:** `mui_headless::autocomplete` | Option level helpers for automation IDs and ARIA wiring. |
+| Avatar | ❌ | Pending Joy port | Static display; no state machine needed. |
+| AvatarGroup | ❌ | Pending Joy port | Layout driven aggregation of avatars. |
+| Badge | ❌ | Pending Joy port | Static counter badge. |
+| Box | ❌ | Pending Joy port | Generic layout primitive. |
+| Breadcrumbs | ❌ | Pending Joy port | Navigation aid without local state. |
+| Button | ✅ | Available (`mui_headless::button`) | Button state is already centralised and consumed by Joy. |
+| ButtonGroup | ✅ | **New:** `mui_headless::toggle_button_group` | Shared toggle orchestration for grouped buttons. |
+| Card | ❌ | Available (`crates/mui-joy::card`) | Presentational Joy component. |
+| CardActions | ❌ | Pending Joy port | Layout helper. |
+| CardContent | ❌ | Pending Joy port | Layout helper. |
+| CardCover | ❌ | Pending Joy port | Layout helper. |
+| CardOverflow | ❌ | Pending Joy port | Layout helper. |
+| Checkbox | ✅ | Available (`mui_headless::checkbox`) | Already wired through Material + Joy. |
+| Chip | ✅ | Available (`mui_headless::chip`) | Hover/delete automation already documented. |
+| ChipDelete | ✅ | Available (`mui_headless::chip`) | Uses chip trailing action state. |
+| CircularProgress | ❌ | Pending Joy port | Visual only. |
+| Container | ❌ | Pending Joy port | Layout wrapper. |
+| CssBaseline | ❌ | Pending Joy port | Global CSS reset. |
+| DialogActions | ❌ | Pending Joy port | Static region in Joy dialogs. |
+| DialogContent | ❌ | Pending Joy port | Static region in Joy dialogs. |
+| DialogTitle | ❌ | Pending Joy port | Static region in Joy dialogs. |
+| Divider | ❌ | Pending Joy port | Visual only. |
+| Drawer | ✅ | Available (`mui_headless::drawer`) | Shares dialog style modal logic. |
+| Dropdown | ✅ | Available (`mui_headless::menu`) | Wraps menu/listbox behavior. |
+| FormControl | ❌ | Pending Joy port | Structural helper. |
+| FormHelperText | ❌ | Pending Joy port | Static text. |
+| FormLabel | ❌ | Pending Joy port | Static label. |
+| Grid | ❌ | Pending Joy port | Layout system. |
+| IconButton | ✅ | Available (`mui_headless::button`) | Button variant. |
+| Input | ✅ | Available (`mui_headless::text_field`) | Shares the text field state machine. |
+| LinearProgress | ❌ | Pending Joy port | Visual only. |
+| Link | ✅ | Pending Joy port | Minimal interactivity, standard anchor semantics. |
+| List | ✅ | Available (`mui_headless::list`) | Keyboard navigation + typeahead. |
+| ListDivider | ❌ | Pending Joy port | Visual only. |
+| ListItem | ✅ | Available (`mui_headless::list`) | Delegates to list navigation logic. |
+| ListItemButton | ✅ | Available (`mui_headless::list`) | Delegates to list navigation logic. |
+| ListItemContent | ❌ | Pending Joy port | Static container. |
+| ListItemDecorator | ❌ | Pending Joy port | Static container. |
+| ListSubheader | ❌ | Pending Joy port | Static container. |
+| Menu | ✅ | Available (`mui_headless::menu`) | Driven by menu state machine. |
+| MenuButton | ✅ | Available (`mui_headless::menu`) | Uses the menu trigger helpers. |
+| MenuItem | ✅ | Available (`mui_headless::menu`) | Option level helpers. |
+| MenuList | ✅ | Available (`mui_headless::menu`) | Popover container. |
+| Modal | ✅ | Available (`mui_headless::dialog`) | Shares dialog state machine for overlays. |
+| ModalClose | ✅ | Available (`mui_headless::dialog`) | Uses dialog close intents. |
+| ModalDialog | ✅ | Available (`mui_headless::dialog`) | Uses dialog positioning + focus trap. |
+| ModalOverflow | ❌ | Pending Joy port | Presentational. |
+| Option | ✅ | Available (`mui_headless::select`) | Headless select option state. |
+| Radio | ✅ | Available (`mui_headless::radio`) | State machine shared with Material. |
+| RadioGroup | ✅ | Available (`mui_headless::radio`) | Group level orchestrator. |
+| ScopedCssBaseline | ❌ | Pending Joy port | Global CSS helper. |
+| Select | ✅ | Available (`mui_headless::select`) | Comprehensive listbox state. |
+| Sheet | ❌ | Pending Joy port | Layout container. |
+| Skeleton | ❌ | Pending Joy port | Visual only. |
+| Slider | ✅ | **New:** `mui_headless::slider` | Value tracking, keyboard/pointer handling. |
+| Snackbar | ✅ | **New:** `mui_headless::snackbar` | Timed queue mirroring Material behavior. |
+| Stepper | ✅ | **New:** `mui_headless::stepper` | Linear/non-linear progress management. |
+| Step | ✅ | **New:** `mui_headless::stepper` | Per-step completion bookkeeping. |
+| StepButton | ✅ | **New:** `mui_headless::stepper` | Focusable trigger for navigation. |
+| StepIndicator | ✅ | **New:** `mui_headless::stepper` | Derives status from stepper state. |
+| Stack | ❌ | Pending Joy port | Layout primitive. |
+| SvgIcon | ❌ | Pending Joy port | Visual only. |
+| Switch | ✅ | Available (`mui_headless::switch`) | Toggle machine already present. |
+| Tab | ✅ | Available (`mui_headless::tab`) | Tab level helpers. |
+| Table | ⚠️ | Material driven (`mui_material::table`) | Mostly structural; Joy equivalent TBD. |
+| TabList | ✅ | Available (`mui_headless::tabs`) | Tablist orchestration. |
+| TabPanel | ✅ | Available (`mui_headless::tab_panel`) | Panel mapping. |
+| Tabs | ✅ | Available (`mui_headless::tabs`) | High level orchestrator. |
+| Textarea | ✅ | Available (`mui_headless::text_field`) | Shares text field state machine. |
+| TextField | ✅ | Available (`mui_headless::text_field`) | Already implemented. |
+| ToggleButtonGroup | ✅ | **New:** `mui_headless::toggle_button_group` | Exclusive/multi selection toggles. |
+| Tooltip | ✅ | Available (`mui_headless::tooltip`) | Hover/focus timing machine. |
+| Typography | ❌ | Pending Joy port | Static text styles. |
+
+## Next steps
+
+The newly introduced headless modules (`accordion`, `autocomplete`, `slider`,
+`snackbar`, `stepper`, `toggle_button_group`) unlock Joy specific wrappers in
+`crates/mui-joy`.  Remaining non-interactive components can be brought across
+iteratively without headless changes, while future interactive widgets (e.g.
+Alert dismissal, advanced tables) should follow the same headless-first
+pattern.


### PR DESCRIPTION
## Summary
- document the Joy UI component surface and flag the headless parity gaps
- add headless state machines for Joy accordion, autocomplete, slider, snackbar, stepper, and toggle button group primitives with unit tests
- scaffold matching Joy controllers that wrap the new headless primitives and re-export them from the Joy crate

## Testing
- cargo test -p mui-headless

------
https://chatgpt.com/codex/tasks/task_e_68d191af3b2c832ebd026702593afe08