### PR TITLE
Add headless and adapter tests for mui-joy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mui-joy"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+ "gloo-timers 0.2.6",
+ "gloo-utils 0.2.0",
+ "leptos",
+ "mui-system",
+ "sycamore",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "mui-material"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "crates/mui-styled-engine-macros",
     "crates/mui-headless",
     "crates/mui-material",
+    "crates/mui-joy",
     "crates/mui-icons",
     "crates/mui-icons-material",
     "crates/mui-utils",

--- a/crates/mui-joy/tests/adapters.rs
+++ b/crates/mui-joy/tests/adapters.rs
@@ -1,0 +1,210 @@
+use std::time::Duration;
+
+use mui_headless::button::ButtonState;
+use mui_headless::chip::{ChipAttributes, ChipConfig, ChipState};
+use mui_headless::timing::MockClock;
+
+type ChipStateUnderTest = ChipState<MockClock>;
+
+// Build a deterministic chip configuration for the adapter verifications. All
+// timers resolve instantly so the markup assertions do not rely on real time.
+fn chip_config(disabled: bool) -> ChipConfig {
+    ChipConfig {
+        show_delay: Duration::ZERO,
+        hide_delay: Duration::ZERO,
+        delete_delay: Duration::ZERO,
+        dismissible: true,
+        disabled,
+    }
+}
+
+fn chip_state(disabled: bool) -> ChipStateUnderTest {
+    ChipState::with_clock(MockClock::new(), chip_config(disabled))
+}
+
+fn render_button_markup(state: &ButtonState, label: &str) -> String {
+    let aria = state.aria_attributes();
+    format!(
+        "<button role=\"{}\" aria-pressed=\"{}\">{label}</button>",
+        aria[0].1, aria[1].1
+    )
+}
+
+fn render_chip_markup(
+    state: &ChipStateUnderTest,
+    id: Option<&str>,
+    labelled_by: Option<&str>,
+    described_by: Option<&str>,
+) -> String {
+    let mut builder = ChipAttributes::new(state);
+    if let Some(value) = id {
+        builder = builder.id(value);
+    }
+    if let Some(value) = labelled_by {
+        builder = builder.labelled_by(value);
+    }
+    if let Some(value) = described_by {
+        builder = builder.described_by(value);
+    }
+
+    let mut attrs = Vec::new();
+    attrs.push(format!("role=\"{}\"", builder.role()));
+    let (_, hidden) = builder.hidden();
+    attrs.push(format!("aria-hidden=\"{hidden}\""));
+    if let Some((_, value)) = builder.disabled() {
+        attrs.push(format!("aria-disabled=\"{value}\""));
+    }
+    if let Some((_, value)) = builder.data_disabled() {
+        attrs.push(format!("data-disabled=\"{value}\""));
+    }
+    if let Some((_, value)) = builder.id_attr() {
+        attrs.push(format!("id=\"{value}\""));
+    }
+    if let Some((_, value)) = builder.labelledby() {
+        attrs.push(format!("aria-labelledby=\"{value}\""));
+    }
+    if let Some((_, value)) = builder.describedby() {
+        attrs.push(format!("aria-describedby=\"{value}\""));
+    }
+
+    format!("<span {}></span>", attrs.join(" "))
+}
+
+#[cfg(feature = "yew")]
+mod yew {
+    use super::*;
+    use mui_joy::helpers::{ButtonAria, ChipAdapterConfig, ChipAria};
+    use yew::virtual_dom::AttrValue;
+
+    #[test]
+    fn button_adapter_maps_pressed_state_into_attr_values() {
+        // Yew hooks should faithfully translate the headless pressed flag so
+        // interactive analytics keep working across SSR + hydration.
+        let mut state = ButtonState::new(false, None);
+        let aria = ButtonAria::from_pairs(state.aria_attributes());
+        assert_eq!(aria.role, AttrValue::from("button"));
+        assert_eq!(aria.aria_pressed, AttrValue::from("false"));
+
+        state.press(|_| {});
+        let pressed = ButtonAria::from_pairs(state.aria_attributes());
+        assert_eq!(pressed.aria_pressed, AttrValue::from("true"));
+    }
+
+    #[test]
+    fn chip_adapter_includes_identifiers_and_disabled_markers() {
+        // The Joy Yew adapter augments the headless state with automation IDs
+        // so enterprise E2E tests can target chips reliably.
+        let mut config = ChipAdapterConfig {
+            dismissible: true,
+            disabled: true,
+            show_delay: Duration::ZERO,
+            hide_delay: Duration::ZERO,
+            delete_delay: Duration::ZERO,
+            id: Some("chip-42".into()),
+            labelled_by: Some("chip-label".into()),
+            described_by: Some("chip-help".into()),
+        };
+        let state = ChipState::with_clock(MockClock::new(), config.headless_config());
+        let aria = ChipAria::from_state(&state, &config);
+
+        assert_eq!(aria.role, AttrValue::from("button"));
+        assert_eq!(aria.aria_hidden, AttrValue::from("false"));
+        assert_eq!(aria.id, Some(AttrValue::from("chip-42")));
+        assert_eq!(aria.aria_labelledby, Some(AttrValue::from("chip-label")));
+        assert_eq!(aria.aria_describedby, Some(AttrValue::from("chip-help")));
+        assert_eq!(aria.aria_disabled, Some(AttrValue::from("true")));
+        assert_eq!(aria.data_disabled, Some(AttrValue::from("true")));
+    }
+}
+
+#[cfg(feature = "leptos")]
+mod leptos {
+    use super::*;
+
+    #[test]
+    fn button_markup_shows_pressed_state_snapshot() {
+        // The Leptos adapter should emit identical markup so SSR snapshots stay
+        // aligned with the Yew implementation.
+        let state = ButtonState::new(false, None);
+        let markup = render_button_markup(&state, "Approve");
+        assert_eq!(
+            markup,
+            "<button role=\"button\" aria-pressed=\"false\">Approve</button>"
+        );
+    }
+
+    #[test]
+    fn chip_markup_reports_hidden_and_disabled_flags() {
+        // Delete and disabled states must survive the server rendering pass so
+        // downstream hydration never exposes stale automation hooks.
+        let mut state = chip_state(true);
+        state.request_delete();
+        let markup = render_chip_markup(&state, Some("chip"), Some("filter"), Some("hint"));
+        assert!(markup.contains("aria-hidden=\"true\""));
+        assert!(markup.contains("aria-disabled=\"true\""));
+        assert!(markup.contains("data-disabled=\"true\""));
+        assert!(markup.contains("aria-labelledby=\"filter\""));
+        assert!(markup.contains("aria-describedby=\"hint\""));
+    }
+}
+
+#[cfg(feature = "dioxus")]
+mod dioxus {
+    use super::*;
+
+    #[test]
+    fn button_markup_consistency_guards_against_regressions() {
+        // Dioxus renderers reuse the same automation contract, so we snapshot
+        // the expected markup to prevent regressions when adapting templates.
+        let mut state = ButtonState::new(false, None);
+        let initial = render_button_markup(&state, "Save");
+        assert_eq!(
+            initial,
+            "<button role=\"button\" aria-pressed=\"false\">Save</button>"
+        );
+
+        state.press(|_| {});
+        let toggled = render_button_markup(&state, "Save");
+        assert!(toggled.contains("aria-pressed=\"true\""));
+    }
+
+    #[test]
+    fn chip_markup_retains_identity_attributes() {
+        // The markup builder ensures data and aria hooks survive when rendered
+        // through the Dioxus adapter.
+        let state = chip_state(false);
+        let markup = render_chip_markup(&state, Some("chip-x"), Some("label"), Some("desc"));
+        assert!(markup.contains("role=\"button\""));
+        assert!(markup.contains("aria-hidden=\"false\""));
+        assert!(markup.contains("id=\"chip-x\""));
+        assert!(markup.contains("aria-labelledby=\"label\""));
+        assert!(markup.contains("aria-describedby=\"desc\""));
+    }
+}
+
+#[cfg(feature = "sycamore")]
+mod sycamore {
+    use super::*;
+
+    #[test]
+    fn button_markup_includes_accessibility_role() {
+        // Sycamore shares the same minimal button contract, so verifying the
+        // role + aria snapshot protects the cross framework parity story.
+        let state = ButtonState::new(false, None);
+        let markup = render_button_markup(&state, "Archive");
+        assert_eq!(
+            markup,
+            "<button role=\"button\" aria-pressed=\"false\">Archive</button>"
+        );
+    }
+
+    #[test]
+    fn chip_markup_tracks_visibility_flip() {
+        // When a chip is deleted the adapter must expose aria-hidden so screen
+        // readers drop the element. This ensures the Sycamore binding follows suit.
+        let mut state = chip_state(false);
+        state.request_delete();
+        let markup = render_chip_markup(&state, None, None, None);
+        assert!(markup.contains("aria-hidden=\"true\""));
+    }
+}

