### PR TITLE
Add axe accessibility harness for Joy wasm tests

### DIFF
--- a/crates/mui-joy/tests/axe.js
+++ b/crates/mui-joy/tests/axe.js
@@ -1,0 +1,9 @@
+import axe from 'axe-core';
+
+// Wrapper function exposed to wasm tests.  It runs axe-core against the
+// provided DOM node and returns the violations collection for lightweight
+// marshaling back into Rust.
+export async function runAxe(node) {
+  const results = await axe.run(node);
+  return { violations: results.violations };
+}

--- a/crates/mui-joy/tests/axe.rs
+++ b/crates/mui-joy/tests/axe.rs
@@ -1,0 +1,39 @@
+#![cfg(feature = "yew")]
+
+//! Thin wasm-bindgen bridge exposing the `axe-core` accessibility engine to
+//! Rust-based web integration tests.
+//!
+//! The `wasm_bindgen` macro wires in the JavaScript implementation that lives
+//! alongside the test suite (`axe.js`).  Keeping the interop layer centralized
+//! minimizes boilerplate inside individual test cases and makes it trivial to
+//! expand coverage across additional Joy UI components.
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+#[wasm_bindgen(module = "/tests/axe.js")]
+extern "C" {
+    #[wasm_bindgen(catch)]
+    async fn runAxe(node: JsValue) -> Result<JsValue, JsValue>;
+}
+
+/// Execute an axe-core audit against the provided DOM node, panicking if any
+/// violations are encountered.
+///
+/// Centralizing this logic ensures every test benefits from consistent
+/// assertions and verbose failure messages, delivering actionable feedback when
+/// regressions slip in.
+pub async fn axe_check(node: &web_sys::Element) {
+    // Invoke the JS bridge and unwrap the resulting Promise, bubbling up any
+    // underlying errors so the test harness surfaces them immediately.
+    let result = runAxe(node.clone().into())
+        .await
+        .expect("axe-core execution failed");
+
+    // Extract and validate the violations array.  An empty list indicates the
+    // component tree satisfied all configured accessibility rules.
+    let violations = js_sys::Reflect::get(&result, &JsValue::from_str("violations"))
+        .expect("missing violations field");
+    let arr = js_sys::Array::from(&violations);
+    assert_eq!(arr.length(), 0, "Accessibility violations: {:?}", arr);
+}

--- a/crates/mui-joy/tests/wasm.rs
+++ b/crates/mui-joy/tests/wasm.rs
@@ -5,6 +5,9 @@
 //! Sycamore without the Yew feature still produces a clean build focussed on
 //! the framework-neutral prop definitions.
 
+mod axe;
+
+use axe::axe_check;
 use mui_joy::{AspectRatio, Button, Chip, Color, Variant};
 use mui_system::theme_provider::ThemeProvider;
 use mui_system::Theme;
@@ -14,11 +17,39 @@ use yew::Renderer;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+/// Create and append a DOM mount point that individual tests can reuse.
+///
+/// Centralizing the scaffolding keeps each test focussed on behaviour and
+/// accessibility assertions rather than the mechanics of DOM construction.
+fn mount_host() -> web_sys::Element {
+    let document = gloo_utils::document();
+    let mount = document
+        .create_element("div")
+        .expect("failed to create mount point");
+    document
+        .body()
+        .expect("missing <body> element")
+        .append_child(&mount)
+        .expect("failed to insert mount point");
+    mount
+}
+
+/// Remove the temporary mount point created via [`mount_host`].  This ensures
+/// every test leaves the DOM in a known-good state, which is critical when the
+/// wasm test harness runs suites sequentially in the same document.
+fn teardown_host(mount: &web_sys::Element) {
+    let document = gloo_utils::document();
+    let mount_node: web_sys::Node = mount.clone().into();
+    document
+        .body()
+        .expect("missing <body> element")
+        .remove_child(&mount_node)
+        .expect("failed to remove mount point");
+}
+
 #[wasm_bindgen_test]
 fn button_clicks_increment() {
-    let document = gloo_utils::document();
-    let mount = document.create_element("div").unwrap();
-    document.body().unwrap().append_child(&mount).unwrap();
+    let mount = mount_host();
 
     #[function_component(App)]
     fn app() -> Html {
@@ -43,13 +74,13 @@ fn button_clicks_increment() {
 
     let count = mount.query_selector("#count").unwrap().unwrap();
     assert_eq!(count.text_content().unwrap(), "1");
+
+    teardown_host(&mount);
 }
 
 #[wasm_bindgen_test]
 fn chip_delete_triggers_callback() {
-    let document = gloo_utils::document();
-    let mount = document.create_element("div").unwrap();
-    document.body().unwrap().append_child(&mount).unwrap();
+    let mount = mount_host();
 
     #[function_component(App)]
     fn app() -> Html {
@@ -74,13 +105,13 @@ fn chip_delete_triggers_callback() {
 
     let count = mount.query_selector("#count").unwrap().unwrap();
     assert_eq!(count.text_content().unwrap(), "1");
+
+    teardown_host(&mount);
 }
 
 #[wasm_bindgen_test]
 fn aspect_ratio_sets_padding() {
-    let document = gloo_utils::document();
-    let mount = document.create_element("div").unwrap();
-    document.body().unwrap().append_child(&mount).unwrap();
+    let mount = mount_host();
 
     #[function_component(App)]
     fn app() -> Html {
@@ -96,4 +127,60 @@ fn aspect_ratio_sets_padding() {
     let outer = mount.first_element_child().unwrap();
     let style = outer.get_attribute("style").unwrap();
     assert!(style.contains("56.25%"));
+
+    teardown_host(&mount);
+}
+
+#[wasm_bindgen_test]
+async fn button_is_accessible() {
+    let mount = mount_host();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <Button label="Add" color={Color::Primary} variant={Variant::Solid} />
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+    axe_check(&mount).await;
+    teardown_host(&mount);
+}
+
+#[wasm_bindgen_test]
+async fn chip_is_accessible() {
+    let mount = mount_host();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <Chip label="Filter" color={Color::Success} variant={Variant::Soft} />
+            </ThemeProvider>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+    axe_check(&mount).await;
+    teardown_host(&mount);
+}
+
+#[wasm_bindgen_test]
+async fn aspect_ratio_is_accessible() {
+    let mount = mount_host();
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <AspectRatio ratio={4.0 / 3.0}>
+                <img src="https://via.placeholder.com/400x300" alt="placeholder" />
+            </AspectRatio>
+        }
+    }
+
+    Renderer::<App>::with_root(mount.clone()).render();
+    axe_check(&mount).await;
+    teardown_host(&mount);
 }


### PR DESCRIPTION
## Summary
- add an axe-core wasm bridge for Joy UI browser tests
- wire wasm tests to reuse the shared mount helpers and invoke axe audits
- include a JS harness that exposes axe-core to the wasm environment

## Testing
- `wasm-pack test --headless --chrome --features yew` *(fails: mui-headless dependency missing in current crate configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c47245e8832e9107e1978e760038