### PR TITLE
test: add Joy adapter parity suites

### DIFF
--- a/crates/mui-material/src/button.rs
+++ b/crates/mui-material/src/button.rs
@@ -127,6 +127,24 @@ fn themed_button_attributes(state: &ButtonState) -> Vec<(String, String)> {
 // Adapter implementations
 // ---------------------------------------------------------------------------
 
+/// Adapter targeting server rendered React experiences.
+///
+/// React environments typically reuse the SSR string as a golden baseline for
+/// hydration verification. Exposing a lightweight adapter that simply forwards
+/// to the shared [`render_html`] routine keeps parity tests trivial while
+/// allowing automation to diff the generated markup across frameworks.
+pub mod react {
+    use super::*;
+
+    /// Render the Material button into a HTML string identical to other
+    /// adapters. The helper intentionally mirrors the existing framework
+    /// adapters so integration tests can compare React output against Rust
+    /// renderers without reimplementing styling logic.
+    pub fn render(props: &ButtonProps, state: &ButtonState) -> String {
+        super::render_html(props, state)
+    }
+}
+
 /// Adapter targeting the [`yew`] framework.
 pub mod yew {
     use super::*;

--- a/crates/mui-material/src/chip.rs
+++ b/crates/mui-material/src/chip.rs
@@ -358,6 +358,24 @@ fn themed_delete_style() -> Style {
 // Adapter implementations
 // ---------------------------------------------------------------------------
 
+/// Adapter targeting server rendered React environments.
+///
+/// Server driven React stacks often diff SSR output against client renders to
+/// guarantee hydration fidelity. Providing a dedicated adapter that reuses the
+/// shared [`render_html`] helper keeps those comparisons simple and avoids
+/// duplicating style orchestration in automation harnesses.
+pub mod react {
+    use super::*;
+
+    /// Render the chip into a HTML string that mirrors the other framework
+    /// adapters. Keeping the implementation as a thin wrapper over
+    /// [`super::render_html`] ensures every integration emits identical markup
+    /// and scoped class names.
+    pub fn render(props: &ChipProps, state: &ChipState) -> String {
+        super::render_html(props, state)
+    }
+}
+
 /// Adapter targeting the [`yew`] framework.
 pub mod yew {
     use super::*;

--- a/crates/mui-material/src/dialog.rs
+++ b/crates/mui-material/src/dialog.rs
@@ -227,6 +227,52 @@ fn render_dialog_surface_html(
 }
 
 // ---------------------------------------------------------------------------
+// React SSR adapter
+// ---------------------------------------------------------------------------
+
+/// React integrations lean on the serialized markup for parity checks and
+/// hydration validation. Exposing a thin adapter that mirrors the server-side
+/// renderers keeps framework comparisons straightforward without duplicating
+/// style or accessibility wiring.
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+))]
+pub mod react {
+    use super::*;
+
+    /// Properties accepted by the React oriented renderer. The struct mirrors
+    /// the SSR adapters to keep orchestration consistent across frameworks.
+    #[derive(Clone, Debug, Default, PartialEq)]
+    pub struct DialogProps {
+        /// Dialog state machine controlling visibility and analytics hooks.
+        pub state: DialogState,
+        /// Optional attribute overrides applied to the dialog surface.
+        pub surface: DialogSurfaceOptions,
+        /// Serialized child markup rendered inside the dialog.
+        pub children: String,
+        /// Optional accessible label announced by assistive technologies.
+        pub aria_label: Option<String>,
+    }
+
+    /// Render the dialog surface using the shared SSR helper so React output
+    /// matches the strings produced by Leptos/Dioxus/Sycamore adapters.
+    pub fn render(props: &DialogProps) -> String {
+        if !props.state.is_open() {
+            return String::new();
+        }
+        let surface_attrs = apply_surface_options(props.state.surface_attributes(), &props.surface);
+        super::render_dialog_surface_html(
+            surface_attrs,
+            props.aria_label.as_deref(),
+            &props.children,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Yew adapter
 // ---------------------------------------------------------------------------
 

--- a/crates/mui-material/tests/common/fixtures.rs
+++ b/crates/mui-material/tests/common/fixtures.rs
@@ -1,0 +1,79 @@
+//! Shared fixtures feeding the Joy parity integration tests.
+//!
+//! The helpers centralize representative props and headless states so every
+//! adapter comparison exercises the same automation identifiers, focus
+//! transitions and accessibility metadata. Keeping the data builders in one
+//! place dramatically reduces maintenance overhead when design tokens evolve
+//! because tests for each framework automatically reuse the updated contract.
+
+use std::time::Duration;
+
+use mui_headless::button::ButtonState;
+use mui_headless::chip::{ChipConfig, ChipState};
+use mui_headless::dialog::DialogState;
+use mui_material::button::ButtonProps;
+use mui_material::chip::ChipProps;
+use mui_material::dialog::DialogSurfaceOptions;
+
+/// Build button props representing a primary action used throughout the tests.
+#[must_use]
+pub fn button_props() -> ButtonProps {
+    ButtonProps::new("Launch Joyride")
+}
+
+/// Construct a default [`ButtonState`] mirroring an idle toggle.
+#[must_use]
+pub fn button_state_default() -> ButtonState {
+    ButtonState::new(false, None)
+}
+
+/// Assemble chip props with automation identifiers and delete affordance labels.
+#[must_use]
+pub fn chip_props() -> ChipProps {
+    ChipProps::new("Joy filter")
+        .with_automation_id("joy-chip")
+        .with_delete_label("Remove joy filter")
+        .with_delete_icon("✕")
+}
+
+/// Construct a chip state with timers disabled so trailing controls appear immediately.
+#[must_use]
+pub fn chip_state_focused() -> ChipState {
+    let mut config = ChipConfig::default();
+    config.show_delay = Duration::ZERO;
+    config.hide_delay = Duration::ZERO;
+    config.delete_delay = Duration::ZERO;
+    let mut state = ChipState::new(config);
+    let _ = state.focus();
+    state
+}
+
+/// Create an open dialog state to exercise SSR renderers.
+#[must_use]
+pub fn dialog_state_open() -> DialogState {
+    DialogState::uncontrolled(true)
+}
+
+/// Provide deterministic surface overrides for the dialog renderers.
+#[must_use]
+pub fn dialog_surface_options() -> DialogSurfaceOptions {
+    let mut surface = DialogSurfaceOptions::default();
+    surface.id = Some("joy-dialog".into());
+    surface.labelled_by = Some("joy-dialog-heading".into());
+    surface.described_by = Some("joy-dialog-description".into());
+    surface.analytics_id = Some("joy-modal".into());
+    surface
+}
+
+/// Return representative dialog body markup used by every adapter snapshot.
+#[must_use]
+pub fn dialog_body_markup() -> String {
+    "<h2 id=\"joy-dialog-heading\">Joy UX</h2><p id=\"joy-dialog-description\">Amplify delight across adapters.</p>"
+        .into()
+}
+
+/// Optional aria label supplementing the heading metadata.
+#[must_use]
+pub fn dialog_aria_label() -> Option<String> {
+    Some("Joy interaction dialog".into())
+}

--- a/crates/mui-material/tests/joy_dioxus.rs
+++ b/crates/mui-material/tests/joy_dioxus.rs
@@ -1,0 +1,71 @@
+#![cfg(feature = "dioxus")]
+
+//! Joy adapter regression tests for the Dioxus renderer.
+//!
+//! Dioxus consumes the same shared renderers as the SSR integrations, so these
+//! assertions ensure the serialized HTML continues to line up with the React
+//! baseline when Joy styling tokens change.
+
+#[path = "common/fixtures.rs"]
+mod fixtures;
+
+use fixtures::{
+    button_props, button_state_default, chip_props, chip_state_focused, dialog_aria_label,
+    dialog_body_markup, dialog_state_open, dialog_surface_options,
+};
+use mui_material::{button, chip, dialog};
+
+#[test]
+fn dioxus_button_matches_react_output() {
+    let props = button_props();
+    let state = button_state_default();
+
+    let react = button::react::render(&props, &state);
+    let dioxus = button::dioxus::render(&props, &state);
+
+    assert_eq!(dioxus, react);
+    assert!(react.contains("class=\""));
+    assert!(react.contains("role=\"button\""));
+}
+
+#[test]
+fn dioxus_chip_retains_focus_and_delete_hooks() {
+    let props = chip_props();
+    let state_react = chip_state_focused();
+    let state_dioxus = chip_state_focused();
+
+    let react = chip::react::render(&props, &state_react);
+    let dioxus = chip::dioxus::render(&props, &state_dioxus);
+
+    assert_eq!(dioxus, react);
+    assert!(react.contains("aria-describedby=\"joy-chip-delete\""));
+    assert!(react.contains("data-chip-slot=\"delete\""));
+}
+
+#[test]
+fn dioxus_dialog_parity_preserves_focus_trap_metadata() {
+    let state = dialog_state_open();
+    let surface = dialog_surface_options();
+    let body = dialog_body_markup();
+    let aria_label = dialog_aria_label();
+
+    let react_props = dialog::react::DialogProps {
+        state: state.clone(),
+        surface: surface.clone(),
+        children: body.clone(),
+        aria_label: aria_label.clone(),
+    };
+    let react = dialog::react::render(&react_props);
+
+    let dioxus_props = dialog::dioxus::DialogProps {
+        state,
+        surface,
+        children: body,
+        aria_label,
+    };
+    let dioxus = dialog::dioxus::render(&dioxus_props);
+
+    assert_eq!(dioxus, react);
+    assert!(react.contains("data-focus-trap=\"true\""));
+    assert!(react.contains("data-transition"));
+}

--- a/crates/mui-material/tests/joy_leptos.rs
+++ b/crates/mui-material/tests/joy_leptos.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "leptos")]
+
+//! Joy adapter parity checks for the Leptos SSR renderer.
+//!
+//! Each test compares the canonical React HTML against the Leptos adapter to
+//! guarantee hydration-friendly markup parity for Material components that lean
+//! on Joy design tokens.
+
+#[path = "common/fixtures.rs"]
+mod fixtures;
+
+use fixtures::{
+    button_props, button_state_default, chip_props, chip_state_focused, dialog_aria_label,
+    dialog_body_markup, dialog_state_open, dialog_surface_options,
+};
+use mui_material::{button, chip, dialog};
+
+#[test]
+fn leptos_button_matches_react_markup() {
+    let props = button_props();
+    let state = button_state_default();
+
+    let react = button::react::render(&props, &state);
+    let leptos = button::leptos::render(&props, &state);
+
+    assert_eq!(leptos, react);
+    assert!(react.contains("class=\""));
+    assert!(react.contains("role=\"button\""));
+}
+
+#[test]
+fn leptos_chip_mirrors_react_snapshot() {
+    let props = chip_props();
+    let state_react = chip_state_focused();
+    let state_leptos = chip_state_focused();
+
+    let react = chip::react::render(&props, &state_react);
+    let leptos = chip::leptos::render(&props, &state_leptos);
+
+    assert_eq!(leptos, react);
+    assert!(react.contains("data-component=\"mui-chip\""));
+    assert!(react.contains("aria-describedby=\"joy-chip-delete\""));
+}
+
+#[test]
+fn leptos_dialog_ssr_matches_react_renderer() {
+    let state = dialog_state_open();
+    let surface = dialog_surface_options();
+    let body = dialog_body_markup();
+    let aria_label = dialog_aria_label();
+
+    let react_props = dialog::react::DialogProps {
+        state: state.clone(),
+        surface: surface.clone(),
+        children: body.clone(),
+        aria_label: aria_label.clone(),
+    };
+    let react = dialog::react::render(&react_props);
+
+    let leptos_props = dialog::leptos::DialogProps {
+        state,
+        surface,
+        children: body,
+        aria_label,
+    };
+    let leptos = dialog::leptos::render(&leptos_props);
+
+    assert_eq!(leptos, react);
+    assert!(react.contains("role=\"dialog\""));
+    assert!(react.contains("data-focus-trap=\"true\""));
+    assert!(react.contains("data-analytics-id=\"joy-modal\""));
+}

--- a/crates/mui-material/tests/joy_sycamore.rs
+++ b/crates/mui-material/tests/joy_sycamore.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "sycamore")]
+
+//! Joy adapter parity for the Sycamore SSR renderer.
+//!
+//! These tests lean on the shared fixtures to validate that Sycamore continues
+//! to emit the same markup as the React baseline for Joy-influenced Material
+//! components.
+
+#[path = "common/fixtures.rs"]
+mod fixtures;
+
+use fixtures::{
+    button_props, button_state_default, chip_props, chip_state_focused, dialog_aria_label,
+    dialog_body_markup, dialog_state_open, dialog_surface_options,
+};
+use mui_material::{button, chip, dialog};
+
+#[test]
+fn sycamore_button_parity() {
+    let props = button_props();
+    let state = button_state_default();
+
+    let react = button::react::render(&props, &state);
+    let sycamore = button::sycamore::render(&props, &state);
+
+    assert_eq!(sycamore, react);
+    assert!(react.contains("role=\"button\""));
+}
+
+#[test]
+fn sycamore_chip_snapshot_matches_react() {
+    let props = chip_props();
+    let state_react = chip_state_focused();
+    let state_sycamore = chip_state_focused();
+
+    let react = chip::react::render(&props, &state_react);
+    let sycamore = chip::sycamore::render(&props, &state_sycamore);
+
+    assert_eq!(sycamore, react);
+    assert!(react.contains("data-automation-id=\"joy-chip\""));
+}
+
+#[test]
+fn sycamore_dialog_preserves_focus_and_analytics_tags() {
+    let state = dialog_state_open();
+    let surface = dialog_surface_options();
+    let body = dialog_body_markup();
+    let aria_label = dialog_aria_label();
+
+    let react_props = dialog::react::DialogProps {
+        state: state.clone(),
+        surface: surface.clone(),
+        children: body.clone(),
+        aria_label: aria_label.clone(),
+    };
+    let react = dialog::react::render(&react_props);
+
+    let sycamore_props = dialog::sycamore::DialogProps {
+        state,
+        surface,
+        children: body,
+        aria_label,
+    };
+    let sycamore = dialog::sycamore::render(&sycamore_props);
+
+    assert_eq!(sycamore, react);
+    assert!(react.contains("role=\"dialog\""));
+    assert!(react.contains("data-analytics-id=\"joy-modal\""));
+}

