### PR TITLE
Refactor Joy props for cross-framework support

### DIFF
--- a/crates/mui-joy/Cargo.toml
+++ b/crates/mui-joy/Cargo.toml
@@ -18,6 +18,8 @@ mui-system = { path = "../mui-system" }
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+dioxus = { workspace = true, optional = true }
+sycamore = { workspace = true, optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test.workspace = true
@@ -28,3 +30,5 @@ web-sys = { workspace = true, features = ["HtmlElement", "Event", "EventTarget"]
 default = []
 yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew"]
 leptos = ["dep:leptos", "dep:wasm-bindgen", "mui-system/leptos"]
+dioxus = ["dep:dioxus", "dep:wasm-bindgen", "mui-system/dioxus"]
+sycamore = ["dep:sycamore", "dep:wasm-bindgen", "mui-system/sycamore"]

--- a/crates/mui-joy/src/lib.rs
+++ b/crates/mui-joy/src/lib.rs
@@ -1,36 +1,83 @@
 //! Joy UI component library.
 //!
-//! This crate mirrors the structure of `mui-material` but implements
-//! components and tokens from the Joy design system. The goal is to provide
-//! a fully typed Rust API that can scale with additional components.
+//! The crate exposes two complementary building blocks:
+//!
+//! * **Framework-neutral prop definitions** – [`joy_props!`](crate::joy_props) and
+//!   [`joy_component_props!`](crate::joy_component_props) emit plain Rust
+//!   structs that capture component configuration without binding to a specific
+//!   renderer. Optional `#[cfg_attr]` hooks layer in `yew::Properties`,
+//!   `dioxus::Props` and `sycamore::Props` derives when the corresponding Cargo
+//!   feature is enabled. Leptos consumers can lean on the
+//!   `LeptosPropsAdapter` (available when the `leptos` feature is enabled) to
+//!   assert compatibility inside custom wrappers.
+//! * **Yew-first component implementations** – the existing modules under
+//!   `src/` currently target Yew and are gated behind the `yew` feature. This
+//!   keeps the crate compiling for Leptos, Dioxus and Sycamore consumers that
+//!   only need the shared prop structs while the remaining adapters are built
+//!   out incrementally.
+//!
+//! ### Enabling framework integrations
+//!
+//! | Feature      | Purpose                                                                 |
+//! |--------------|-------------------------------------------------------------------------|
+//! | `yew`        | Activates the concrete Yew components and applies `yew::Properties`     |
+//! | `leptos`     | Enables the Leptos marker trait so downstream crates can add adapters   |
+//! | `dioxus`     | Derives `dioxus::Props` on every generated prop struct                  |
+//! | `sycamore`   | Derives `sycamore::Props` on every generated prop struct                |
+//!
+//! All features activate the corresponding `mui-system` adapter to guarantee that themed
+//! primitives behave consistently across frameworks. This design avoids manual repetitive
+//! glue code and ensures future adapters reuse the exact same prop contracts.
 
+#[cfg(feature = "yew")]
 pub mod accordion;
+#[cfg(feature = "yew")]
 pub mod aspect_ratio;
+#[cfg(feature = "yew")]
 pub mod autocomplete;
+#[cfg(feature = "yew")]
 pub mod button;
+#[cfg(feature = "yew")]
 pub mod card;
+#[cfg(feature = "yew")]
 pub mod chip;
+#[cfg(feature = "yew")]
 pub mod slider;
+#[cfg(feature = "yew")]
 pub mod snackbar;
+#[cfg(feature = "yew")]
 pub mod stepper;
+#[cfg(feature = "yew")]
 pub mod toggle_button_group;
 pub mod macros;
 
+#[cfg(feature = "yew")]
 pub use accordion::{AccordionController, AccordionGroupState, AccordionItemChange};
+#[cfg(feature = "yew")]
 pub use aspect_ratio::{AspectRatio, AspectRatioProps};
+#[cfg(feature = "yew")]
 pub use autocomplete::{
     AutocompleteChange, AutocompleteConfig, AutocompleteController, AutocompleteControlStrategy,
     AutocompleteState,
 };
+#[cfg(feature = "yew")]
 pub use button::{Button, ButtonProps};
+#[cfg(feature = "yew")]
 pub use card::{Card, CardProps};
+#[cfg(feature = "yew")]
 pub use chip::{Chip, ChipProps};
 pub use macros::{Color, Variant};
+#[cfg(feature = "yew")]
 pub use slider::{
     SliderChange, SliderConfig, SliderController, SliderOrientation, SliderState,
 };
-pub use snackbar::{SnackbarChange, SnackbarConfig, SnackbarController, SnackbarMessage, SnackbarState};
+#[cfg(feature = "yew")]
+pub use snackbar::{
+    SnackbarChange, SnackbarConfig, SnackbarController, SnackbarMessage, SnackbarState,
+};
+#[cfg(feature = "yew")]
 pub use stepper::{StepStatus, StepperChange, StepperController, StepperConfig, StepperState};
+#[cfg(feature = "yew")]
 pub use toggle_button_group::{
     ToggleButtonGroupChange, ToggleButtonGroupConfig, ToggleButtonGroupController,
     ToggleButtonGroupState,

--- a/crates/mui-joy/src/macros.rs
+++ b/crates/mui-joy/src/macros.rs
@@ -1,15 +1,54 @@
 //! Helper macros for defining Joy UI component props and enums.
+//!
+//! Historically the props macros were tightly coupled to Yew which meant the
+//! generated structs could not be reused by other front-end adapters without
+//! copy/pasting definitions. The updated implementation below intentionally
+//! emits framework-neutral structs and layers optional integration points for
+//! each supported renderer. This keeps enterprise teams from maintaining
+//! divergent prop models while still allowing framework specific derive macros
+//! (for example `yew::Properties` or `dioxus::Props`) to hook into the shared
+//! definition when the corresponding Cargo feature is enabled.
 
-/// Generates a `yew::Properties` struct with `Default` implementation and
-/// automatic `#[prop_or_default]` markers for ergonomics.
+/// Marker trait implemented for every props struct whenever the `leptos`
+/// feature is active.
+///
+/// Leptos primarily relies on function parameters for component props rather
+/// than derive macros. The trait provides a lightweight hook that downstream
+/// adapters can use to enforce that a props struct is compatible with Leptos
+/// specific builders without forcing additional trait bounds on every field.
+#[cfg(feature = "leptos")]
+pub trait LeptosPropsAdapter: Clone + Default {}
+
+/// Generates a framework-neutral struct capturing Joy component props.
+///
+/// * Always derives `Clone`, `Default` and `PartialEq` so the props can be
+///   cloned across async boundaries and merged with defaults in controller
+///   style patterns without locking the implementation into a particular
+///   rendering strategy.
+/// * Applies optional derives for each supported front-end framework via
+///   `#[cfg_attr]`. When the associated Cargo feature is active the struct will
+///   automatically implement that framework's props trait without duplicating
+///   the field list.
+/// * Annotates every field with optional framework specific attributes (for
+///   example Yew's `#[prop_or_default]`) using `cfg_attr` so the metadata is
+///   only emitted when the framework is compiled in.
 #[macro_export]
 macro_rules! joy_props {
     ($name:ident { $( $(#[$meta:meta])* $field:ident : $ty:ty ),* $(,)? }) => {
-        #[cfg(feature = "yew")]
-        #[derive(yew::Properties, Clone, PartialEq, Default)]
+        #[derive(Clone, Default, PartialEq)]
+        #[cfg_attr(feature = "yew", derive(yew::Properties))]
+        #[cfg_attr(feature = "dioxus", derive(dioxus::Props))]
+        #[cfg_attr(feature = "sycamore", derive(sycamore::Props))]
         pub struct $name {
-            $( $(#[$meta])* #[prop_or_default] pub $field: $ty, )*
+            $(
+                $(#[$meta])*
+                #[cfg_attr(feature = "yew", yew::prop_or_default)]
+                pub $field: $ty,
+            )*
         }
+
+        #[cfg(feature = "leptos")]
+        impl crate::macros::LeptosPropsAdapter for $name {}
     };
 }
 

--- a/crates/mui-joy/tests/wasm.rs
+++ b/crates/mui-joy/tests/wasm.rs
@@ -1,3 +1,10 @@
+#![cfg(feature = "yew")]
+//! Browser integration tests exercising the Yew adapters.
+//!
+//! The suite is compiled conditionally so that enabling Leptos, Dioxus or
+//! Sycamore without the Yew feature still produces a clean build focussed on
+//! the framework-neutral prop definitions.
+
 use mui_joy::{AspectRatio, Button, Chip, Color, Variant};
 use mui_system::theme_provider::ThemeProvider;
 use mui_system::Theme;


### PR DESCRIPTION
## Summary
- refactor the Joy props macro to emit framework-neutral structs with cfg_attr hooks and a Leptos adapter marker
- expose dioxus and sycamore features in the crate manifest so mui-system integrations can be toggled alongside yew and leptos
- document the feature matrix in the crate root and gate Yew-specific modules/tests to keep non-Yew builds clean

## Testing
- `cargo fmt`
- `cargo check --manifest-path crates/mui-joy/Cargo.toml --no-default-features --features yew` *(fails: crate expects to be a workspace member)*

------
https://chatgpt.com/codex/tasks/task_e_68d198f09564832e82db125fddc35c71