### PR TITLE
docs: expand rust ci guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ cargo xtask build-docs            # build the documentation site
 
 Each task emits verbose logs and returns a non-zero exit code on failure so it can be safely wired into CI pipelines.
 
+### Rust CI quick reference
+
+The Rust workspace CI expects every pull request to validate the full adapter matrix locally. Install Chrome/Chromium plus `wasm-pack` (see [`docs/rust-ci.md`](docs/rust-ci.md) for setup) and run:
+
+```bash
+cargo test --workspace --all-features
+cargo xtask wasm-test
+cargo test -p mui-material --test joy_yew --features yew
+cargo test -p mui-material --test joy_leptos --features leptos
+cargo test -p mui-material --test joy_dioxus --features dioxus
+cargo test -p mui-material --test joy_sycamore --features sycamore
+```
+
+Use the parity suites above to chase snapshot mismatches: rerun the failing test with `-- --nocapture --exact` to inspect the React versus adapter markup before refreshing fixtures or renderers. The [Rust CI guide](docs/rust-ci.md) documents deeper troubleshooting steps, snapshot refresh flows, and coverage tooling so teams can keep automation green without guesswork.
+
 ## Select and menu reference implementations
 
 The `examples/select-menu-*` packages provide production-ready blueprints for

--- a/docs/rust-ci.md
+++ b/docs/rust-ci.md
@@ -1,17 +1,21 @@
 # Rust CI and Local Reproduction Guide
 
-This document outlines the automation used in our Rust workspace CI and how to reproduce the steps locally. The CI pipeline is designed to minimize manual work and provide repeatable builds for enterprise-grade reliability.
+This document outlines the automation used in our Rust workspace CI and how to reproduce the steps locally. The CI pipeline is designed to minimize manual work and provide repeatable builds for enterprise-grade reliability, covering unit tests, Joy headless suites, WebAssembly smoke tests across every framework adapter, and the Joy snapshot parity checks.
 
 ## Prerequisites
 - Rust stable toolchain with `rustfmt`, `clippy`, and `llvm-tools-preview` components