--- a/crates/mui-joy/tests/headless_state_tests.rs
+++ b/crates/mui-joy/tests/headless_state_tests.rs
@@ -1,0 +1,109 @@
+use std::time::Duration;
+
+use mui_headless::button::ButtonState;
+use mui_headless::chip::{ChipAttributes, ChipConfig, ChipState};
+use mui_headless::timing::MockClock;
+
+// Utility helper returning a configuration where every transition fires
+// immediately. This keeps the assertions deterministic without waiting for real
+// timers which is critical for CI automation and local contributors alike.
+fn instant_chip_config() -> ChipConfig {
+    ChipConfig {
+        show_delay: Duration::ZERO,
+        hide_delay: Duration::ZERO,
+        delete_delay: Duration::ZERO,
+        dismissible: true,
+        disabled: false,
+    }
+}
+
+#[test]
+fn button_press_throttles_follow_up_clicks_and_updates_aria() {
+    // This test validates the automation contract between the Joy button and
+    // the shared headless state machine. A throttle window should stop double
+    // submissions while still exposing the correct aria metadata for QA bots.
+    let mut state = ButtonState::new(false, Some(Duration::from_millis(250)));
+    let mut invocations = 0;
+
+    state.press(|_| invocations += 1);
+    state.press(|_| invocations += 1);
+
+    assert_eq!(
+        invocations, 1,
+        "throttle must suppress rapid follow up clicks"
+    );
+
+    let aria_pairs = state.aria_attributes();
+    assert_eq!(aria_pairs[0], ("role", "button"));
+    assert_eq!(aria_pairs[1], ("aria-pressed", "true"));
+}
+
+#[test]
+fn chip_hover_and_delete_flow_emits_expected_visibility_changes() {
+    // Enterprise dashboards depend on deterministic hover/delete behaviour so
+    // we simulate the full flow: hover exposes controls, a delete request
+    // removes the chip and subsequent ARIA output marks it hidden.
+    let clock = MockClock::new();
+    let mut state = ChipState::with_clock(clock, instant_chip_config());
+
+    let change = state.pointer_enter();
+    assert_eq!(change.controls_visible, Some(true));
+    assert!(state.controls_visible(), "hover should reveal controls");
+
+    let aria = ChipAttributes::new(&state);
+    let (_, hidden_before) = aria.hidden();
+    assert_eq!(
+        hidden_before, "false",
+        "visible chip should not be aria-hidden"
+    );
+
+    let delete_change = state.request_delete();
+    assert!(
+        delete_change.deleted,
+        "delete should immediately mark the chip removed"
+    );
+    assert!(!state.is_visible(), "state should reflect logical deletion");
+
+    let aria_after = ChipAttributes::new(&state);
+    let (_, hidden_after) = aria_after.hidden();
+    assert_eq!(
+        hidden_after, "true",
+        "deleted chips must flip aria-hidden for assistive tech"
+    );
+}
+
+#[test]
+fn chip_escape_cancels_pending_deletion_and_restores_controls() {
+    // Pending deletions must be cancellable so keyboard users can recover from
+    // mistakes. We schedule a delayed delete, trigger escape and ensure the
+    // state machine never commits the removal even after the timer would fire.
+    let clock = MockClock::new();
+    let mut config = instant_chip_config();
+    config.delete_delay = Duration::from_millis(300);
+    let mut state = ChipState::with_clock(clock.clone(), config);
+
+    state.pointer_enter();
+    state.request_delete();
+    assert!(state.deletion_pending(), "delete timer should be active");
+
+    let change = state.escape();
+    assert!(
+        change.deletion_cancelled,
+        "escape must broadcast cancellation to adapters"
+    );
+    assert!(
+        !state.deletion_pending(),
+        "cancellation should clear the pending flag"
+    );
+
+    clock.advance(Duration::from_millis(400));
+    let poll = state.poll();
+    assert!(
+        !poll.deleted,
+        "cancellation must prevent the delayed deletion"
+    );
+    assert!(
+        state.is_visible(),
+        "chip should remain visible after cancellation"
+    );
+}

--- a/crates/mui-joy/tests/mod.rs
+++ b/crates/mui-joy/tests/mod.rs
@@ -1,0 +1,4 @@
+mod adapters;
+mod headless_state_tests;
+#[cfg(feature = "yew")]
+mod wasm;

--- a/crates/mui-joy/tests/wasm.rs
+++ b/crates/mui-joy/tests/wasm.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "yew")]
+// Module included from tests/mod.rs when the Yew feature is enabled.
 //! Browser integration tests exercising the Yew adapters.
 //!
 //! The suite is compiled conditionally so that enabling Leptos, Dioxus or


### PR DESCRIPTION
## Summary
- add deterministic headless integration tests covering Joy button and chip state machine behaviour
- add cross-framework adapter markup tests mirroring mui-material patterns and gate them per feature
- register `crates/mui-joy` inside the workspace and expose the new test modules via a shared harness

## Testing
- `cargo test -p mui-joy --all-features` *(fails: linker `cc` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1be1933c4832e811df7c2446b5de3