### PR TITLE
refactor(joy): centralize helpers and integrate headless state

### DIFF
--- a/crates/mui-joy/Cargo.toml
+++ b/crates/mui-joy/Cargo.toml
@@ -20,6 +20,7 @@ yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 dioxus = { workspace = true, optional = true }
 sycamore = { workspace = true, optional = true }
+gloo-timers = { version = "0.2", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test.workspace = true
@@ -28,7 +29,7 @@ web-sys = { workspace = true, features = ["HtmlElement", "Event", "EventTarget"]
 
 [features]
 default = []
-yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew"]
+yew = ["dep:yew", "dep:wasm-bindgen", "mui-system/yew", "dep:gloo-timers"]
 leptos = ["dep:leptos", "dep:wasm-bindgen", "mui-system/leptos"]
 dioxus = ["dep:dioxus", "dep:wasm-bindgen", "mui-system/dioxus"]
 sycamore = ["dep:sycamore", "dep:wasm-bindgen", "mui-system/sycamore"]

--- a/crates/mui-joy/src/aspect_ratio.rs
+++ b/crates/mui-joy/src/aspect_ratio.rs
@@ -1,5 +1,6 @@
 use yew::prelude::*;
 
+use crate::helpers::{resolve_aspect_ratio_styles, AspectRatioStyles};
 use crate::joy_props;
 
 joy_props!(AspectRatioProps {
@@ -11,17 +12,21 @@ joy_props!(AspectRatioProps {
 
 /// Maintains a consistent width/height ratio for its child.
 ///
-/// The component uses the classic padding-top hack so it works without any
-/// JavaScript and keeps layout calculations on the GPU.
+/// # Design tokens
+/// This primitive does not consume palette tokens directly. It relies on
+/// [`resolve_aspect_ratio_styles`](crate::helpers::resolve_aspect_ratio_styles) to emit the
+/// padding-top hack and is therefore safe to use across all framework adapters without additional
+/// styling.
+///
+/// # Headless state contract
+/// Aspect ratios are stateless; no headless state machine is required. Each adapter simply renders
+/// the deterministic layout scaffolding supplied by the helper.
 #[function_component(AspectRatio)]
 pub fn aspect_ratio(props: &AspectRatioProps) -> Html {
-    let padding = format!(
-        "padding-top:{}%;position:relative;width:100%;",
-        100.0 / props.ratio
-    );
+    let styles: AspectRatioStyles = resolve_aspect_ratio_styles(props.ratio);
     html! {
-        <div style={padding}>
-            <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
+        <div style={styles.outer}>
+            <div style={styles.inner}>
                 { for props.children.iter() }
             </div>
         </div>

--- a/crates/mui-joy/src/button.rs
+++ b/crates/mui-joy/src/button.rs
@@ -1,6 +1,11 @@
+use std::time::Duration;
+
 use mui_system::theme_provider::use_theme;
 use yew::prelude::*;
 
+use crate::helpers::{
+    resolve_surface_tokens, use_button_adapter, ButtonAdapterConfig, SurfaceTokens,
+};
 // Import shared enums and macros so all components stay aligned.
 use crate::{joy_component_props, Color, Variant};
 
@@ -9,35 +14,65 @@ joy_component_props!(ButtonProps {
     label: String,
     /// Click handler for interactive behavior.
     onclick: Callback<MouseEvent>,
+    /// Optional throttle window (in milliseconds) guarding against accidental double clicks.
+    throttle_ms: Option<u64>,
+    /// Whether the button should be disabled.
+    disabled: bool,
 });
 
-/// A basic Joy UI button.
+/// Joy UI button rendering the [`mui_headless::button::ButtonState`] machine.
+///
+/// # Design tokens
+/// * [`helpers::resolve_surface_tokens`](crate::helpers::resolve_surface_tokens) pulls the
+///   palette entry for [`Color`] and merges it with the Joy border radius + focus tokens.
+/// * [`Theme::spacing`](mui_system::theme::Theme::spacing) is leveraged for consistent padding.
+///
+/// # Headless state contract
+/// The component delegates click orchestration to
+/// [`mui_headless::button::ButtonState`], exposed to Yew via
+/// [`helpers::use_button_adapter`](crate::helpers::use_button_adapter). The adapter mirrors the
+/// same state transitions across future Leptos/Dioxus/Sycamore bindings ensuring SSR + hydration
+/// consistency.
 #[function_component(Button)]
 pub fn button(props: &ButtonProps) -> Html {
     let theme = use_theme();
-    let color = match props.color {
-        Color::Primary => theme.palette.primary.clone(),
-        Color::Neutral => theme.palette.neutral.clone(),
-        Color::Danger => theme.palette.danger.clone(),
-    };
-    let style = match props.variant {
-        Variant::Solid => format!(
-            "background:{};color:#fff;border-radius:{}px;",
-            color, theme.joy.radius
+
+    // Resolve design tokens once so we can build the final inline styles declaratively.
+    let surface: SurfaceTokens = resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
+    let padding = format!("{}px {}px", theme.spacing(1), theme.spacing(2));
+
+    let adapter = use_button_adapter(
+        ButtonAdapterConfig {
+            disabled: props.disabled,
+            throttle: props.throttle_ms.map(Duration::from_millis),
+        },
+        props.onclick.clone(),
+    );
+
+    let mut extra = vec![
+        ("padding", padding),
+        ("border", "none".to_string()),
+        (
+            "cursor",
+            if adapter.disabled {
+                "not-allowed".to_string()
+            } else {
+                "pointer".to_string()
+            },
         ),
-        Variant::Soft => format!(
-            "background:{}33;color:{};border-radius:{}px;",
-            color, color, theme.joy.radius
-        ),
-        Variant::Outlined => format!(
-            "color:{};border:1px solid {};background:transparent;border-radius:{}px;",
-            color, color, theme.joy.radius
-        ),
-        Variant::Plain => format!(
-            "color:{};background:transparent;border-radius:{}px;",
-            color, theme.joy.radius
-        ),
-    };
-    let onclick = props.onclick.clone();
-    html! { <button style={style} onclick={onclick}>{ &props.label }</button> }
+        ("transition", "background 120ms ease, color 120ms ease".to_string()),
+    ];
+    let style = surface.compose(extra.drain(..));
+
+    html! {
+        <button
+            style={style}
+            role={adapter.aria.role.clone()}
+            aria-pressed={adapter.aria.aria_pressed.clone()}
+            disabled={adapter.disabled}
+            onclick={adapter.onclick}
+        >
+            { &props.label }
+        </button>
+    }
 }

--- a/crates/mui-joy/src/card.rs
+++ b/crates/mui-joy/src/card.rs
@@ -1,6 +1,7 @@
 use mui_system::theme_provider::use_theme;
 use yew::prelude::*;
 
+use crate::helpers::{resolve_surface_tokens, SurfaceTokens};
 use crate::{joy_component_props, Color, Variant};
 
 joy_component_props!(CardProps {
@@ -8,35 +9,28 @@ joy_component_props!(CardProps {
     children: Children,
 });
 
-/// Simple container mirroring Joy UI's Card component.
+/// Joy UI card built on top of shared design token helpers.
 ///
-/// The implementation intentionally focuses on the core layout primitives
-/// so it can serve as a foundation for more advanced features such as
-/// headers, footers or media sections.
+/// # Design tokens
+/// * [`helpers::resolve_surface_tokens`](crate::helpers::resolve_surface_tokens) aligns the
+///   background/border styling with Joy variants.
+/// * [`Theme::spacing`](mui_system::theme::Theme::spacing) drives the padding rhythm.
+///
+/// # Headless state contract
+/// Cards are purely presentational today and therefore do not bind to a headless state machine.
+/// Downstream adapters simply render the resolved tokens making this component safe to reuse
+/// across Yew, Leptos, Dioxus, and Sycamore.
 #[function_component(Card)]
 pub fn card(props: &CardProps) -> Html {
     let theme = use_theme();
-    // Resolve the color from the active theme's palette.
-    let color = match props.color {
-        Color::Primary => theme.palette.primary.clone(),
-        Color::Neutral => theme.palette.neutral.clone(),
-        Color::Danger => theme.palette.danger.clone(),
-    };
-    // Basic styling demonstrating Joy's variant system.
-    let style = match props.variant {
-        Variant::Solid => format!(
-            "background:{};padding:16px;border-radius:{}px;",
-            color, theme.joy.radius
-        ),
-        Variant::Soft => format!(
-            "background:{}33;padding:16px;border-radius:{}px;",
-            color, theme.joy.radius
-        ),
-        Variant::Outlined => format!(
-            "border:1px solid {};padding:16px;border-radius:{}px;",
-            color, theme.joy.radius
-        ),
-        Variant::Plain => format!("padding:16px;border-radius:{}px;", theme.joy.radius),
-    };
+
+    let surface: SurfaceTokens = resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
+    let padding = format!("{}px", theme.spacing(2));
+    let style = surface.compose([
+        ("padding", padding),
+        ("display", "block".to_string()),
+        ("box-sizing", "border-box".to_string()),
+    ]);
+
     html! { <div style={style}>{ for props.children.iter() }</div> }
 }

--- a/crates/mui-joy/src/chip.rs
+++ b/crates/mui-joy/src/chip.rs
@@ -1,6 +1,12 @@
+use std::time::Duration;
+
 use mui_system::theme_provider::use_theme;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
+use crate::helpers::{
+    compose_inline_style, resolve_surface_tokens, use_chip_adapter, ChipAdapterConfig, SurfaceTokens,
+};
 use crate::{joy_component_props, Color, Variant};
 
 joy_component_props!(ChipProps {
@@ -8,37 +14,146 @@ joy_component_props!(ChipProps {
     label: String,
     /// Optional handler invoked when the delete icon is clicked.
     on_delete: Option<Callback<MouseEvent>>,
+    /// Explicit toggle for the trailing delete affordance. Defaults to `on_delete.is_some()`.
+    dismissible: Option<bool>,
+    /// Whether the chip is interactive.
+    disabled: bool,
+    /// Optional DOM id to link analytics tooling or automation scripts.
+    id: Option<String>,
+    /// Optional `aria-labelledby` reference id.
+    aria_labelledby: Option<String>,
+    /// Optional `aria-describedby` reference id.
+    aria_describedby: Option<String>,
+    /// Delay before the trailing controls become visible (milliseconds).
+    show_delay_ms: Option<u64>,
+    /// Delay before hiding the trailing controls (milliseconds).
+    hide_delay_ms: Option<u64>,
+    /// Grace period before a deletion is committed (milliseconds).
+    delete_delay_ms: Option<u64>,
 });
 
-/// A small piece of information, often used as an input or tag.
+/// Joy UI chip that wires into [`mui_headless::chip::ChipState`].
+///
+/// # Design tokens
+/// * [`helpers::resolve_surface_tokens`](crate::helpers::resolve_surface_tokens) aligns color and
+///   border treatments with Joy's variant system and propagates the shared focus outline tokens.
+/// * The helper derived styles are augmented with layout hints (`display`, `padding`, etc.) so the
+///   component stays consistent across adapters without hand-maintained CSS.
+///
+/// # Headless state contract
+/// The component renders the state exposed by [`mui_headless::chip::ChipState`] via
+/// [`helpers::use_chip_adapter`](crate::helpers::use_chip_adapter). Hover/focus/delete semantics
+/// remain identical across the Yew implementation and future Leptos/Dioxus/Sycamore bindings.
 #[function_component(Chip)]
 pub fn chip(props: &ChipProps) -> Html {
     let theme = use_theme();
-    let color = match props.color {
-        Color::Primary => theme.palette.primary.clone(),
-        Color::Neutral => theme.palette.neutral.clone(),
-        Color::Danger => theme.palette.danger.clone(),
+
+    let surface: SurfaceTokens = resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
+    let dismissible = props.dismissible.unwrap_or_else(|| props.on_delete.is_some());
+    let config = ChipAdapterConfig {
+        dismissible: dismissible && props.on_delete.is_some(),
+        disabled: props.disabled,
+        show_delay: props
+            .show_delay_ms
+            .map(Duration::from_millis)
+            .unwrap_or_else(|| Duration::from_millis(0)),
+        hide_delay: props
+            .hide_delay_ms
+            .map(Duration::from_millis)
+            .unwrap_or_else(|| Duration::from_millis(0)),
+        delete_delay: props
+            .delete_delay_ms
+            .map(Duration::from_millis)
+            .unwrap_or_else(|| Duration::from_millis(0)),
+        id: props.id.clone(),
+        labelled_by: props.aria_labelledby.clone(),
+        described_by: props.aria_describedby.clone(),
     };
-    let style = match props.variant {
-        Variant::Solid => format!(
-            "background:{};color:#fff;border-radius:{}px;padding:4px 8px;",
-            color, theme.joy.radius
-        ),
-        Variant::Soft => format!(
-            "background:{}33;color:{};border-radius:{}px;padding:4px 8px;",
-            color, color, theme.joy.radius
-        ),
-        Variant::Outlined => format!(
-            "border:1px solid {};color:{};border-radius:{}px;padding:4px 8px;",
-            color, color, theme.joy.radius
-        ),
-        Variant::Plain => format!(
-            "color:{};border-radius:{}px;padding:4px 8px;",
-            color, theme.joy.radius
-        ),
+    let adapter = use_chip_adapter(config, props.on_delete.clone());
+
+    if !adapter.visible {
+        return Html::default();
+    }
+
+    let mut extra = vec![
+        ("display", "inline-flex".to_string()),
+        ("align-items", "center".to_string()),
+        ("gap", "4px".to_string()),
+        ("padding", "4px 8px".to_string()),
+        ("user-select", "none".to_string()),
+    ];
+    extra.push((
+        "cursor",
+        if adapter.disabled {
+            "not-allowed".to_string()
+        } else {
+            "pointer".to_string()
+        },
+    ));
+    if adapter.disabled {
+        extra.push(("opacity", "0.6".to_string()));
+    }
+    let style = surface.compose(extra);
+
+    let tabindex: AttrValue = if adapter.disabled {
+        AttrValue::from("-1")
+    } else {
+        AttrValue::from("0")
     };
-    let delete_button = props.on_delete.as_ref().map(|cb| {
-        html! { <button style="margin-left:4px" onclick={cb.clone()}>{{"×"}}</button> }
-    });
-    html! { <span style={style}>{ &props.label }{ delete_button }</span> }
+
+    let delete_button = if (adapter.controls_visible || adapter.deleting)
+        && adapter.on_delete_click.is_some()
+    {
+        let mut delete_style = vec![
+            ("background", "transparent".to_string()),
+            ("border", "none".to_string()),
+            ("padding", "0".to_string()),
+            ("margin-left", "4px".to_string()),
+        ];
+        delete_style.push((
+            "cursor",
+            if adapter.disabled {
+                "not-allowed".to_string()
+            } else {
+                "pointer".to_string()
+            },
+        ));
+        let delete_style = compose_inline_style(delete_style);
+        let onclick = adapter.on_delete_click.as_ref().unwrap().clone();
+        html! {
+            <button
+                type="button"
+                style={delete_style}
+                aria-label="Remove chip"
+                disabled={adapter.disabled}
+                onclick={onclick}
+            >
+                {"×"}
+            </button>
+        }
+    } else {
+        Html::default()
+    };
+
+    html! {
+        <span
+            style={style}
+            role={adapter.aria.role.clone()}
+            aria-hidden={adapter.aria.aria_hidden.clone()}
+            aria-disabled={adapter.aria.aria_disabled.clone()}
+            data-disabled={adapter.aria.data_disabled.clone()}
+            id={adapter.aria.id.clone()}
+            aria-labelledby={adapter.aria.aria_labelledby.clone()}
+            aria-describedby={adapter.aria.aria_describedby.clone()}
+            tabindex={tabindex}
+            onmouseenter={adapter.on_pointer_enter}
+            onmouseleave={adapter.on_pointer_leave}
+            onfocus={adapter.on_focus}
+            onblur={adapter.on_blur}
+            onkeydown={adapter.on_keydown}
+        >
+            { &props.label }
+            { delete_button }
+        </span>
+    }
 }

--- a/crates/mui-joy/src/helpers/mod.rs
+++ b/crates/mui-joy/src/helpers/mod.rs
@@ -1,0 +1,575 @@
+//! Centralised Joy helper utilities shared across framework adapters.
+//!
+//! The helpers deliberately separate three concerns that previously lived
+//! inside the individual component modules:
+//!
+//! * **Design token resolution** – everything that transforms the strongly
+//!   typed [`Theme`](mui_system::theme::Theme) into inline CSS declarations now
+//!   flows through [`resolve_surface_tokens`].  This keeps palette lookups,
+//!   border radius calculations and future theming extensions reusable across
+//!   the Yew/Dioxus/Leptos/Sycamore adapters without hand-maintaining the
+//!   formatting logic in every component.
+//! * **ARIA/automation metadata** – [`aria`] converts the tuples emitted by the
+//!   headless state machines into framework friendly attribute values.  The
+//!   translation lives in one place so enterprise automation suites can rely on
+//!   consistent role/aria/data hooks across renderers.
+//! * **Adapter glue** – [`yew::use_button_adapter`] and
+//!   [`yew::use_chip_adapter`] wrap the [`mui_headless`] state machines inside
+//!   ergonomic hooks.  They expose stable callbacks/events so feature teams can
+//!   bolt on analytics, logging or custom styling without re-implementing the
+//!   headless transitions.
+//!
+//! The module is intentionally verbose with inline documentation so future
+//! contributors understand how to extend the helpers when new Joy primitives
+//! are ported.  The goal is to eliminate repetitive boilerplate and make it
+//! trivial to add enterprise grade behaviour to additional components.
+
+use crate::{Color, Variant};
+use mui_system::theme::{PaletteScheme, Theme};
+
+/// Describes the resolved surface level design tokens for a Joy component.
+///
+/// Consumers pass the struct into [`SurfaceTokens::compose`] to produce inline
+/// styles tailored for the specific component (buttons, chips, cards, etc).
+#[derive(Clone, Debug, PartialEq)]
+pub struct SurfaceTokens {
+    /// Background color applied to the component surface.
+    pub background: Option<String>,
+    /// Foreground/text color emitted alongside the surface background.
+    pub foreground: Option<String>,
+    /// Border declaration matching the Joy variant.
+    pub border: Option<String>,
+    /// Outline declaration driven by the Joy focus tokens.
+    pub focus_outline: Option<String>,
+    /// Corner radius pulled from [`Theme::joy`].
+    pub radius_px: u8,
+}
+
+impl SurfaceTokens {
+    /// Compose a CSS style string using the resolved tokens and any additional
+    /// declarations supplied by the caller (padding, layout, etc).
+    pub fn compose<I>(&self, extra: I) -> String
+    where
+        I: IntoIterator<Item = (&'static str, String)>,
+    {
+        let mut segments = Vec::with_capacity(6);
+        if let Some(background) = &self.background {
+            segments.push(("background", background.clone()));
+        }
+        if let Some(foreground) = &self.foreground {
+            segments.push(("color", foreground.clone()));
+        }
+        if let Some(border) = &self.border {
+            segments.push(("border", border.clone()));
+        }
+        segments.push(("border-radius", format!("{}px", self.radius_px)));
+        if let Some(outline) = &self.focus_outline {
+            segments.push(("outline", outline.clone()));
+            // Align focus outlines with Joy defaults so we get a subtle inset
+            // shadow instead of the browser default thick blue ring.
+            segments.push(("outline-offset", format!("-{}px", self.radius_px.min(4))));
+        }
+        segments.extend(extra);
+        compose_inline_style(segments)
+    }
+}
+
+/// Convenience helper for turning key/value pairs into an inline CSS string.
+pub fn compose_inline_style<I>(pairs: I) -> String
+where
+    I: IntoIterator<Item = (&'static str, String)>,
+{
+    pairs
+        .into_iter()
+        .map(|(key, value)| format!("{key}:{value};"))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+/// Resolve the active palette entry for the requested Joy color.
+fn palette_color(theme: &Theme, color: Color) -> String {
+    let palette: &PaletteScheme = theme.palette.active();
+    match color {
+        Color::Primary => palette.primary.clone(),
+        Color::Neutral => palette.neutral.clone(),
+        Color::Danger => palette.danger.clone(),
+    }
+}
+
+/// Convert a base color into an 8-digit hex string with the supplied alpha.
+fn with_alpha(color: &str, alpha: &str) -> String {
+    format!("{color}{alpha}")
+}
+
+/// Resolve Joy surface tokens for a given color + variant pairing.
+pub fn resolve_surface_tokens(theme: &Theme, color: Color, variant: Variant) -> SurfaceTokens {
+    let palette_color = palette_color(theme, color);
+    let radius = theme.joy.radius;
+    let focus_outline = Some(format!("{}px solid {}", theme.joy.focus_thickness, palette_color));
+
+    match variant {
+        Variant::Solid => SurfaceTokens {
+            background: Some(palette_color.clone()),
+            foreground: Some("#fff".to_string()),
+            border: Some("none".to_string()),
+            focus_outline,
+            radius_px: radius,
+        },
+        Variant::Soft => SurfaceTokens {
+            background: Some(with_alpha(&palette_color, "33")),
+            foreground: Some(palette_color.clone()),
+            border: Some("none".to_string()),
+            focus_outline,
+            radius_px: radius,
+        },
+        Variant::Outlined => SurfaceTokens {
+            background: Some("transparent".to_string()),
+            foreground: Some(palette_color.clone()),
+            border: Some(format!("1px solid {}", palette_color)),
+            focus_outline,
+            radius_px: radius,
+        },
+        Variant::Plain => SurfaceTokens {
+            background: Some("transparent".to_string()),
+            foreground: Some(palette_color.clone()),
+            border: Some("none".to_string()),
+            focus_outline,
+            radius_px: radius,
+        },
+    }
+}
+
+/// Pre-computed inline styles for the Joy `AspectRatio` primitive.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AspectRatioStyles {
+    /// Wrapper element style which enforces the padding-top hack.
+    pub outer: String,
+    /// Inner element style that pins the content to the wrapper.
+    pub inner: String,
+}
+
+/// Resolve the inline styles required to maintain the provided aspect ratio.
+pub fn resolve_aspect_ratio_styles(ratio: f32) -> AspectRatioStyles {
+    assert!(ratio > 0.0, "aspect ratio must be positive");
+    let outer = format!(
+        "position:relative;width:100%;padding-top:{}%;",
+        100.0 / ratio
+    );
+    let inner = "position:absolute;top:0;left:0;width:100%;height:100%;".to_string();
+    AspectRatioStyles { outer, inner }
+}
+
+#[cfg(feature = "yew")]
+mod aria {
+    use mui_headless::aria;
+    use mui_headless::chip::{ChipAttributes, ChipState};
+    use yew::virtual_dom::AttrValue;
+
+    use super::ChipAdapterConfig;
+
+    /// Standardised ARIA attributes for Joy buttons.
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct ButtonAria {
+        pub role: AttrValue,
+        pub aria_pressed: AttrValue,
+    }
+
+    impl ButtonAria {
+        pub fn from_pairs(pairs: [(&'static str, &'static str); 2]) -> Self {
+            let mut role = aria::role_button();
+            let mut pressed = "false";
+            for (name, value) in pairs {
+                match name {
+                    "role" => role = value,
+                    "aria-pressed" => pressed = value,
+                    _ => {}
+                }
+            }
+            Self {
+                role: AttrValue::from(role),
+                aria_pressed: AttrValue::from(pressed),
+            }
+        }
+    }
+
+    /// Standardised ARIA attributes for Joy chips.
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct ChipAria {
+        pub role: AttrValue,
+        pub aria_hidden: AttrValue,
+        pub aria_disabled: Option<AttrValue>,
+        pub data_disabled: Option<AttrValue>,
+        pub id: Option<AttrValue>,
+        pub aria_labelledby: Option<AttrValue>,
+        pub aria_describedby: Option<AttrValue>,
+    }
+
+    impl ChipAria {
+        pub fn from_state(state: &ChipState, config: &ChipAdapterConfig) -> Self {
+            let mut builder = ChipAttributes::new(state);
+            if let Some(id) = config.id.as_deref() {
+                builder = builder.id(id);
+            }
+            if let Some(value) = config.labelled_by.as_deref() {
+                builder = builder.labelled_by(value);
+            }
+            if let Some(value) = config.described_by.as_deref() {
+                builder = builder.described_by(value);
+            }
+
+            let role = AttrValue::from(builder.role());
+            let hidden = builder.hidden();
+            let aria_hidden = AttrValue::from(hidden.1);
+            let aria_disabled = builder
+                .disabled()
+                .map(|(_, value)| AttrValue::from(value));
+            let data_disabled = builder
+                .data_disabled()
+                .map(|(_, value)| AttrValue::from(value));
+            let id = builder.id_attr().map(|(_, value)| AttrValue::from(value));
+            let aria_labelledby = builder
+                .labelledby()
+                .map(|(_, value)| AttrValue::from(value));
+            let aria_describedby = builder
+                .describedby()
+                .map(|(_, value)| AttrValue::from(value));
+
+            Self {
+                role,
+                aria_hidden,
+                aria_disabled,
+                data_disabled,
+                id,
+                aria_labelledby,
+                aria_describedby,
+            }
+        }
+    }
+
+    pub use ButtonAria as Button;
+    pub use ChipAria as Chip;
+}
+
+#[cfg(feature = "yew")]
+pub use aria::{Button as ButtonAria, Chip as ChipAria};
+
+#[cfg(feature = "yew")]
+mod yew_adapters {
+    use std::time::Duration;
+
+    use gloo_timers::callback::Interval;
+    use mui_headless::button::ButtonState;
+    use mui_headless::chip::{ChipChange, ChipConfig, ChipState};
+    use yew::prelude::*;
+
+    use super::{aria, ChipAria};
+
+    /// Configuration passed into [`use_button_adapter`].
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct ButtonAdapterConfig {
+        pub disabled: bool,
+        pub throttle: Option<Duration>,
+    }
+
+    impl Default for ButtonAdapterConfig {
+        fn default() -> Self {
+            Self {
+                disabled: false,
+                throttle: None,
+            }
+        }
+    }
+
+    /// Aggregated adapter output returned from [`use_button_adapter`].
+    pub struct ButtonAdapter {
+        pub onclick: Callback<MouseEvent>,
+        pub aria: aria::ButtonAria,
+        pub disabled: bool,
+    }
+
+    /// Hook exposing the [`mui_headless::button::ButtonState`] state machine to Yew.
+    pub fn use_button_adapter(
+        config: ButtonAdapterConfig,
+        on_press: Callback<MouseEvent>,
+    ) -> ButtonAdapter {
+        let state = use_mut_ref(|| ButtonState::new(config.disabled, config.throttle));
+        let rerender = use_state(|| 0u64);
+
+        {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            use_effect_with_deps(
+                move |config: &ButtonAdapterConfig| {
+                    *state.borrow_mut() = ButtonState::new(config.disabled, config.throttle);
+                    rerender.set(*rerender + 1);
+                    || ()
+                },
+                config.clone(),
+            );
+        }
+
+        let onclick = {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            let on_press = on_press.clone();
+            Callback::from(move |event: MouseEvent| {
+                let event_clone = event.clone();
+                let mut triggered = false;
+                state.borrow_mut().press(|_| {
+                    triggered = true;
+                    on_press.emit(event_clone);
+                });
+                if triggered {
+                    rerender.set(*rerender + 1);
+                }
+            })
+        };
+
+        let aria = {
+            let state_ref = state.borrow();
+            aria::ButtonAria::from_pairs(state_ref.aria_attributes())
+        };
+
+        ButtonAdapter {
+            onclick,
+            aria,
+            disabled: config.disabled,
+        }
+    }
+
+    /// Configuration for the Joy chip adapter.
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct ChipAdapterConfig {
+        pub dismissible: bool,
+        pub disabled: bool,
+        pub show_delay: Duration,
+        pub hide_delay: Duration,
+        pub delete_delay: Duration,
+        pub id: Option<String>,
+        pub labelled_by: Option<String>,
+        pub described_by: Option<String>,
+    }
+
+    impl ChipAdapterConfig {
+        pub fn headless_config(&self) -> ChipConfig {
+            ChipConfig {
+                show_delay: self.show_delay,
+                hide_delay: self.hide_delay,
+                delete_delay: self.delete_delay,
+                dismissible: self.dismissible,
+                disabled: self.disabled,
+            }
+        }
+    }
+
+    impl Default for ChipAdapterConfig {
+        fn default() -> Self {
+            Self {
+                dismissible: false,
+                disabled: false,
+                show_delay: Duration::from_millis(0),
+                hide_delay: Duration::from_millis(0),
+                delete_delay: Duration::from_millis(0),
+                id: None,
+                labelled_by: None,
+                described_by: None,
+            }
+        }
+    }
+
+    /// Adapter output consumed by the Joy chip component.
+    pub struct ChipAdapter {
+        pub visible: bool,
+        pub controls_visible: bool,
+        pub deleting: bool,
+        pub aria: ChipAria,
+        pub on_pointer_enter: Callback<MouseEvent>,
+        pub on_pointer_leave: Callback<MouseEvent>,
+        pub on_focus: Callback<FocusEvent>,
+        pub on_blur: Callback<FocusEvent>,
+        pub on_keydown: Callback<KeyboardEvent>,
+        pub on_delete_click: Option<Callback<MouseEvent>>,
+        pub disabled: bool,
+    }
+
+    fn process_chip_change(
+        change: ChipChange,
+        rerender: &UseStateHandle<u64>,
+        delete_cb: Option<&Callback<MouseEvent>>,
+        event: Option<MouseEvent>,
+    ) {
+        let mut needs_render = false;
+        if change.controls_visible.is_some() || change.deletion_cancelled {
+            needs_render = true;
+        }
+        if change.deleted {
+            needs_render = true;
+            if let (Some(callback), Some(event)) = (delete_cb, event) {
+                callback.emit(event);
+            }
+        }
+        if needs_render {
+            rerender.set(*rerender + 1);
+        }
+    }
+
+    /// Hook exposing the [`mui_headless::chip::ChipState`] state machine to Yew.
+    pub fn use_chip_adapter(
+        config: ChipAdapterConfig,
+        on_delete: Option<Callback<MouseEvent>>,
+    ) -> ChipAdapter {
+        let state = use_mut_ref(|| ChipState::new(config.headless_config()));
+        let rerender = use_state(|| 0u64);
+
+        {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            use_effect_with_deps(
+                move |config: &ChipAdapterConfig| {
+                    *state.borrow_mut() = ChipState::new(config.headless_config());
+                    rerender.set(*rerender + 1);
+                    || ()
+                },
+                config.clone(),
+            );
+        }
+
+        {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            let delete_cb = on_delete.clone();
+            use_effect(move || {
+                let interval = Interval::new(32, move || {
+                    let change = state.borrow_mut().poll();
+                    process_chip_change(change, &rerender, delete_cb.as_ref(), None);
+                });
+                move || drop(interval)
+            });
+        }
+
+        let on_pointer_enter = {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            let delete_cb = on_delete.clone();
+            Callback::from(move |event: MouseEvent| {
+                event.stop_propagation();
+                let change = state.borrow_mut().pointer_enter();
+                process_chip_change(change, &rerender, delete_cb.as_ref(), None);
+            })
+        };
+
+        let on_pointer_leave = {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            let delete_cb = on_delete.clone();
+            Callback::from(move |event: MouseEvent| {
+                event.stop_propagation();
+                let change = state.borrow_mut().pointer_leave();
+                process_chip_change(change, &rerender, delete_cb.as_ref(), None);
+            })
+        };
+
+        let on_focus = {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            let delete_cb = on_delete.clone();
+            Callback::from(move |_event: FocusEvent| {
+                let change = state.borrow_mut().focus();
+                process_chip_change(change, &rerender, delete_cb.as_ref(), None);
+            })
+        };
+
+        let on_blur = {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            let delete_cb = on_delete.clone();
+            Callback::from(move |_event: FocusEvent| {
+                let change = state.borrow_mut().blur();
+                process_chip_change(change, &rerender, delete_cb.as_ref(), None);
+            })
+        };
+
+        let on_keydown = {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            let delete_cb = on_delete.clone();
+            Callback::from(move |event: KeyboardEvent| {
+                let key = event.key();
+                let change = match key.as_str() {
+                    "Delete" | "Backspace" => {
+                        event.prevent_default();
+                        state.borrow_mut().request_delete()
+                    }
+                    "Escape" => {
+                        event.prevent_default();
+                        state.borrow_mut().escape()
+                    }
+                    _ => return,
+                };
+                process_chip_change(change, &rerender, delete_cb.as_ref(), None);
+            })
+        };
+
+        let on_delete_click = on_delete.clone().map(|callback| {
+            let state = state.clone();
+            let rerender = rerender.clone();
+            Callback::from(move |event: MouseEvent| {
+                event.prevent_default();
+                event.stop_propagation();
+                let event_clone = event.clone();
+                let change = state.borrow_mut().request_delete();
+                process_chip_change(change, &rerender, Some(&callback), Some(event_clone));
+            })
+        });
+
+        let aria = {
+            let state_ref = state.borrow();
+            super::aria::Chip::from_state(&state_ref, &config)
+        };
+
+        let state_ref = state.borrow();
+        ChipAdapter {
+            visible: state_ref.is_visible(),
+            controls_visible: state_ref.controls_visible(),
+            deleting: state_ref.deletion_pending(),
+            aria,
+            on_pointer_enter,
+            on_pointer_leave,
+            on_focus,
+            on_blur,
+            on_keydown,
+            on_delete_click,
+            disabled: config.disabled,
+        }
+    }
+
+    pub use ButtonAdapter as Button;
+    pub use ButtonAdapterConfig as ButtonConfig;
+    pub use ChipAdapter as Chip;
+    pub use ChipAdapterConfig as ChipConfig;
+}
+
+#[cfg(feature = "yew")]
+pub use yew_adapters::{use_button_adapter, use_chip_adapter, Button as ButtonAdapter, ButtonConfig as ButtonAdapterConfig, Chip as ChipAdapter, ChipConfig as ChipAdapterConfig};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Color, Variant};
+    use mui_system::theme::Theme;
+
+    #[test]
+    fn surface_tokens_resolve() {
+        let theme = Theme::default();
+        let tokens = resolve_surface_tokens(&theme, Color::Primary, Variant::Soft);
+        assert_eq!(tokens.radius_px, theme.joy.radius);
+        assert!(tokens.background.unwrap().ends_with("33"));
+    }
+
+    #[test]
+    fn aspect_ratio_styles_are_generated() {
+        let styles = resolve_aspect_ratio_styles(16.0 / 9.0);
+        assert!(styles.outer.contains("padding-top"));
+        assert!(styles.inner.contains("position:absolute"));
+    }
+}

--- a/crates/mui-joy/src/lib.rs
+++ b/crates/mui-joy/src/lib.rs
@@ -29,6 +29,7 @@
 //! primitives behave consistently across frameworks. This design avoids manual repetitive
 //! glue code and ensures future adapters reuse the exact same prop contracts.
 
+pub mod helpers;
 #[cfg(feature = "yew")]
 pub mod accordion;
 #[cfg(feature = "yew")]


### PR DESCRIPTION
## Summary
- add a Joy helpers module that centralizes design token resolution, ARIA attribute mapping, and Yew adapters over the headless state machines
- refactor the Button, Card, Chip, and AspectRatio components to consume the helpers while expanding their documentation
- wire the new helpers into the crate exports and enable timer support for chip polling

## Testing
- `cargo fmt`
- `cargo check --manifest-path crates/mui-joy/Cargo.toml --features yew` *(fails: crate expects to be part of the top-level workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a02b958c832e804a90082f1e78d6