--- a/crates/mui-material/tests/joy_yew.rs
+++ b/crates/mui-material/tests/joy_yew.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "yew")]
+
+//! Joy adapter parity checks for the Yew integration.
+//!
+//! The tests render representative components through the new React SSR adapter
+//! and the existing Yew hooks, asserting the serialized markup matches exactly.
+//! Comparing the HTML strings guarantees that scoped classes, ARIA metadata and
+//! automation hooks stay aligned across frameworks even as design tokens evolve.
+
+#[path = "common/fixtures.rs"]
+mod fixtures;
+
+use fixtures::{button_props, button_state_default, chip_props, chip_state_focused};
+use mui_material::{button, chip};
+
+#[test]
+fn yew_button_matches_react_baseline() {
+    let props = button_props();
+    let state = button_state_default();
+
+    let react = button::react::render(&props, &state);
+    let yew = button::yew::render(&props, &state);
+
+    assert_eq!(yew, react);
+    assert!(react.contains("class=\""), "missing scoped class: {react}");
+    assert!(react.contains("role=\"button\""));
+    assert!(react.contains("aria-pressed=\"false\""));
+}
+
+#[test]
+fn yew_chip_includes_all_automation_hooks() {
+    let props = chip_props();
+    let state_react = chip_state_focused();
+    let state_yew = chip_state_focused();
+
+    let react = chip::react::render(&props, &state_react);
+    let yew = chip::yew::render(&props, &state_yew);
+
+    assert_eq!(yew, react);
+    assert!(react.contains("data-component=\"mui-chip\""));
+    assert!(react.contains("data-automation-id=\"joy-chip\""));
+    assert!(react.contains("data-chip-slot=\"delete\""));
+    assert!(react.contains("aria-label=\"Remove joy filter\""));
+}


### PR DESCRIPTION
## Summary
- expose lightweight React render adapters for the button, chip, and dialog modules so every framework can be compared against a canonical SSR baseline
- add shared Joy fixtures plus new integration tests that assert Yew, Leptos, Dioxus, and Sycamore adapters emit the same markup as the React renderer

## Testing
- `cargo test -p mui-material --all-features` *(fails: existing macro and derive errors in mui-material when enabling all frameworks concurrently)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c98c76fc832eb2585430e068aac6