+- WebAssembly target: `rustup target add wasm32-unknown-unknown`
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/) for WebAssembly tests
+- Latest Chrome or Chromium for headless browser execution (Firefox is optional for local debugging)
+- [`wasm-bindgen-test`](https://rustwasm.github.io/docs/wasm-bindgen/reference/wasm-bindgen-test/introduction.html) (already listed as a dev-dependency in the crates, add it when authoring new suites)
 - [grcov](https://github.com/mozilla/grcov) for coverage reports
-- Chrome or Firefox installed for headless browser tests
 
 Install prerequisites:
 ```bash
 rustup component add rustfmt clippy llvm-tools-preview
+rustup target add wasm32-unknown-unknown
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+cargo install wasm-bindgen-cli # provides wasm-bindgen-test runners if you extend the suites
 cargo install grcov
 ```
 
@@ -24,42 +28,82 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-### Tests and Coverage
+Running `cargo xtask fmt --check` mirrors the CI lint job by wrapping the two commands above with consistent logging.
+
+### Core workspace tests
 ```bash
-cargo test --workspace
-# Coverage
-grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing -o lcov.info
+cargo test --workspace --all-features
 ```
 
-### WebAssembly Tests
-Only crates with `wasm-bindgen-test` are executed. Interactive components rely
-on the `yew` feature and are automatically audited for accessibility using
-[`axe-core`](https://github.com/dequelabs/axe-core).
+This is the quickest way to surface failures in the shared headless state machines, Material adapter suites, and the Joy headless unit tests under `crates/mui-joy/tests/headless_state_tests.rs`. CI calls the same entrypoint via `cargo xtask test`, which additionally checks that each example still compiles for `wasm32-unknown-unknown`.
+
+### Joy snapshot parity suites
+Joy UI ships SSR renderers for every supported framework. The parity suites compare each adapter to the canonical React output so teams can guarantee hydration-safe markup whenever Joy tokens evolve. Target a single framework or run the whole matrix:
+
 ```bash
-for crate in crates/mui-joy crates/mui-material; do
-  (cd "$crate" && wasm-pack test --headless --chrome --features yew)
-done
+# Yew parity
+cargo test -p mui-material --test joy_yew --features yew
+
+# Leptos parity
+cargo test -p mui-material --test joy_leptos --features leptos
+
+# Dioxus parity
+cargo test -p mui-material --test joy_dioxus --features dioxus
+
+# Sycamore parity
+cargo test -p mui-material --test joy_sycamore --features sycamore
 ```
 
-### Accessibility Audits
-The `mui-material` test suite integrates `axe-core` via `wasm-bindgen` to
-validate ARIA roles, keyboard navigation and overall accessibility. Tests fail
-if any violation is detected, making a11y compliance part of the standard CI
-pipeline.
+Each suite consumes the shared fixtures in `crates/mui-material/tests/common/fixtures.rs` so updating the canonical props or Joy analytics hooks automatically propagates across frameworks.
 
-### Component Rendering Assertions
+### WebAssembly integration tests
+Interactive components execute inside a headless Chrome instance using the `wasm-bindgen-test` harness. Install Chrome/Chromium locally so `wasm-pack test --headless --chrome` can launch the browser. The fastest way to exercise every crate/feature pair is:
 
-Cross-framework unit tests in `mui-material` render each component and verify
-that the generated HTML includes the hashed CSS class and expected ARIA
-metadata. These structured assertions guard against regressions in both styling
-and accessibility across adapters.
-
-### Documentation and Benchmarks
 ```bash
-cargo doc --no-deps --workspace
+cargo xtask wasm-test
+```
+
+CI relies on this command to build and run WebAssembly tests for both `mui-joy` and `mui-material`. To run suites individually (useful when isolating regressions) call the underlying commands directly—one per framework adapter:
+
+```bash
+# Joy UI adapters
+(cd crates/mui-joy && wasm-pack test --headless --chrome -- --no-default-features --features yew)
+(cd crates/mui-joy && wasm-pack test --headless --chrome -- --no-default-features --features leptos)
+(cd crates/mui-joy && wasm-pack test --headless --chrome -- --no-default-features --features dioxus)
+(cd crates/mui-joy && wasm-pack test --headless --chrome -- --no-default-features --features sycamore)
+
+# Material adapters
+(cd crates/mui-material && wasm-pack test --headless --chrome -- --no-default-features --features yew)
+(cd crates/mui-material && wasm-pack test --headless --chrome -- --no-default-features --features leptos)
+(cd crates/mui-material && wasm-pack test --headless --chrome -- --no-default-features --features dioxus)
+(cd crates/mui-material && wasm-pack test --headless --chrome -- --no-default-features --features sycamore)
+```
+
+The `--no-default-features` flag mirrors CI by ensuring optional adapters declare their dependencies explicitly. When a run fails because Chrome cannot be located, set `CHROME` or `CHROMIUM` to the browser executable path. Browser console output is captured automatically, so rerun with `-- --nocapture` to view detailed logs.
+
+### Snapshot maintenance workflow
+When a Joy snapshot test fails, the panic message includes both the framework-specific markup and the React baseline. Use `-- --nocapture --exact` to focus on the failing test:
+
+```bash
+cargo test -p mui-material yew_button_matches_react_baseline --features yew -- --nocapture --exact
+```
+
+Typical remediation steps:
+
+1. Confirm whether the React renderer (`mui_material::button::react`, `mui_material::chip::react`, etc.) changed intentionally. If so, update the corresponding framework adapter module so it emits the new markup.
+2. If analytics hooks or accessibility IDs changed globally, adjust the shared fixtures in `crates/mui-material/tests/common/fixtures.rs` so every parity suite receives the same canonical data.
+3. Re-run the targeted test, then `cargo test --workspace --all-features` to ensure no other suites regressed.
+
+This approach keeps the parity harness self-healing—updating either the fixtures or adapter renderers refreshes the "snapshot" without maintaining external files.
+
+### Coverage and documentation
+```bash
+cargo xtask coverage            # runs cargo test --workspace --all-features and emits lcov.info
+cargo doc --no-deps --workspace --all-features
 cargo bench --workspace || true
 ```
-Artifacts can be found under `target/doc` and `target/criterion` respectively.
+
+Artifacts can be found under `target/doc` and `target/criterion` respectively. Upload `lcov.info` to Codecov (CI does this automatically).
 
 ## Caching
 CI uses [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) to reuse build output across jobs. Locally, Cargo's own cache handles this automatically.
@@ -68,3 +112,4 @@ CI uses [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) to reuse
 - Coverage results are uploaded to Codecov in CI.
 - Benchmark and documentation outputs are uploaded as artifacts for easy inspection.
 - When adding new crates, ensure they are listed in `Cargo.toml` and include any necessary test or bench targets.
+- For new wasm suites, add `wasm-bindgen-test` and mark functions with `#[wasm_bindgen_test]` so they run consistently via `wasm-pack` locally and in CI.


### PR DESCRIPTION
## Summary
- expand `docs/rust-ci.md` with the full workspace test matrix, Joy parity snapshot guidance, and wasm tooling prerequisites
- add a README quick reference so contributors can run the Joy parity suites and wasm packs before opening a PR

## Testing
- cargo xtask fmt --check *(fails on pre-existing formatting drift in mui-joy when executed with the container toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68d1db9ee088832ebcf032f9c493a66c