### PR TITLE
Add Joy workflow examples across frameworks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,10 +123,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -228,6 +256,9 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "boolinator"
@@ -392,6 +423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "config"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +473,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constcat"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "convert_case"
@@ -535,6 +581,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +667,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9e3b0725e520250bf23213f996d241cca29cea4360a9bf08a44e0033f8e569"
 dependencies = [
  "dioxus-core",
+ "dioxus-core-macro",
+ "dioxus-hooks",
+ "dioxus-html",
+ "dioxus-rsx",
 ]
 
 [[package]]
@@ -600,9 +684,129 @@ dependencies = [
  "futures-util",
  "longest-increasing-subsequence",
  "rustc-hash 1.1.0",
+ "serde",
  "slab",
  "smallbox",
  "tracing",
+]
+
+[[package]]
+name = "dioxus-core-macro"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21afaccb28587aed0ba98856335912f5ce7052c0aafa74b213829a3b8bfd2345"
+dependencies = [
+ "constcat",
+ "dioxus-core",
+ "dioxus-rsx",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "dioxus-debug-cell"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
+
+[[package]]
+name = "dioxus-hooks"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb23ce82df4fb13e9ddaa01d1469f1f32d683dd4636204bd0a0eaf434b65946"
+dependencies = [
+ "dioxus-core",
+ "dioxus-debug-cell",
+ "futures-channel",
+ "slab",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-html"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828a42a2d70688a2412a8538c8b5a5eceadf68f682f899dc4455a0169db39dfd"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "dioxus-core",
+ "enumset",
+ "euclid",
+ "keyboard-types",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_repr",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "dioxus-interpreter-js"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a3115cf9f550a9af88de615c21a15a72dee44230602087dd7b0c5d01f46c37"
+dependencies = [
+ "js-sys",
+ "sledgehammer_bindgen",
+ "sledgehammer_utils",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "dioxus-rsx"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c974133c7c95497a486d587e40449927711430b308134b9cd374b8d35eceafb3"
+dependencies = [
+ "dioxus-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "dioxus-ssr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32c006feb2cd0d9aafc6263167d52f81fd8004fd6545c90582504314766f775"
+dependencies = [
+ "askama_escape",
+ "dioxus-core",
+ "http 0.2.12",
+ "lru 0.10.1",
+ "rustc-hash 1.1.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "dioxus-web"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fafaff75f50035078c2da45441ee61472fd0f335fa15b05170165eaf3479f0df"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "dioxus-core",
+ "dioxus-html",
+ "dioxus-interpreter-js",
+ "futures-channel",
+ "futures-util",
+ "js-sys",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde-wasm-bindgen 0.5.0",
+ "serde_json",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -635,6 +839,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enumset"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,7 +882,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
 dependencies = [
  "num-traits",
+ "serde",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
@@ -721,6 +953,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fontconfig-parser"
@@ -1270,6 +1508,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1283,6 +1530,11 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1451,6 +1703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1848,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "joy-dioxus"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+ "dioxus-ssr",
+ "dioxus-web",
+ "joy-workflows-core",
+ "mui-headless",
+ "mui-joy",
+ "mui-system",
+]
+
+[[package]]
+name = "joy-leptos"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "joy-workflows-core",
+ "leptos",
+ "mui-headless",
+ "mui-joy",
+ "mui-system",
+ "tokio",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "joy-parity"
 version = "0.1.0"
 dependencies = [
@@ -1606,6 +1891,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "joy-sycamore"
+version = "0.1.0"
+dependencies = [
+ "joy-workflows-core",
+ "mui-headless",
+ "mui-joy",
+ "mui-system",
+ "sycamore",
+ "tokio",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "joy-workflows-core"
+version = "0.1.0"
+dependencies = [
+ "mui-headless",
+ "mui-joy",
+ "mui-system",
+]
+
+[[package]]
+name = "joy-yew"
+version = "0.1.0"
+dependencies = [
+ "joy-workflows-core",
+ "mui-joy",
+ "mui-system",
+ "tokio",
+ "wasm-bindgen",
+ "web-sys",
+ "yew",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1934,17 @@ checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1836,6 +2168,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 
 [[package]]
+name = "lru"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "manyhow"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2314,7 @@ dependencies = [
  "gloo-timers 0.2.6",
  "gloo-utils 0.2.0",
  "leptos",
+ "mui-headless",
  "mui-system",
  "sycamore",
  "wasm-bindgen",
@@ -2133,6 +2484,15 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "pad-adapter"
@@ -2867,6 +3227,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +3299,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3054,6 +3435,27 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "sledgehammer_bindgen"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bc2cf26c12673eee8674b19d56cec04e9b815704c71298eafac61f131f99d7"
+dependencies = [
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "sledgehammer_utils"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f20798defa0e9d4eff9ca451c7f84774c7378a9c3b5a40112cfa2b3eadb97ae2"
+dependencies = [
+ "lru 0.12.5",
+ "once_cell",
+ "rustc-hash 1.1.0",
+]
 
 [[package]]
 name = "slotmap"
@@ -3563,6 +3965,18 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,11 @@ members = [
     "examples/feedback-chips",
     "examples/data-display-avatar",
     "examples/shared-dialog-state-core",
+    "examples/joy-workflows-core",
+    "examples/joy-yew",
+    "examples/joy-leptos",
+    "examples/joy-dioxus",
+    "examples/joy-sycamore",
 ]
 
 # Use Cargo's second feature resolver so optional dependencies don't

--- a/crates/mui-joy/Cargo.toml
+++ b/crates/mui-joy/Cargo.toml
@@ -15,6 +15,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 mui-system = { path = "../mui-system" }
+mui-headless = { path = "../mui-headless" }
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/mui-joy/README.md
+++ b/crates/mui-joy/README.md
@@ -1,40 +1,136 @@
 # mui-joy
 
-Experimental Joy UI component library for Rust.
+Rust-first bindings for the Joy UI design language. The crate mirrors the
+structure of Material UI while exposing Joy-specific tokens such as neutral and
+danger palettes, radius controls, and focus outlines. Every prop definition is
+framework agnostic so Yew, Leptos, Dioxus, and Sycamore adapters share the same
+API surface and analytics hooks.
 
-This crate mirrors the `mui-material` crate but targets the Joy design
-language.  It showcases how additional design tokens such as `neutral` and
-`danger` palette colors or corner `radius` can be modeled in Rust.
-Shared enums and macros keep component props consistent and reduce manual
-boilerplate when authoring new widgets.
+## Installation
 
-## Differences from Material
-
-* Extra palette colors: `neutral` and `danger`.
-* Joy specific tokens grouped under `Theme::joy` such as `radius` and
-  `focus_thickness` which have no Material equivalents.
-* Component variants `solid`, `soft`, `outlined`, and `plain` shared across
-  multiple components via macros.
-
-## Usage
-
-```rust
-use mui_joy::{Button, Card, Chip, Color, Variant};
-
-let button = html! { <Button label="Save" color={Color::Primary} /> };
+```bash
+cargo add mui-joy --features yew
+# or
+cargo add mui-joy --features leptos
 ```
 
-## Migration from Material
+`mui-joy` deliberately keeps features granular so applications only compile the
+adapters they need:
 
-Material components use `color`/`variant` patterns but the available values
-are different. Joy's `Color` adds `Neutral` and `Danger`, while `Variant`
-expands to `Soft` and `Plain`. When moving from Material simply switch to the
-`Color` and `Variant` enums exported by this crate and reference any Joy
-specific tokens through `Theme::joy`.
+| Feature    | Purpose                                                                 | Typical consumers                |
+|------------|-------------------------------------------------------------------------|----------------------------------|
+| `yew`      | Enables the concrete Yew components plus `yew::Properties` derives.      | SPA/CSR apps built with Yew.     |
+| `leptos`   | Implements the Leptos marker trait so downstream crates can validate prop compatibility inside `view!` templates. | SSR/Hydrate apps using Leptos.   |
+| `dioxus`   | Derives `dioxus::Props` on every generated prop struct.                  | Dioxus CSR/SSR renderers.        |
+| `sycamore` | Derives `sycamore::Props` on every generated prop struct.                | Sycamore SPA or islands apps.    |
+
+The prop macros (`joy_props!` and `joy_component_props!`) always emit plain Rust
+structs so feature flags only influence which derive macros are attached. This
+keeps CI fast and eliminates manual duplication when new adapters are added.
+
+## Framework snippets
+
+### Yew
+
+```rust
+use mui_joy::{Button, ButtonProps, Color, Variant};
+use yew::prelude::*;
+
+#[function_component(SaveButton)]
+fn save_button() -> Html {
+    html! {
+        <Button
+            ..ButtonProps {
+                color: Color::Primary,
+                variant: Variant::Solid,
+                label: "Approve deployment".into(),
+                onclick: Callback::noop(),
+                throttle_ms: Some(400),
+                disabled: false,
+            }
+        />
+    }
+}
+```
+
+### Leptos
+
+```rust
+use leptos::*;
+use mui_joy::helpers::resolve_surface_tokens;
+use mui_joy::{Color, Variant};
+use mui_system::theme::Theme;
+
+#[component]
+pub fn JoyTag(theme: Theme) -> impl IntoView {
+    let style = resolve_surface_tokens(&theme, Color::Neutral, Variant::Soft)
+        .compose([("padding", "6px 12px".to_string())]);
+    view! { <span style=style>{"Production window"}</span> }
+}
+```
+
+### Dioxus
+
+```rust
+use dioxus::prelude::*;
+use mui_joy::helpers::resolve_surface_tokens;
+use mui_joy::{Color, Variant};
+use mui_system::theme::Theme;
+
+fn Chip(theme: &Theme) -> String {
+    resolve_surface_tokens(theme, Color::Danger, Variant::Soft)
+        .compose([("padding", "8px 14px".to_string())])
+}
+```
+
+### Sycamore
+
+```rust
+use mui_joy::helpers::resolve_surface_tokens;
+use mui_joy::{Color, Variant};
+use sycamore::prelude::*;
+
+#[component]
+fn AlertBadge<G: Html>(cx: Scope) -> View<G> {
+    let theme = mui_system::theme::Theme::default();
+    let style = resolve_surface_tokens(&theme, Color::Primary, Variant::Solid)
+        .compose([("padding", "8px 16px".to_string())]);
+    view! { cx, span(style=style) { "Joy automation green" } }
+}
+```
+
+Each snippet is a distilled version of the [cross-framework Joy workflow
+examples](../../examples) which demonstrate full automation pipelines and shared
+state management.
 
 ## Examples
 
+The repository hosts comprehensive workflow demos under `examples/`:
+
+- [`joy-yew`](../../examples/joy-yew) – Trunk-powered CSR build showcasing Joy
+  components driven by the shared workflow machine.
+- [`joy-leptos`](../../examples/joy-leptos) – Signal-driven SSR/CSR hybrid that
+  reuses the identical automation hooks.
+- [`joy-dioxus`](../../examples/joy-dioxus) – `rsx!` templates backed by the
+  central workflow state.
+- [`joy-sycamore`](../../examples/joy-sycamore) – fine-grained Sycamore signals
+  consuming the same machine without duplicating business logic.
+
+All demos depend on [`joy-workflows-core`](../../examples/joy-workflows-core), a
+crate that centralises the state machine, analytics identifiers, and design
+tokens so every adapter stays in lockstep.
+
+## Parity automation
+
+The Joy adapters participate in the workspace parity pipeline. Run the inventory
+scanner to refresh coverage metrics and CI fixtures:
+
 ```bash
-cargo run -p mui-joy --example button --features yew
-cargo run -p mui-joy --example card --features yew
+cargo xtask joy-parity
 ```
+
+The command emits an inventory report at
+[`docs/joy-component-parity.md`](../../docs/joy-component-parity.md) and is
+executed automatically in CI. The report lists every Joy component alongside the
+React baseline so teams can track adoption progress and enforce automation
+parity across frameworks.

--- a/crates/mui-joy/src/accordion.rs
+++ b/crates/mui-joy/src/accordion.rs
@@ -5,9 +5,7 @@
 //! component templates.  Centralising the boilerplate here keeps future Joy
 //! components focused on styling rather than state orchestration.
 
-pub use mui_headless::accordion::{
-    AccordionGroupState, AccordionItemChange,
-};
+pub use mui_headless::accordion::{AccordionGroupState, AccordionItemChange};
 
 /// Convenience wrapper around [`AccordionGroupState`] so Joy renderers can
 /// instantiate accordions without touching the headless crate directly.

--- a/crates/mui-joy/src/autocomplete.rs
+++ b/crates/mui-joy/src/autocomplete.rs
@@ -6,8 +6,7 @@
 //! business logic.
 
 pub use mui_headless::autocomplete::{
-    AutocompleteChange, AutocompleteConfig, AutocompleteControlStrategy,
-    AutocompleteState,
+    AutocompleteChange, AutocompleteConfig, AutocompleteControlStrategy, AutocompleteState,
 };
 
 /// Wrapper that owns an [`AutocompleteState`] ready to be plugged into Joy

--- a/crates/mui-joy/src/button.rs
+++ b/crates/mui-joy/src/button.rs
@@ -38,7 +38,8 @@ pub fn button(props: &ButtonProps) -> Html {
     let theme = use_theme();
 
     // Resolve design tokens once so we can build the final inline styles declaratively.
-    let surface: SurfaceTokens = resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
+    let surface: SurfaceTokens =
+        resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
     let padding = format!("{}px {}px", theme.spacing(1), theme.spacing(2));
 
     let adapter = use_button_adapter(
@@ -60,7 +61,10 @@ pub fn button(props: &ButtonProps) -> Html {
                 "pointer".to_string()
             },
         ),
-        ("transition", "background 120ms ease, color 120ms ease".to_string()),
+        (
+            "transition",
+            "background 120ms ease, color 120ms ease".to_string(),
+        ),
     ];
     let style = surface.compose(extra.drain(..));
 

--- a/crates/mui-joy/src/card.rs
+++ b/crates/mui-joy/src/card.rs
@@ -24,7 +24,8 @@ joy_component_props!(CardProps {
 pub fn card(props: &CardProps) -> Html {
     let theme = use_theme();
 
-    let surface: SurfaceTokens = resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
+    let surface: SurfaceTokens =
+        resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
     let padding = format!("{}px", theme.spacing(2));
     let style = surface.compose([
         ("padding", padding),

--- a/crates/mui-joy/src/chip.rs
+++ b/crates/mui-joy/src/chip.rs
@@ -5,7 +5,8 @@ use yew::prelude::*;
 use yew::virtual_dom::AttrValue;
 
 use crate::helpers::{
-    compose_inline_style, resolve_surface_tokens, use_chip_adapter, ChipAdapterConfig, SurfaceTokens,
+    compose_inline_style, resolve_surface_tokens, use_chip_adapter, ChipAdapterConfig,
+    SurfaceTokens,
 };
 use crate::{joy_component_props, Color, Variant};
 
@@ -48,8 +49,11 @@ joy_component_props!(ChipProps {
 pub fn chip(props: &ChipProps) -> Html {
     let theme = use_theme();
 
-    let surface: SurfaceTokens = resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
-    let dismissible = props.dismissible.unwrap_or_else(|| props.on_delete.is_some());
+    let surface: SurfaceTokens =
+        resolve_surface_tokens(&theme, props.color.clone(), props.variant.clone());
+    let dismissible = props
+        .dismissible
+        .unwrap_or_else(|| props.on_delete.is_some());
     let config = ChipAdapterConfig {
         dismissible: dismissible && props.on_delete.is_some(),
         disabled: props.disabled,
@@ -101,39 +105,38 @@ pub fn chip(props: &ChipProps) -> Html {
         AttrValue::from("0")
     };
 
-    let delete_button = if (adapter.controls_visible || adapter.deleting)
-        && adapter.on_delete_click.is_some()
-    {
-        let mut delete_style = vec![
-            ("background", "transparent".to_string()),
-            ("border", "none".to_string()),
-            ("padding", "0".to_string()),
-            ("margin-left", "4px".to_string()),
-        ];
-        delete_style.push((
-            "cursor",
-            if adapter.disabled {
-                "not-allowed".to_string()
-            } else {
-                "pointer".to_string()
-            },
-        ));
-        let delete_style = compose_inline_style(delete_style);
-        let onclick = adapter.on_delete_click.as_ref().unwrap().clone();
-        html! {
-            <button
-                type="button"
-                style={delete_style}
-                aria-label="Remove chip"
-                disabled={adapter.disabled}
-                onclick={onclick}
-            >
-                {"×"}
-            </button>
-        }
-    } else {
-        Html::default()
-    };
+    let delete_button =
+        if (adapter.controls_visible || adapter.deleting) && adapter.on_delete_click.is_some() {
+            let mut delete_style = vec![
+                ("background", "transparent".to_string()),
+                ("border", "none".to_string()),
+                ("padding", "0".to_string()),
+                ("margin-left", "4px".to_string()),
+            ];
+            delete_style.push((
+                "cursor",
+                if adapter.disabled {
+                    "not-allowed".to_string()
+                } else {
+                    "pointer".to_string()
+                },
+            ));
+            let delete_style = compose_inline_style(delete_style);
+            let onclick = adapter.on_delete_click.as_ref().unwrap().clone();
+            html! {
+                <button
+                    type="button"
+                    style={delete_style}
+                    aria-label="Remove chip"
+                    disabled={adapter.disabled}
+                    onclick={onclick}
+                >
+                    {"×"}
+                </button>
+            }
+        } else {
+            Html::default()
+        };
 
     html! {
         <span

--- a/crates/mui-joy/src/lib.rs
+++ b/crates/mui-joy/src/lib.rs
@@ -29,7 +29,6 @@
 //! primitives behave consistently across frameworks. This design avoids manual repetitive
 //! glue code and ensures future adapters reuse the exact same prop contracts.
 
-pub mod helpers;
 #[cfg(feature = "yew")]
 pub mod accordion;
 #[cfg(feature = "yew")]
@@ -42,6 +41,8 @@ pub mod button;
 pub mod card;
 #[cfg(feature = "yew")]
 pub mod chip;
+pub mod helpers;
+pub mod macros;
 #[cfg(feature = "yew")]
 pub mod slider;
 #[cfg(feature = "yew")]
@@ -50,7 +51,6 @@ pub mod snackbar;
 pub mod stepper;
 #[cfg(feature = "yew")]
 pub mod toggle_button_group;
-pub mod macros;
 
 #[cfg(feature = "yew")]
 pub use accordion::{AccordionController, AccordionGroupState, AccordionItemChange};
@@ -58,7 +58,7 @@ pub use accordion::{AccordionController, AccordionGroupState, AccordionItemChang
 pub use aspect_ratio::{AspectRatio, AspectRatioProps};
 #[cfg(feature = "yew")]
 pub use autocomplete::{
-    AutocompleteChange, AutocompleteConfig, AutocompleteController, AutocompleteControlStrategy,
+    AutocompleteChange, AutocompleteConfig, AutocompleteControlStrategy, AutocompleteController,
     AutocompleteState,
 };
 #[cfg(feature = "yew")]
@@ -69,15 +69,13 @@ pub use card::{Card, CardProps};
 pub use chip::{Chip, ChipProps};
 pub use macros::{Color, Variant};
 #[cfg(feature = "yew")]
-pub use slider::{
-    SliderChange, SliderConfig, SliderController, SliderOrientation, SliderState,
-};
+pub use slider::{SliderChange, SliderConfig, SliderController, SliderOrientation, SliderState};
 #[cfg(feature = "yew")]
 pub use snackbar::{
     SnackbarChange, SnackbarConfig, SnackbarController, SnackbarMessage, SnackbarState,
 };
 #[cfg(feature = "yew")]
-pub use stepper::{StepStatus, StepperChange, StepperController, StepperConfig, StepperState};
+pub use stepper::{StepStatus, StepperChange, StepperConfig, StepperController, StepperState};
 #[cfg(feature = "yew")]
 pub use toggle_button_group::{
     ToggleButtonGroupChange, ToggleButtonGroupConfig, ToggleButtonGroupController,

--- a/crates/mui-joy/src/macros.rs
+++ b/crates/mui-joy/src/macros.rs
@@ -42,7 +42,7 @@ macro_rules! joy_props {
         pub struct $name {
             $(
                 $(#[$meta])*
-                #[cfg_attr(feature = "yew", yew::prop_or_default)]
+                #[cfg_attr(feature = "yew", prop_or_default)]
                 pub $field: $ty,
             )*
         }

--- a/crates/mui-joy/src/slider.rs
+++ b/crates/mui-joy/src/slider.rs
@@ -5,9 +5,7 @@
 //! controller simply wraps the reusable [`SliderState`] so state transitions stay
 //! centralised.
 
-pub use mui_headless::slider::{
-    SliderChange, SliderConfig, SliderOrientation, SliderState,
-};
+pub use mui_headless::slider::{SliderChange, SliderConfig, SliderOrientation, SliderState};
 
 /// Wrapper owning a [`SliderState`] for Joy renderers.
 #[derive(Debug, Clone)]

--- a/crates/mui-joy/src/snackbar.rs
+++ b/crates/mui-joy/src/snackbar.rs
@@ -5,9 +5,7 @@
 //! simply forward events into the controller and map the emitted
 //! [`SnackbarChange`] into UI updates.
 
-pub use mui_headless::snackbar::{
-    SnackbarChange, SnackbarConfig, SnackbarMessage, SnackbarState,
-};
+pub use mui_headless::snackbar::{SnackbarChange, SnackbarConfig, SnackbarMessage, SnackbarState};
 
 /// Wrapper around [`SnackbarState`] that keeps the clock generic for tests.
 #[derive(Debug, Clone)]

--- a/crates/mui-joy/src/stepper.rs
+++ b/crates/mui-joy/src/stepper.rs
@@ -4,9 +4,7 @@
 //! teams can consolidate automation and analytics.  Once visual components are
 //! added they simply render according to the controller’s change stream.
 
-pub use mui_headless::stepper::{
-    StepStatus, StepperChange, StepperConfig, StepperState,
-};
+pub use mui_headless::stepper::{StepStatus, StepperChange, StepperConfig, StepperState};
 
 /// Wrapper around [`StepperState`] prepared for Joy adapters.
 #[derive(Debug, Clone)]

--- a/docs/src/pages/company/joy-workflows.md
+++ b/docs/src/pages/company/joy-workflows.md
@@ -1,0 +1,30 @@
+# Joy UI workflows across frameworks
+
+The RusticUI workspace ships a shared Joy workflow machine that keeps SSR,
+hydration, and analytics semantics in sync across every supported framework. The
+`joy-workflows-core` crate centralises the business logic while the adapter
+crates (Yew, Leptos, Dioxus, Sycamore) focus purely on rendering.
+
+## Reference demos
+
+- [Joy workflow – Yew](../../../../examples/joy-yew) (`trunk serve --open`)
+- [Joy workflow – Leptos](../../../../examples/joy-leptos) (`trunk serve --open`)
+- [Joy workflow – Dioxus](../../../../examples/joy-dioxus) (`dx serve --open`)
+- [Joy workflow – Sycamore](../../../../examples/joy-sycamore) (`trunk serve --open`)
+
+Each demo consumes the same `JoyWorkflowMachine` and analytics identifiers so QA
+pipelines can reuse automation selectors without branching per framework.
+
+## Parity automation
+
+Coverage is enforced by the `joy-parity` inventory scanner:
+
+```bash
+cargo xtask joy-parity
+```
+
+The task refreshes [`docs/joy-component-parity.md`](../../../joy-component-parity.md)
+which CI consumes to guarantee that the Rust adapters match the canonical React
+markup. Running the scanner locally before opening a pull request keeps the
+workflows in lockstep and prevents regressions from slipping through SSR or
+hydration.

--- a/examples/joy-dioxus/Cargo.toml
+++ b/examples/joy-dioxus/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "joy-dioxus"
+version = "0.1.0"
+edition = "2021"
+description = "Joy UI workflow demo rendered with Dioxus"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+dioxus = { workspace = true, features = ["macro", "hooks", "html"] }
+dioxus-web = { workspace = true, features = ["file_engine"] }
+joy-workflows-core = { path = "../joy-workflows-core" }
+mui-joy = { path = "../../crates/mui-joy", default-features = false, features = ["dioxus"] }
+mui-system = { path = "../../crates/mui-system", features = ["dioxus"] }
+mui-headless = { path = "../../crates/mui-headless" }
+dioxus-ssr = { workspace = true, optional = true }
+
+[features]
+default = ["csr"]
+csr = []
+ssr = ["dioxus-ssr"]

--- a/examples/joy-dioxus/README.md
+++ b/examples/joy-dioxus/README.md
@@ -1,0 +1,34 @@
+# Joy workflow – Dioxus
+
+The Dioxus flavour of the Joy workflow consumes the same
+[`joy-workflows-core`](../joy-workflows-core) machine used by Yew and Leptos. The
+rendering logic relies on `rsx!` templates and Dioxus signals while all business
+rules (step transitions, snackbar logic, analytics IDs) remain centralised.
+
+## Highlights
+
+- **Framework agnostic state** – `use_ref` stores `JoyWorkflowMachine` so event
+  handlers mutate the shared logic directly before replacing the snapshot state.
+- **Joy token styling** – Buttons, chips, and snackbars use `resolve_surface_tokens`
+  ensuring visual parity with the Yew and Leptos builds.
+- **Analytics ready** – data attributes surface the blueprint analytics IDs so
+  cross-framework parity checks can assert identical SSR output.
+
+## Running the demo (CSR)
+
+```bash
+cd examples/joy-dioxus
+dx serve --open
+```
+
+Any Dioxus-compatible dev server (`dx serve`) will compile the workflow for
+WebAssembly and apply live reload.
+
+## Server-side rendering snapshot
+
+```bash
+cargo run --manifest-path examples/joy-dioxus/Cargo.toml --features ssr
+```
+
+The SSR binary prints a short summary including the active step and capacity
+allocation, matching the other framework adapters exactly.

--- a/examples/joy-dioxus/src/main.rs
+++ b/examples/joy-dioxus/src/main.rs
@@ -1,0 +1,297 @@
+use dioxus::events::FormEvent;
+use dioxus::prelude::*;
+use joy_workflows_core::{JoyWorkflowEvent, JoyWorkflowMachine, SnackbarSeverity};
+use mui_headless::stepper::StepStatus;
+use mui_joy::helpers::resolve_surface_tokens;
+use mui_joy::{Color, Variant};
+use mui_system::theme::Theme;
+
+fn snackbar_tokens(severity: &SnackbarSeverity) -> (Color, Variant) {
+    match severity {
+        SnackbarSeverity::Info => (Color::Neutral, Variant::Soft),
+        SnackbarSeverity::Success => (Color::Primary, Variant::Solid),
+        SnackbarSeverity::Warning => (Color::Danger, Variant::Soft),
+    }
+}
+
+fn App(cx: Scope) -> Element {
+    let machine = use_ref(cx, JoyWorkflowMachine::new);
+    let snapshot = use_state(cx, || machine.read().snapshot());
+    let capacity_profile = use_state(cx, || machine.read().capacity_profile().to_string());
+    let blueprint = machine.read().blueprint().clone();
+    let theme: Theme = blueprint.theme.clone();
+
+    let environment_style = resolve_surface_tokens(
+        &theme,
+        blueprint.environment.color.clone(),
+        blueprint.environment.variant.clone(),
+    )
+    .compose([
+        ("display", "inline-flex".to_string()),
+        ("align-items", "center".to_string()),
+        ("gap", "8px".to_string()),
+        ("padding", "6px 12px".to_string()),
+        ("font-weight", "600".to_string()),
+    ]);
+
+    let approve_style = resolve_surface_tokens(
+        &theme,
+        blueprint.approve_action.color.clone(),
+        blueprint.approve_action.variant.clone(),
+    )
+    .compose([
+        ("padding", "10px 18px".to_string()),
+        ("border", "none".to_string()),
+        ("cursor", "pointer".to_string()),
+        ("font-weight", "600".to_string()),
+        ("border-radius", "8px".to_string()),
+    ]);
+
+    let rollback_style = resolve_surface_tokens(
+        &theme,
+        blueprint.rollback_action.color.clone(),
+        blueprint.rollback_action.variant.clone(),
+    )
+    .compose([
+        ("padding", "10px 18px".to_string()),
+        ("border", "none".to_string()),
+        ("cursor", "pointer".to_string()),
+        ("font-weight", "600".to_string()),
+        ("border-radius", "8px".to_string()),
+    ]);
+
+    let on_advance = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        move |_| {
+            let next = {
+                let mut machine = machine.write_silent();
+                let next = machine.apply(JoyWorkflowEvent::Advance);
+                capacity_profile.set(machine.capacity_profile().to_string());
+                next
+            };
+            snapshot.set(next);
+        }
+    };
+
+    let on_rollback = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        move |_| {
+            let next = {
+                let mut machine = machine.write_silent();
+                let next = machine.apply(JoyWorkflowEvent::Rollback);
+                capacity_profile.set(machine.capacity_profile().to_string());
+                next
+            };
+            snapshot.set(next);
+        }
+    };
+
+    let on_capacity = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        move |ev: FormEvent| {
+            if let Ok(value) = ev.value.parse::<f64>() {
+                let next = {
+                    let mut machine = machine.write_silent();
+                    let next = machine.apply(JoyWorkflowEvent::SetCapacity(value));
+                    capacity_profile.set(machine.capacity_profile().to_string());
+                    next
+                };
+                snapshot.set(next);
+            }
+        }
+    };
+
+    let dismiss_snackbar = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        move |_| {
+            let next = {
+                let mut machine = machine.write_silent();
+                machine.apply(JoyWorkflowEvent::DismissSnackbar)
+            };
+            snapshot.set(next);
+        }
+    };
+
+    let card_shell = "max-width:960px;margin:48px auto;box-shadow:0 30px 70px rgba(15,23,42,0.35);border-radius:12px;padding:24px;display:flex;flex-direction:column;gap:16px;background:#0b1120;color:#e2e8f0;";
+
+    let snackbar_view = snapshot
+        .get()
+        .snackbar
+        .as_ref()
+        .map(|payload| {
+            let (color, variant) = snackbar_tokens(&payload.severity);
+            let style = resolve_surface_tokens(&theme, color, variant).compose([
+                ("padding", "12px 16px".to_string()),
+                ("border-radius", "8px".to_string()),
+                ("display", "flex".to_string()),
+                ("align-items", "center".to_string()),
+                ("justify-content", "space-between".to_string()),
+                ("gap", "16px".to_string()),
+            ]);
+            rsx! {
+                div {
+                    style: "{style}",
+                    "data-analytics-id": "{blueprint.automation.snackbar_id}",
+                    role: "status",
+                    "aria-live": "polite",
+                    span {{format!("{} — {}", blueprint.snackbar.success_label, payload.message)}}
+                    button {
+                        style: "background:rgba(15,23,42,0.35);border:none;color:inherit;padding:6px 12px;border-radius:6px;cursor:pointer;",
+                        onclick: move |_| dismiss_snackbar(()),
+                        "Dismiss"
+                    }
+                }
+            }
+        });
+
+    let metrics = blueprint.metrics.clone();
+    let steps = blueprint.steps.clone();
+    let marks = blueprint.capacity.marks.clone();
+
+    cx.render(rsx! {
+        main {
+            style: "min-height:100vh;background:#0f172a;padding:32px;box-sizing:border-box;font-family:'Inter',sans-serif;color:#e2e8f0;",
+            section {
+                style: "{card_shell}",
+                "data-analytics-id": "{blueprint.automation.card_id}",
+                header {
+                    style: "display:flex;flex-direction:column;gap:12px;",
+                    span {
+                        style: "{environment_style}",
+                        "data-analytics-id": "{blueprint.automation.environment_chip_id}",
+                        span {{blueprint.environment.label}}
+                        span { style: "font-weight:400;font-size:0.875rem;", {blueprint.environment.description} }
+                    }
+                    div {
+                        h1 { style: "margin:0;font-size:2rem;", {blueprint.release_title} }
+                        p { style: "margin:4px 0 0;max-width:60ch;", {blueprint.release_summary} }
+                    }
+                }
+
+                {snackbar_view}
+
+                section {
+                    style: "display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;",
+                    {metrics.iter().map(|metric| rsx! {
+                        article {
+                            style: "display:flex;flex-direction:column;gap:4px;",
+                            span { style: "font-size:0.75rem;letter-spacing:0.08em;text-transform:uppercase;color:#94a3b8;", {metric.label} }
+                            strong { style: "font-size:1.5rem;", {metric.value} }
+                            span { style: "font-size:0.9rem;color:#cbd5f5;opacity:0.9;", {metric.detail} }
+                        }
+                    })}
+                }
+
+                section {
+                    style: "display:flex;flex-direction:column;gap:12px;",
+                    label { r#for: "joy-capacity", style: "font-weight:600;", "Deployment capacity" }
+                    input {
+                        id: "joy-capacity",
+                        r#type: "range",
+                        min: "{blueprint.capacity.min}",
+                        max: "{blueprint.capacity.max}",
+                        step: "{blueprint.capacity.step}",
+                        value: format_args!("{:.0}", snapshot.get().capacity_value),
+                        style: format_args!(
+                            "width:100%;appearance:none;background:linear-gradient(90deg,#38bdf8 0%,#3b82f6 {:.2}%,rgba(148,163,184,0.3) {:.2}%);height:8px;border-radius:6px;outline:none;",
+                            snapshot.get().capacity_percent,
+                            snapshot.get().capacity_percent
+                        ),
+                        "data-analytics-id": "{blueprint.automation.capacity_slider_id}",
+                        oninput: on_capacity.clone()
+                    }
+                    div {
+                        style: "display:flex;justify-content:space-between;font-size:0.85rem;color:#94a3b8;",
+                        {marks.iter().map(|mark| rsx! { span {{format!("{}% — {}", mark.value, mark.label)}} })}
+                    }
+                    p {
+                        style: "margin:0;font-weight:500;",
+                        {format!("Current allocation: {:.0}% ({})", snapshot.get().capacity_value, capacity_profile.get())}
+                    }
+                }
+
+                section {
+                    style: "display:flex;flex-direction:column;gap:12px;",
+                    h2 { style: "margin:0;font-size:1.25rem;", "Release checklist" }
+                    ol {
+                        style: "margin:0;padding-left:18px;display:flex;flex-direction:column;gap:8px;",
+                        {steps.iter().enumerate().map(|(index, step)| {
+                            let status = snapshot
+                                .get()
+                                .step_status
+                                .get(index)
+                                .cloned()
+                                .unwrap_or(StepStatus::Pending);
+                            let status_label = match status {
+                                StepStatus::Completed => "Completed",
+                                StepStatus::Active => "In progress",
+                                _ => "Pending",
+                            };
+                            rsx! {
+                                li {
+                                    div { style: "display:flex;flex-direction:column;gap:4px;",
+                                        div { style: "display:flex;align-items:center;gap:8px;",
+                                            span { style: "font-weight:600;", {step.title} }
+                                            span { style: "font-size:0.8rem;color:#94a3b8;", {status_label} }
+                                        }
+                                        p { style: "margin:0;color:#cbd5f5;", {step.detail} }
+                                    }
+                                }
+                            }
+                        })}
+                    }
+                }
+
+                section {
+                    style: "display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;",
+                    div {
+                        "data-analytics-id": "{blueprint.approve_action.analytics_id}",
+                        style: "display:flex;flex-direction:column;gap:6px;max-width:28ch;",
+                        button { style: "{approve_style}", onclick: on_advance.clone(), disabled: snapshot.get().completed, {blueprint.approve_action.label} }
+                        span { style: "font-size:0.85rem;color:#94a3b8;", {blueprint.approve_action.description} }
+                    }
+                    div {
+                        "data-analytics-id": "{blueprint.rollback_action.analytics_id}",
+                        style: "display:flex;flex-direction:column;gap:6px;max-width:28ch;",
+                        button { style: "{rollback_style}", onclick: on_rollback.clone(), {blueprint.rollback_action.label} }
+                        span { style: "font-size:0.85rem;color:#94a3b8;", {blueprint.rollback_action.description} }
+                    }
+                }
+
+                section {
+                    style: "display:flex;flex-direction:column;gap:8px;",
+                    h3 { style: "margin:0;font-size:1rem;", "Lifecycle journal" }
+                    ul {
+                        style: "margin:0;padding-left:18px;display:flex;flex-direction:column;gap:4px;",
+                        {snapshot
+                            .get()
+                            .lifecycle_log
+                            .iter()
+                            .map(|entry| rsx! { li {{entry.clone()}} })}
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[cfg(feature = "csr")]
+fn main() {
+    dioxus_web::launch(App);
+}
+
+#[cfg(feature = "ssr")]
+fn main() {
+    let snapshot = JoyWorkflowMachine::new().snapshot();
+    println!(
+        "Joy workflow SSR snapshot: step {:?}, capacity {:.0}%",
+        snapshot.active_step_label, snapshot.capacity_value
+    );
+}

--- a/examples/joy-leptos/Cargo.toml
+++ b/examples/joy-leptos/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "joy-leptos"
+version = "0.1.0"
+edition = "2021"
+description = "Joy UI workflow demo rendered with Leptos"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+leptos = { workspace = true, default-features = false }
+wasm-bindgen.workspace = true
+joy-workflows-core = { path = "../joy-workflows-core" }
+mui-headless = { path = "../../crates/mui-headless" }
+mui-joy = { path = "../../crates/mui-joy", default-features = false, features = ["leptos"] }
+mui-system = { path = "../../crates/mui-system", features = ["leptos"] }
+tokio = { workspace = true, optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
+
+[features]
+default = ["csr"]
+csr = ["leptos/csr", "console_error_panic_hook"]
+ssr = ["leptos/ssr", "tokio"]

--- a/examples/joy-leptos/README.md
+++ b/examples/joy-leptos/README.md
@@ -1,0 +1,36 @@
+# Joy workflow – Leptos
+
+The Leptos variant reuses the [`joy-workflows-core`](../joy-workflows-core)
+state machine to deliver the exact same Joy workflow without duplicating any
+business logic. The view is composed with `view!` templates and leverages Joy
+surface tokens to keep styling consistent with the Yew build.
+
+## Highlights
+
+- **Signal driven orchestration** – a single `JoyWorkflowMachine` instance feeds
+  a `RwSignal<JoyWorkflowSnapshot>`, so every interaction runs through the shared
+  `apply` helper and re-renders declaratively.
+- **Token aware styling** – `resolve_surface_tokens` drives the environment chip,
+  action buttons, and snackbar just like the Yew implementation.
+- **Automation hooks** – the analytics identifiers from the blueprint are wired
+  into `data-analytics-id` attributes, enabling parity checks between SSR output
+  and hydrated DOM trees.
+
+## Running the demo (CSR)
+
+```bash
+rustup target add wasm32-unknown-unknown
+cd examples/joy-leptos
+trunk serve --open
+```
+
+The workflow is served from `http://127.0.0.1:8081` with live reload.
+
+## Server-side rendering snapshot
+
+```bash
+cargo run --manifest-path examples/joy-leptos/Cargo.toml --features ssr
+```
+
+The SSR binary prints the same lifecycle summary as the other adapters so teams
+can diff output across frameworks during parity audits.

--- a/examples/joy-leptos/Trunk.toml
+++ b/examples/joy-leptos/Trunk.toml
@@ -1,0 +1,5 @@
+[build]
+release = true
+
+[serve]
+port = 8081

--- a/examples/joy-leptos/index.html
+++ b/examples/joy-leptos/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Joy workflow – Leptos</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <link data-trunk rel="rust" href="Cargo.toml" />
+  </body>
+</html>

--- a/examples/joy-leptos/src/main.rs
+++ b/examples/joy-leptos/src/main.rs
@@ -1,0 +1,311 @@
+use std::{cell::RefCell, rc::Rc};
+
+use joy_workflows_core::{
+    JoyWorkflowEvent, JoyWorkflowMachine, JoyWorkflowSnapshot, SnackbarSeverity,
+};
+use leptos::ev::{Event, MouseEvent};
+use leptos::*;
+use leptos::{event_target_value, IntoView};
+use mui_headless::stepper::StepStatus;
+use mui_joy::helpers::resolve_surface_tokens;
+use mui_joy::{Color, Variant};
+
+/// Map the shared snackbar severity into Joy color/variant pairs for styling.
+fn snackbar_tokens(severity: &SnackbarSeverity) -> (Color, Variant) {
+    match severity {
+        SnackbarSeverity::Info => (Color::Neutral, Variant::Soft),
+        SnackbarSeverity::Success => (Color::Primary, Variant::Solid),
+        SnackbarSeverity::Warning => (Color::Danger, Variant::Soft),
+    }
+}
+
+/// Render the shared Joy workflow using Leptos signals.
+#[component]
+pub fn App() -> impl IntoView {
+    let machine = Rc::new(RefCell::new(JoyWorkflowMachine::new()));
+    let snapshot = create_rw_signal(machine.borrow().snapshot());
+    let capacity_profile = create_rw_signal(machine.borrow().capacity_profile().to_string());
+
+    let blueprint = machine.borrow().blueprint().clone();
+    let theme = Rc::new(blueprint.theme.clone());
+    let snackbar_theme = store_value(theme.clone());
+
+    // Callbacks centralise mutations inside the shared machine so every adapter
+    // reuses the exact same logic.
+    let on_advance = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        move |_| {
+            let next = {
+                let mut machine = machine.borrow_mut();
+                let next = machine.apply(JoyWorkflowEvent::Advance);
+                capacity_profile.set(machine.capacity_profile().to_string());
+                next
+            };
+            snapshot.set(next);
+        }
+    };
+
+    let on_rollback = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        move |_| {
+            let next = {
+                let mut machine = machine.borrow_mut();
+                let next = machine.apply(JoyWorkflowEvent::Rollback);
+                capacity_profile.set(machine.capacity_profile().to_string());
+                next
+            };
+            snapshot.set(next);
+        }
+    };
+
+    let on_capacity_change = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        move |ev: Event| {
+            if let Ok(value) = event_target_value(&ev).parse::<f64>() {
+                let next = {
+                    let mut machine = machine.borrow_mut();
+                    let next = machine.apply(JoyWorkflowEvent::SetCapacity(value));
+                    capacity_profile.set(machine.capacity_profile().to_string());
+                    next
+                };
+                snapshot.set(next);
+            }
+        }
+    };
+
+    let dismiss_snackbar = {
+        let machine = machine.clone();
+        let snapshot = snapshot.clone();
+        store_value(move |_: MouseEvent| {
+            let next = {
+                let mut machine = machine.borrow_mut();
+                machine.apply(JoyWorkflowEvent::DismissSnackbar)
+            };
+            snapshot.set(next);
+        })
+    };
+
+    let environment_style = resolve_surface_tokens(
+        &*theme,
+        blueprint.environment.color.clone(),
+        blueprint.environment.variant.clone(),
+    )
+    .compose([
+        ("display", "inline-flex".to_string()),
+        ("align-items", "center".to_string()),
+        ("gap", "8px".to_string()),
+        ("padding", "6px 12px".to_string()),
+        ("font-weight", "600".to_string()),
+    ]);
+
+    let approve_style = resolve_surface_tokens(
+        &*theme,
+        blueprint.approve_action.color.clone(),
+        blueprint.approve_action.variant.clone(),
+    )
+    .compose([
+        ("padding", "10px 18px".to_string()),
+        ("border", "none".to_string()),
+        ("cursor", "pointer".to_string()),
+        ("font-weight", "600".to_string()),
+        ("border-radius", "8px".to_string()),
+    ]);
+
+    let rollback_style = resolve_surface_tokens(
+        &*theme,
+        blueprint.rollback_action.color.clone(),
+        blueprint.rollback_action.variant.clone(),
+    )
+    .compose([
+        ("padding", "10px 18px".to_string()),
+        ("border", "none".to_string()),
+        ("cursor", "pointer".to_string()),
+        ("font-weight", "600".to_string()),
+        ("border-radius", "8px".to_string()),
+    ]);
+
+    let card_shell = "max-width:960px;margin:48px auto;box-shadow:0 30px 70px rgba(15,23,42,0.35);border-radius:12px;padding:24px;display:flex;flex-direction:column;gap:16px;background:#0b1120;color:#e2e8f0;";
+
+    view! {
+        <main style="min-height:100vh;background:#0f172a;padding:32px;box-sizing:border-box;font-family:'Inter',sans-serif;color:#e2e8f0;">
+            <section style=card_shell data-analytics-id={blueprint.automation.card_id}>
+                <header style="display:flex;flex-direction:column;gap:12px;">
+                    <span style={environment_style} data-analytics-id={blueprint.automation.environment_chip_id}>
+                        <span>{blueprint.environment.label}</span>
+                        <span style="font-weight:400;font-size:0.875rem;">{blueprint.environment.description}</span>
+                    </span>
+                    <div>
+                        <h1 style="margin:0;font-size:2rem;">{blueprint.release_title}</h1>
+                        <p style="margin:4px 0 0;max-width:60ch;">{blueprint.release_summary}</p>
+                    </div>
+                </header>
+
+                <Show when=move || snapshot.get().snackbar.is_some() fallback=|| view! { <></> }>
+                    {move || {
+                        let snapshot: JoyWorkflowSnapshot = snapshot.get();
+                        match snapshot.snackbar {
+                            Some(payload) => {
+                                let (color, variant) = snackbar_tokens(&payload.severity);
+                                let style = snackbar_theme.with_value(|theme| {
+                                    resolve_surface_tokens(
+                                        theme.as_ref(),
+                                        color.clone(),
+                                        variant.clone(),
+                                    )
+                                    .compose([
+                                        ("padding", "12px 16px".to_string()),
+                                        ("border-radius", "8px".to_string()),
+                                        ("display", "flex".to_string()),
+                                        ("align-items", "center".to_string()),
+                                        ("justify-content", "space-between".to_string()),
+                                        ("gap", "16px".to_string()),
+                                    ])
+                                });
+                                view! {
+                                    <div
+                                        style=style
+                                        data-analytics-id={blueprint.automation.snackbar_id}
+                                        role="status"
+                                        aria-live="polite"
+                                    >
+                                        <span>{format!("{} — {}", blueprint.snackbar.success_label, payload.message)}</span>
+                                        <button
+                                            style="background:rgba(15,23,42,0.35);border:none;color:inherit;padding:6px 12px;border-radius:6px;cursor:pointer;"
+                                            on:click=move |event| dismiss_snackbar.with_value(|handler| handler(event))
+                                        >{"Dismiss"}</button>
+                                    </div>
+                                }
+                            }
+                            None => view! { <div style="display:none;"></div> },
+                        }
+                    }}
+                </Show>
+
+                <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;">
+                    {blueprint
+                        .metrics
+                        .iter()
+                        .map(|metric| {
+                            view! {
+                                <article style="display:flex;flex-direction:column;gap:4px;">
+                                    <span style="font-size:0.75rem;letter-spacing:0.08em;text-transform:uppercase;color:#94a3b8;">{metric.label}</span>
+                                    <strong style="font-size:1.5rem;">{metric.value}</strong>
+                                    <span style="font-size:0.9rem;color:#cbd5f5;opacity:0.9;">{metric.detail}</span>
+                                </article>
+                            }
+                        })
+                        .collect::<Vec<_>>()}
+                </section>
+
+                <section style="display:flex;flex-direction:column;gap:12px;">
+                    <label for="joy-capacity" style="font-weight:600;">{"Deployment capacity"}</label>
+                    <input
+                        id="joy-capacity"
+                        type="range"
+                        min={blueprint.capacity.min}
+                        max={blueprint.capacity.max}
+                        step={blueprint.capacity.step}
+                        prop:value=move || format!("{:.0}", snapshot.get().capacity_value)
+                        style=move || format!(
+                            "width:100%;appearance:none;background:linear-gradient(90deg,#38bdf8 0%,#3b82f6 {:.2}%,rgba(148,163,184,0.3) {:.2}%);height:8px;border-radius:6px;outline:none;",
+                            snapshot.get().capacity_percent,
+                            snapshot.get().capacity_percent
+                        )
+                        data-analytics-id={blueprint.automation.capacity_slider_id}
+                        on:input=on_capacity_change.clone()
+                    />
+                    <div style="display:flex;justify-content:space-between;font-size:0.85rem;color:#94a3b8;">
+                        {blueprint
+                            .capacity
+                            .marks
+                            .iter()
+                            .map(|mark| view! { <span>{format!("{}% — {}", mark.value, mark.label)}</span> })
+                            .collect::<Vec<_>>()}
+                    </div>
+                    <p style="margin:0;font-weight:500;">{move || format!("Current allocation: {:.0}% ({})", snapshot.get().capacity_value, capacity_profile.get())}</p>
+                </section>
+
+                <section style="display:flex;flex-direction:column;gap:12px;">
+                    <h2 style="margin:0;font-size:1.25rem;">{"Release checklist"}</h2>
+                    <ol style="margin:0;padding-left:18px;display:flex;flex-direction:column;gap:8px;">
+                        {blueprint
+                            .steps
+                            .iter()
+                            .enumerate()
+                            .map(|(index, step)| {
+                                view! {
+                                    <li>
+                                        <div style="display:flex;flex-direction:column;gap:4px;">
+                                            <div style="display:flex;align-items:center;gap:8px;">
+                                                <span style="font-weight:600;">{step.title}</span>
+                                            <span style="font-size:0.8rem;color:#94a3b8;">{move || {
+                                                snapshot
+                                                    .get()
+                                                    .step_status
+                                                    .get(index)
+                                                    .map(|status| match status {
+                                                        StepStatus::Completed => "Completed",
+                                                        StepStatus::Active => "In progress",
+                                                        _ => "Pending",
+                                                    })
+                                                    .unwrap_or("Pending")
+                                                    .to_string()
+                                            }}</span>
+                                            </div>
+                                            <p style="margin:0;color:#cbd5f5;">{step.detail}</p>
+                                        </div>
+                                    </li>
+                                }
+                            })
+                            .collect::<Vec<_>>()}
+                    </ol>
+                </section>
+
+                <section style="display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;">
+                    <div data-analytics-id={blueprint.approve_action.analytics_id} style="display:flex;flex-direction:column;gap:6px;max-width:28ch;">
+                        <button style={approve_style.clone()} on:click=on_advance.clone() disabled=move || snapshot.get().completed>{blueprint.approve_action.label}</button>
+                        <span style="font-size:0.85rem;color:#94a3b8;">{blueprint.approve_action.description}</span>
+                    </div>
+                    <div data-analytics-id={blueprint.rollback_action.analytics_id} style="display:flex;flex-direction:column;gap:6px;max-width:28ch;">
+                        <button style={rollback_style.clone()} on:click=on_rollback.clone()>{blueprint.rollback_action.label}</button>
+                        <span style="font-size:0.85rem;color:#94a3b8;">{blueprint.rollback_action.description}</span>
+                    </div>
+                </section>
+
+                <section style="display:flex;flex-direction:column;gap:8px;">
+                    <h3 style="margin:0;font-size:1rem;">{"Lifecycle journal"}</h3>
+                    <ul style="margin:0;padding-left:18px;display:flex;flex-direction:column;gap:4px;">
+                        <For
+                            each=move || snapshot.get().lifecycle_log.clone()
+                            key=|entry| entry.clone()
+                            children=|entry: String| view! { <li>{entry}</li> }
+                        />
+                    </ul>
+                </section>
+            </section>
+        </main>
+    }
+}
+
+#[cfg(feature = "csr")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn main() {
+    console_error_panic_hook::set_once();
+    leptos::mount_to_body(App);
+}
+
+#[cfg(feature = "ssr")]
+#[tokio::main]
+async fn main() {
+    let snapshot = JoyWorkflowMachine::new().snapshot();
+    println!(
+        "Joy workflow SSR snapshot: step {:?}, capacity {:.0}%",
+        snapshot.active_step_label, snapshot.capacity_value
+    );
+}

--- a/examples/joy-sycamore/Cargo.toml
+++ b/examples/joy-sycamore/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "joy-sycamore"
+version = "0.1.0"
+edition = "2021"
+description = "Joy UI workflow demo rendered with Sycamore"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+sycamore.workspace = true
+wasm-bindgen.workspace = true
+joy-workflows-core = { path = "../joy-workflows-core" }
+mui-headless = { path = "../../crates/mui-headless" }
+mui-joy = { path = "../../crates/mui-joy", default-features = false, features = ["sycamore"] }
+mui-system = { path = "../../crates/mui-system", features = ["sycamore"] }
+tokio = { workspace = true, optional = true }
+web-sys = { workspace = true, optional = true, features = ["HtmlInputElement"] }
+
+[features]
+default = ["csr"]
+csr = ["web-sys"]
+ssr = ["tokio"]

--- a/examples/joy-sycamore/README.md
+++ b/examples/joy-sycamore/README.md
@@ -1,0 +1,36 @@
+# Joy workflow – Sycamore
+
+Sycamore rounds out the Joy workflow examples by rendering the shared
+[`joy-workflows-core`](../joy-workflows-core) machine with fine-grained
+reactivity. Each state transition flows through the core crate so analytics IDs,
+snackbar behaviour, and the lifecycle journal remain identical to the other
+frameworks.
+
+## Highlights
+
+- **Shared machine** – `Rc<RefCell<JoyWorkflowMachine>>` keeps all logic in the
+  central crate while Sycamore signals mirror the resulting snapshot into the UI.
+- **Joy token styling** – surfaces reuse `resolve_surface_tokens` ensuring the
+  same colors/variants as the Yew, Leptos, and Dioxus variants.
+- **Automation parity** – data attributes expose the same analytics IDs, enabling
+  parity checks across SSR + hydration.
+
+## Running the demo (CSR)
+
+```bash
+rustup target add wasm32-unknown-unknown
+cd examples/joy-sycamore
+trunk serve --open
+```
+
+The workflow is available at `http://127.0.0.1:8082` with live reload.
+
+## Server-side rendering snapshot
+
+```bash
+cargo run --manifest-path examples/joy-sycamore/Cargo.toml --features ssr
+```
+
+As with the other adapters, the SSR binary prints a concise summary containing
+step progress and capacity allocation so teams can diff results across
+frameworks.

--- a/examples/joy-sycamore/Trunk.toml
+++ b/examples/joy-sycamore/Trunk.toml
@@ -1,0 +1,5 @@
+[build]
+release = true
+
+[serve]
+port = 8082

--- a/examples/joy-sycamore/index.html
+++ b/examples/joy-sycamore/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Joy workflow – Sycamore</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <link data-trunk rel="rust" href="Cargo.toml" />
+  </body>
+</html>

--- a/examples/joy-sycamore/src/main.rs
+++ b/examples/joy-sycamore/src/main.rs
@@ -1,0 +1,370 @@
+use std::{cell::RefCell, rc::Rc};
+
+use joy_workflows_core::{JoyWorkflowEvent, JoyWorkflowMachine, SnackbarSeverity};
+use mui_headless::stepper::StepStatus;
+use mui_joy::helpers::resolve_surface_tokens;
+use mui_joy::{Color, Variant};
+use mui_system::theme::Theme;
+use sycamore::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::HtmlInputElement;
+
+/// Translate the workflow snackbar severity into Joy color + variant tokens.
+fn snackbar_tokens(severity: &SnackbarSeverity) -> (Color, Variant) {
+    match severity {
+        SnackbarSeverity::Info => (Color::Neutral, Variant::Soft),
+        SnackbarSeverity::Success => (Color::Primary, Variant::Solid),
+        SnackbarSeverity::Warning => (Color::Danger, Variant::Soft),
+    }
+}
+
+/// Root component rendered by the Sycamore example.  The implementation keeps
+/// the business logic and design tokens centralised so we only focus on binding
+/// signals + events to the Joy workflow machine.  Comments are intentionally
+/// verbose to make it obvious how each section contributes to the enterprise
+/// workflow demo and to minimise future manual boilerplate.
+#[component]
+fn App() -> View {
+    // The state machine drives the Joy workflow without any framework specific
+    // dependencies.  We wrap it in `Rc<RefCell<_>>` so event handlers can mutate
+    // it while remaining clonable for memoised closures and signals.
+    let machine = Rc::new(RefCell::new(JoyWorkflowMachine::new()));
+    let snapshot = create_signal(machine.borrow().snapshot());
+    let capacity_profile = create_signal(machine.borrow().capacity_profile().to_string());
+
+    // Clone blueprint + theme once so every closure can reference the shared
+    // descriptors without recomputing derived styles.  `Rc` lets Sycamore capture
+    // the data inside `'static` closures without juggling lifetimes.
+    let blueprint = Rc::new(machine.borrow().blueprint().clone());
+    let theme: Rc<Theme> = Rc::new(blueprint.theme.clone());
+
+    // Pre-compute the Joy surface styles that stay constant for the lifetime of
+    // the component.  Doing this upfront avoids repetitive recomposition inside
+    // the reactive closures.
+    let environment_descriptor = Rc::as_ref(&blueprint).environment.clone();
+    let approve_descriptor = Rc::as_ref(&blueprint).approve_action.clone();
+    let rollback_descriptor = Rc::as_ref(&blueprint).rollback_action.clone();
+    let automation_ids = Rc::as_ref(&blueprint).automation.clone();
+    let snackbar_descriptor = Rc::as_ref(&blueprint).snackbar.clone();
+    let release_title = Rc::as_ref(&blueprint).release_title;
+    let release_summary = Rc::as_ref(&blueprint).release_summary;
+    let card_id = automation_ids.card_id;
+    let environment_chip_id = automation_ids.environment_chip_id;
+    let capacity_slider_id = automation_ids.capacity_slider_id;
+    let snackbar_id = automation_ids.snackbar_id;
+
+    let environment_style = resolve_surface_tokens(
+        theme.as_ref(),
+        environment_descriptor.color.clone(),
+        environment_descriptor.variant.clone(),
+    )
+    .compose([
+        ("display", "inline-flex".to_string()),
+        ("align-items", "center".to_string()),
+        ("gap", "8px".to_string()),
+        ("padding", "6px 12px".to_string()),
+        ("font-weight", "600".to_string()),
+    ]);
+    let approve_style = resolve_surface_tokens(
+        theme.as_ref(),
+        approve_descriptor.color.clone(),
+        approve_descriptor.variant.clone(),
+    )
+    .compose([
+        ("padding", "10px 18px".to_string()),
+        ("border", "none".to_string()),
+        ("cursor", "pointer".to_string()),
+        ("font-weight", "600".to_string()),
+        ("border-radius", "8px".to_string()),
+    ]);
+    let rollback_style = resolve_surface_tokens(
+        theme.as_ref(),
+        rollback_descriptor.color.clone(),
+        rollback_descriptor.variant.clone(),
+    )
+    .compose([
+        ("padding", "10px 18px".to_string()),
+        ("border", "none".to_string()),
+        ("cursor", "pointer".to_string()),
+        ("font-weight", "600".to_string()),
+        ("border-radius", "8px".to_string()),
+    ]);
+
+    // Shared strings reused across the view tree.
+    let card_shell = "max-width:960px;margin:48px auto;box-shadow:0 30px 70px rgba(15,23,42,0.35);border-radius:12px;padding:24px;display:flex;flex-direction:column;gap:16px;background:#0b1120;color:#e2e8f0;";
+    let slider_min = Rc::as_ref(&blueprint).capacity.min.to_string();
+    let slider_max = Rc::as_ref(&blueprint).capacity.max.to_string();
+    let slider_step = Rc::as_ref(&blueprint).capacity.step.to_string();
+
+    // List data copied locally to avoid re-borrowing inside reactive closures.
+    let metrics = Rc::as_ref(&blueprint).metrics.clone();
+    let steps = Rc::as_ref(&blueprint).steps.clone();
+    let marks = Rc::as_ref(&blueprint).capacity.marks.clone();
+
+    // Helper that advances the workflow and refreshes all reactive signals.
+    let on_advance = {
+        let machine = Rc::clone(&machine);
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        Rc::new(move || {
+            let next = {
+                let mut machine = machine.borrow_mut();
+                let next = machine.apply(JoyWorkflowEvent::Advance);
+                capacity_profile.set(machine.capacity_profile().to_string());
+                next
+            };
+            snapshot.set(next);
+        })
+    };
+
+    // Helper that rolls back the workflow.
+    let on_rollback = {
+        let machine = Rc::clone(&machine);
+        let snapshot = snapshot.clone();
+        Rc::new(move || {
+            let next = machine.borrow_mut().apply(JoyWorkflowEvent::Rollback);
+            snapshot.set(next);
+        })
+    };
+
+    // Capacity slider handler wired to the shared machine so the Joy surface
+    // stays in sync with headless state transitions.
+    let on_capacity = {
+        let machine = Rc::clone(&machine);
+        let snapshot = snapshot.clone();
+        let capacity_profile = capacity_profile.clone();
+        Rc::new(move |event: web_sys::Event| {
+            if let Some(target) = event.target() {
+                if let Ok(input) = target.dyn_into::<HtmlInputElement>() {
+                    if let Ok(value) = input.value().parse::<f64>() {
+                        let next = {
+                            let mut machine = machine.borrow_mut();
+                            let next = machine.apply(JoyWorkflowEvent::SetCapacity(value));
+                            capacity_profile.set(machine.capacity_profile().to_string());
+                            next
+                        };
+                        snapshot.set(next);
+                    }
+                }
+            }
+        })
+    };
+
+    // Snackbar dismiss handler reused by the dynamic snackbar view.
+    let dismiss_snackbar = {
+        let machine = Rc::clone(&machine);
+        let snapshot = snapshot.clone();
+        Rc::new(move || {
+            let next = machine
+                .borrow_mut()
+                .apply(JoyWorkflowEvent::DismissSnackbar);
+            snapshot.set(next);
+        })
+    };
+
+    view! {
+        main(style="min-height:100vh;background:#0f172a;padding:32px;box-sizing:border-box;font-family:'Inter',sans-serif;color:#e2e8f0;") {
+            section(style=card_shell, data-analytics-id=card_id) {
+                header(style="display:flex;flex-direction:column;gap:12px;") {
+                    span(style=environment_style.clone(), data-analytics-id=environment_chip_id) {
+                        span { (environment_descriptor.label) }
+                        span(style="font-weight:400;font-size:0.875rem;") { (environment_descriptor.description) }
+                    }
+                    div {
+                        h1(style="margin:0;font-size:2rem;") { (release_title) }
+                        p(style="margin:4px 0 0;max-width:60ch;") { (release_summary) }
+                    }
+                }
+
+                (View::from({
+                    let snapshot = snapshot.clone();
+                    let theme = Rc::clone(&theme);
+                    let snackbar_descriptor = snackbar_descriptor.clone();
+                    let snackbar_id = snackbar_id;
+                    let dismiss_snackbar = Rc::clone(&dismiss_snackbar);
+                    move || {
+                        snapshot.with(|snap| snap.snackbar.clone()).map(|payload| {
+                            let (color, variant) = snackbar_tokens(&payload.severity);
+                            let surface = resolve_surface_tokens(theme.as_ref(), color, variant).compose([
+                                ("padding", "12px 16px".to_string()),
+                                ("border-radius", "8px".to_string()),
+                                ("display", "flex".to_string()),
+                                ("align-items", "center".to_string()),
+                                ("justify-content", "space-between".to_string()),
+                            ("gap", "16px".to_string()),
+                            ]);
+                            let dismiss = Rc::clone(&dismiss_snackbar);
+                            let success_label = snackbar_descriptor.success_label;
+                            view! {
+                                div(
+                                    style=surface,
+                                    data-analytics-id=snackbar_id,
+                                    role="status",
+                                    aria-live="polite"
+                                ) {
+                                    span {
+                                        (format!(
+                                            "{} — {}",
+                                            success_label,
+                                            payload.message
+                                        ))
+                                    }
+                                    button(
+                                        style="background:rgba(15,23,42,0.35);border:none;color:inherit;padding:6px 12px;border-radius:6px;cursor:pointer;",
+                                        on:click=move |_| dismiss()
+                                    ) { "Dismiss" }
+                                }
+                            }
+                        })
+                    }
+                }))
+
+                section(style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;") {
+                    (View::from(metrics.iter().cloned().map(|metric| {
+                        view! {
+                            article(style="display:flex;flex-direction:column;gap:4px;") {
+                                span(style="font-size:0.75rem;letter-spacing:0.08em;text-transform:uppercase;color:#94a3b8;") { (metric.label) }
+                                strong(style="font-size:1.5rem;") { (metric.value) }
+                                span(style="font-size:0.9rem;color:#cbd5f5;opacity:0.9;") { (metric.detail) }
+                            }
+                        }
+                    }).collect::<Vec<_>>()))
+                }
+
+                section(style="display:flex;flex-direction:column;gap:12px;") {
+                    label(r#for="joy-capacity", style="font-weight:600;") { "Deployment capacity" }
+                    input(
+                        id="joy-capacity",
+                        r#type="range",
+                        min=slider_min.clone(),
+                        max=slider_max.clone(),
+                        step=slider_step.clone(),
+                        value=move || snapshot.with(|snap| format!("{:.0}", snap.capacity_value)),
+                        style=move || snapshot.with(|snap| format!("width:100%;appearance:none;background:linear-gradient(90deg,#38bdf80%,#3b82f6 {:.2}%,rgba(148,163,184,0.3) {:.2}%);height:8px;border-radius:6px;outline:none;", snap.capacity_percent, snap.capacity_percent)),
+                        data-analytics-id=capacity_slider_id,
+                        on:input={
+                            let handler = Rc::clone(&on_capacity);
+                            move |event: web_sys::Event| handler(event)
+                        }
+                    )
+                    div(style="display:flex;justify-content:space-between;font-size:0.85rem;color:#94a3b8;") {
+                        (View::from(marks.iter().cloned().map(|mark| {
+                            view! { span { (format!("{}% — {}", mark.value, mark.label)) } }
+                        }).collect::<Vec<_>>()))
+                    }
+                    p(style="margin:0;font-weight:500;") {
+                        (move || {
+                            let profile = capacity_profile.get_clone();
+                            snapshot.with(|snap| {
+                                format!(
+                                    "Current allocation: {:.0}% ({})",
+                                    snap.capacity_value,
+                                    profile
+                                )
+                            })
+                        })
+                    }
+                }
+
+                section(style="display:flex;flex-direction:column;gap:12px;") {
+                    h2(style="margin:0;font-size:1.25rem;") { "Release checklist" }
+                    ol(style="margin:0;padding-left:18px;display:flex;flex-direction:column;gap:8px;") {
+                        (View::from({
+                            let snapshot = snapshot.clone();
+                            let steps = steps.clone();
+                            move || {
+                                let snapshot = snapshot.get_clone();
+                                steps
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(index, step)| {
+                                        let status_label = snapshot
+                                            .step_status
+                                            .get(index)
+                                            .cloned()
+                                            .map(|status| match status {
+                                                StepStatus::Completed => "Completed",
+                                                StepStatus::Active => "In progress",
+                                                StepStatus::Pending => "Pending",
+                                                StepStatus::Disabled => "Pending",
+                                            })
+                                            .unwrap_or("Pending");
+                                        view! {
+                                            li {
+                                                div(style="display:flex;flex-direction:column;gap:4px;") {
+                                                    div(style="display:flex;align-items:center;gap:8px;") {
+                                                        span(style="font-weight:600;") { (step.title) }
+                                                        span(style="font-size:0.8rem;color:#94a3b8;") { (status_label) }
+                                                    }
+                                                    p(style="margin:0;color:#cbd5f5;") { (step.detail) }
+                                                }
+                                            }
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                            }
+                        }))
+                    }
+                }
+
+                section(style="display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;") {
+                    div(data-analytics-id=approve_descriptor.analytics_id, style="display:flex;flex-direction:column;gap:6px;max-width:28ch;") {
+                        button(
+                            style=approve_style.clone(),
+                            disabled=move || snapshot.with(|snap| snap.completed),
+                            on:click={
+                                let handler = Rc::clone(&on_advance);
+                                move |_| handler()
+                            }
+                        ) { (approve_descriptor.label) }
+                        span(style="font-size:0.85rem;color:#94a3b8;") { (approve_descriptor.description) }
+                    }
+                    div(data-analytics-id=rollback_descriptor.analytics_id, style="display:flex;flex-direction:column;gap:6px;max-width:28ch;") {
+                        button(
+                            style=rollback_style.clone(),
+                            on:click={
+                                let handler = Rc::clone(&on_rollback);
+                                move |_| handler()
+                            }
+                        ) { (rollback_descriptor.label) }
+                        span(style="font-size:0.85rem;color:#94a3b8;") { (rollback_descriptor.description) }
+                    }
+                }
+
+                section(style="display:flex;flex-direction:column;gap:8px;") {
+                    h3(style="margin:0;font-size:1rem;") { "Lifecycle journal" }
+                    ul(style="margin:0;padding-left:18px;display:flex;flex-direction:column;gap:4px;") {
+                        (View::from({
+                            let snapshot = snapshot.clone();
+                            move || {
+                                snapshot
+                                    .get_clone()
+                                    .lifecycle_log
+                                    .iter()
+                                    .cloned()
+                                    .map(|entry| view! { li { (entry) } })
+                                    .collect::<Vec<_>>()
+                            }
+                        }))
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "csr")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn main() {
+    sycamore::render(|| view! { App {} });
+}
+
+#[cfg(feature = "ssr")]
+#[tokio::main]
+async fn main() {
+    let snapshot = JoyWorkflowMachine::new().snapshot();
+    println!(
+        "Joy workflow SSR snapshot: step {:?}, capacity {:.0}%",
+        snapshot.active_step_label, snapshot.capacity_value
+    );
+}

--- a/examples/joy-workflows-core/Cargo.toml
+++ b/examples/joy-workflows-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "joy-workflows-core"
+version = "0.1.0"
+edition = "2021"
+description = "Shared automation-first Joy workflow state used by cross-framework demos"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+mui-headless = { path = "../../crates/mui-headless" }
+mui-joy = { path = "../../crates/mui-joy", default-features = false }
+mui-system = { path = "../../crates/mui-system" }
+
+[features]
+default = []

--- a/examples/joy-workflows-core/src/lib.rs
+++ b/examples/joy-workflows-core/src/lib.rs
@@ -1,0 +1,484 @@
+//! Shared Joy UI workflow state powering the cross-framework demos.
+//!
+//! The goal of this crate is to capture **all** business logic, analytics
+//! identifiers, and design-time defaults in one place so every adapter (Yew,
+//! Leptos, Dioxus, Sycamore) can focus purely on rendering.  Keeping the
+//! workflow deterministic dramatically reduces the amount of manual wiring that
+//! enterprise application teams need to perform when spinning up new front-ends
+//! or CI smoke tests.
+//!
+//! Highlights:
+//! * **Single source of truth** – the [`JoyWorkflowMachine`] struct orchestrates
+//!   progress tracking, snackbar messaging, and lifecycle logging without any
+//!   framework specific code.
+//! * **Design token aware** – descriptors expose [`mui_joy::Color`] and
+//!   [`mui_joy::Variant`] enums so renderers can map directly onto Joy surface
+//!   helpers (`resolve_surface_tokens`) without duplicating constants.
+//! * **Automation ready** – every piece of UI state carries analytics IDs and
+//!   data attribute helpers so QA pipelines can assert parity across SSR and
+//!   hydrated runs.
+
+use mui_headless::stepper::StepStatus;
+use mui_joy::{Color, Variant};
+use mui_system::theme::Theme;
+
+/// Maximum number of lifecycle entries retained by the machine.
+const MAX_LOG_ENTRIES: usize = 32;
+
+/// Identifier bundle used by automation and analytics tooling.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowAutomationIds {
+    /// Analytics hook applied to the container card.
+    pub card_id: &'static str,
+    /// Identifier for the status chip representing the target environment.
+    pub environment_chip_id: &'static str,
+    /// Identifier applied to the capacity slider thumb.
+    pub capacity_slider_id: &'static str,
+    /// Identifier emitted on snackbar surfaces.
+    pub snackbar_id: &'static str,
+}
+
+/// Declarative description of the Joy workflow blueprint.  This structure is
+/// intentionally verbose so each adapter can reference the metadata directly in
+/// templates without hard-coding labels or forgetting automation hooks.
+#[derive(Clone)]
+pub struct JoyWorkflowBlueprint {
+    /// Theme shared across every framework example so design tokens stay in sync.
+    pub theme: Theme,
+    /// Headline describing the release under orchestration.
+    pub release_title: &'static str,
+    /// Supporting copy explaining the automation objective.
+    pub release_summary: &'static str,
+    /// Chip describing the target environment (production, staging, etc.).
+    pub environment: ChipDescriptor,
+    /// Primary action that advances the workflow.
+    pub approve_action: ActionDescriptor,
+    /// Secondary action that rolls the workflow back.
+    pub rollback_action: ActionDescriptor,
+    /// Slider controlling the deployment capacity percentage.
+    pub capacity: SliderDescriptor,
+    /// Ordered set of release checklist items rendered inside a stepper.
+    pub steps: Vec<StepDescriptor>,
+    /// Metrics surfaced in the card body (SLOs, automation coverage, etc.).
+    pub metrics: Vec<CardMetric>,
+    /// Snackbar descriptor used when steps complete or values change.
+    pub snackbar: SnackbarDescriptor,
+    /// Analytics identifiers consumed by QA tooling.
+    pub automation: WorkflowAutomationIds,
+}
+
+impl JoyWorkflowBlueprint {
+    /// Returns the enterprise defaults used by all demos.
+    pub fn enterprise_release() -> Self {
+        Self {
+            theme: Theme::default(),
+            release_title: "RusticUI Joy deployment pipeline",
+            release_summary: "This dashboard mirrors the production change management flow. Every interaction flows through the shared machine so SSR and hydration stay in lockstep across frameworks.",
+            environment: ChipDescriptor {
+                label: "Production window",
+                description: "Change freeze ends in 2h",
+                color: Color::Neutral,
+                variant: Variant::Soft,
+            },
+            approve_action: ActionDescriptor {
+                label: "Approve next gate",
+                description: "Confirms the current checklist item and unlocks the subsequent step.",
+                color: Color::Primary,
+                variant: Variant::Solid,
+                analytics_id: "joy-approve-gate",
+                throttle_ms: Some(500),
+            },
+            rollback_action: ActionDescriptor {
+                label: "Rollback gate",
+                description: "Reverts to the previous checklist item so issues can be triaged without bypassing controls.",
+                color: Color::Danger,
+                variant: Variant::Outlined,
+                analytics_id: "joy-rollback-gate",
+                throttle_ms: Some(500),
+            },
+            capacity: SliderDescriptor {
+                min: 50.0,
+                max: 150.0,
+                step: 5.0,
+                default: 100.0,
+                marks: vec![
+                    SliderMark { value: 60.0, label: "Canary" },
+                    SliderMark { value: 100.0, label: "Baseline" },
+                    SliderMark { value: 140.0, label: "Burst" },
+                ],
+            },
+            steps: vec![
+                StepDescriptor {
+                    title: "Artifact integrity",
+                    detail: "SBOM + signature validation mirrors supply chain policies.",
+                },
+                StepDescriptor {
+                    title: "Security review",
+                    detail: "Static analysis gates must succeed before scheduling a window.",
+                },
+                StepDescriptor {
+                    title: "Schedule deployment",
+                    detail: "Capacity slider is locked at 100% once this stage completes.",
+                },
+                StepDescriptor {
+                    title: "Launch + telemetry",
+                    detail: "Open the blast radius gradually and stream metrics into the SRE bridge.",
+                },
+            ],
+            metrics: vec![
+                CardMetric {
+                    label: "Automation coverage",
+                    value: "98.4%",
+                    detail: "Unit + integration suites automatically enforce Joy parity across adapters.",
+                },
+                CardMetric {
+                    label: "Pending approvals",
+                    value: "2",
+                    detail: "Design + security teams must approve before production rollout.",
+                },
+                CardMetric {
+                    label: "Last parity audit",
+                    value: "4h ago",
+                    detail: "CI inventory report refreshed via `cargo xtask joy-parity`.",
+                },
+            ],
+            snackbar: SnackbarDescriptor {
+                success_label: "Workflow updated",
+                analytics_id: "joy-workflow-snackbar",
+            },
+            automation: WorkflowAutomationIds {
+                card_id: "joy-workflow-card",
+                environment_chip_id: "joy-workflow-environment",
+                capacity_slider_id: "joy-workflow-capacity",
+                snackbar_id: "joy-workflow-snackbar",
+            },
+        }
+    }
+}
+
+/// Lightweight description of a metric rendered inside the Joy card.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CardMetric {
+    /// Metric label (for example "Automation coverage").
+    pub label: &'static str,
+    /// Primary value rendered with emphasis.
+    pub value: &'static str,
+    /// Supporting detail exposed as helper text.
+    pub detail: &'static str,
+}
+
+/// Descriptor for action buttons bound to the workflow state.
+#[derive(Clone, PartialEq)]
+pub struct ActionDescriptor {
+    /// Visible button label.
+    pub label: &'static str,
+    /// Supporting helper text shown below or beside the button.
+    pub description: &'static str,
+    /// Joy color token applied to the surface.
+    pub color: Color,
+    /// Joy variant controlling background/border styling.
+    pub variant: Variant,
+    /// Analytics hook assigned to the rendered element.
+    pub analytics_id: &'static str,
+    /// Optional throttle window to guard against double clicks.
+    pub throttle_ms: Option<u64>,
+}
+
+/// Descriptor for the environment chip rendered within the card header.
+#[derive(Clone, PartialEq)]
+pub struct ChipDescriptor {
+    /// Chip label.
+    pub label: &'static str,
+    /// Supporting helper text describing the environment state.
+    pub description: &'static str,
+    /// Joy color token applied to the chip.
+    pub color: Color,
+    /// Joy variant used for the chip surface.
+    pub variant: Variant,
+}
+
+/// Descriptor for the capacity slider.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SliderDescriptor {
+    /// Minimum logical value (percentage) allowed by the slider.
+    pub min: f64,
+    /// Maximum logical value (percentage) allowed by the slider.
+    pub max: f64,
+    /// Step granularity when nudging via keyboard controls.
+    pub step: f64,
+    /// Default value when the workflow boots.
+    pub default: f64,
+    /// Annotated marks rendered alongside the track.
+    pub marks: Vec<SliderMark>,
+}
+
+impl SliderDescriptor {
+    /// Clamp a raw value into the configured slider range.
+    pub fn clamp(&self, value: f64) -> f64 {
+        value.clamp(self.min, self.max)
+    }
+
+    /// Convert a logical value into a percentage (0-100) for progress bars.
+    pub fn percentage(&self, value: f64) -> f64 {
+        let range = (self.max - self.min).abs();
+        if range <= f64::EPSILON {
+            return 0.0;
+        }
+        ((value - self.min) / range).clamp(0.0, 1.0) * 100.0
+    }
+}
+
+/// Annotated slider mark containing a helper label.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SliderMark {
+    /// Logical value represented by the mark.
+    pub value: f64,
+    /// Human friendly label displayed alongside the tick.
+    pub label: &'static str,
+}
+
+/// Descriptor for each release checklist entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StepDescriptor {
+    /// Title rendered inside the Joy stepper.
+    pub title: &'static str,
+    /// Supporting copy explaining the step purpose.
+    pub detail: &'static str,
+}
+
+/// Snackbar configuration shared by all adapters.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnackbarDescriptor {
+    /// Short label communicated alongside snackbar payloads.
+    pub success_label: &'static str,
+    /// Analytics identifier applied to snackbar surfaces.
+    pub analytics_id: &'static str,
+}
+
+/// Severity classification for snackbar messages.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SnackbarSeverity {
+    /// Informational update (for example slider changes).
+    Info,
+    /// Successful step completion.
+    Success,
+    /// Warning when rolling back.
+    Warning,
+}
+
+/// Payload delivered to renderers whenever a snackbar is shown.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnackbarPayload {
+    /// Severity classification (maps to color/variant decisions in renderers).
+    pub severity: SnackbarSeverity,
+    /// Message presented to the user.
+    pub message: String,
+}
+
+/// Snapshot of the workflow emitted after every state transition.  The snapshot
+/// is intentionally serialisable/clonable so adapters can store it directly in
+/// framework signals or state hooks.
+#[derive(Clone, Debug, PartialEq)]
+pub struct JoyWorkflowSnapshot {
+    /// Logical value of the capacity slider.
+    pub capacity_value: f64,
+    /// Capacity value expressed as a percentage of the configured range.
+    pub capacity_percent: f64,
+    /// Index of the currently active step (if any).
+    pub active_step: Option<usize>,
+    /// Human friendly name of the active step (when present).
+    pub active_step_label: Option<&'static str>,
+    /// Presentation status for each configured step.
+    pub step_status: Vec<StepStatus>,
+    /// Snackbar payload visible after the latest transition (if any).
+    pub snackbar: Option<SnackbarPayload>,
+    /// Lifecycle log retained for QA dashboards.
+    pub lifecycle_log: Vec<String>,
+    /// Whether every step has been completed.
+    pub completed: bool,
+}
+
+/// Events recognised by the workflow machine.
+#[derive(Clone, Debug, PartialEq)]
+pub enum JoyWorkflowEvent {
+    /// Advance to the next step (if available).
+    Advance,
+    /// Roll back to the previous step (if possible).
+    Rollback,
+    /// Update the deployment capacity slider.
+    SetCapacity(f64),
+    /// Clear the currently visible snackbar message.
+    DismissSnackbar,
+}
+
+/// Deterministic workflow state machine consumed by every demo.
+#[derive(Clone)]
+pub struct JoyWorkflowMachine {
+    blueprint: JoyWorkflowBlueprint,
+    capacity_value: f64,
+    completed_steps: usize,
+    snackbar: Option<SnackbarPayload>,
+    lifecycle_log: Vec<String>,
+}
+
+impl JoyWorkflowMachine {
+    /// Construct the workflow using the enterprise blueprint.
+    pub fn new() -> Self {
+        let blueprint = JoyWorkflowBlueprint::enterprise_release();
+        let mut machine = Self {
+            capacity_value: blueprint.capacity.default,
+            completed_steps: 0,
+            snackbar: None,
+            lifecycle_log: Vec::new(),
+            blueprint,
+        };
+        machine.push_log("Workflow initialised using enterprise defaults.");
+        machine
+    }
+
+    /// Access the shared blueprint. Renderers typically clone individual
+    /// descriptors from this structure so templates remain declarative.
+    pub fn blueprint(&self) -> &JoyWorkflowBlueprint {
+        &self.blueprint
+    }
+
+    /// Dispatch a workflow event and return the resulting snapshot.
+    pub fn apply(&mut self, event: JoyWorkflowEvent) -> JoyWorkflowSnapshot {
+        match event {
+            JoyWorkflowEvent::Advance => self.advance_step(),
+            JoyWorkflowEvent::Rollback => self.rollback_step(),
+            JoyWorkflowEvent::SetCapacity(value) => self.update_capacity(value),
+            JoyWorkflowEvent::DismissSnackbar => {
+                self.snackbar = None;
+                self.snapshot()
+            }
+        }
+    }
+
+    /// Generate a read-only snapshot of the current state.
+    pub fn snapshot(&self) -> JoyWorkflowSnapshot {
+        let step_status = self
+            .blueprint
+            .steps
+            .iter()
+            .enumerate()
+            .map(|(index, _)| {
+                if index < self.completed_steps {
+                    StepStatus::Completed
+                } else if index == self.completed_steps {
+                    StepStatus::Active
+                } else {
+                    StepStatus::Pending
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let active_step = if self.completed_steps < self.blueprint.steps.len() {
+            Some(self.completed_steps)
+        } else {
+            None
+        };
+
+        let active_step_label = active_step.map(|index| self.blueprint.steps[index].title);
+        let capacity_percent = self.blueprint.capacity.percentage(self.capacity_value);
+
+        JoyWorkflowSnapshot {
+            capacity_value: self.capacity_value,
+            capacity_percent,
+            active_step,
+            active_step_label,
+            step_status,
+            snackbar: self.snackbar.clone(),
+            lifecycle_log: self.lifecycle_log.clone(),
+            completed: self.completed_steps >= self.blueprint.steps.len(),
+        }
+    }
+
+    /// Convenience accessor mirroring the internal capacity profile helper.
+    pub fn capacity_profile(&self) -> &'static str {
+        self.resolve_capacity_profile()
+    }
+
+    /// Append an entry to the lifecycle log while keeping the ring buffer small.
+    fn push_log(&mut self, message: impl Into<String>) {
+        self.lifecycle_log.push(message.into());
+        if self.lifecycle_log.len() > MAX_LOG_ENTRIES {
+            let excess = self.lifecycle_log.len() - MAX_LOG_ENTRIES;
+            self.lifecycle_log.drain(0..excess);
+        }
+    }
+
+    /// Update the snackbar payload with the provided severity + message.
+    fn set_snackbar(&mut self, severity: SnackbarSeverity, message: String) {
+        self.snackbar = Some(SnackbarPayload { severity, message });
+    }
+
+    fn advance_step(&mut self) -> JoyWorkflowSnapshot {
+        if self.completed_steps < self.blueprint.steps.len() {
+            let label = self.blueprint.steps[self.completed_steps].title;
+            self.completed_steps += 1;
+            self.push_log(format!("Completed step: {label}"));
+            if self.completed_steps < self.blueprint.steps.len() {
+                let next = self.blueprint.steps[self.completed_steps].title;
+                self.set_snackbar(SnackbarSeverity::Success, format!("Advanced to '{next}'."));
+            } else {
+                self.set_snackbar(
+                    SnackbarSeverity::Success,
+                    "Release checklist complete. Ready for production push.".into(),
+                );
+            }
+        } else {
+            self.push_log("Advance requested but workflow already completed.");
+        }
+        self.snapshot()
+    }
+
+    fn rollback_step(&mut self) -> JoyWorkflowSnapshot {
+        if self.completed_steps > 0 {
+            self.completed_steps -= 1;
+            let label = self.blueprint.steps[self.completed_steps].title;
+            self.push_log(format!("Rolled back to step: {label}"));
+            self.set_snackbar(
+                SnackbarSeverity::Warning,
+                format!("Returned to '{label}' for remediation."),
+            );
+        } else {
+            self.push_log("Rollback ignored – already at the first step.");
+            self.set_snackbar(
+                SnackbarSeverity::Info,
+                "Already reviewing the first checklist item.".into(),
+            );
+        }
+        self.snapshot()
+    }
+
+    fn update_capacity(&mut self, raw: f64) -> JoyWorkflowSnapshot {
+        let clamped = self.blueprint.capacity.clamp(raw);
+        self.capacity_value =
+            (clamped / self.blueprint.capacity.step).round() * self.blueprint.capacity.step;
+        self.push_log(format!(
+            "Capacity adjusted to {:.1}% of baseline.",
+            self.capacity_value
+        ));
+        self.set_snackbar(
+            SnackbarSeverity::Info,
+            format!(
+                "Capacity now {:.0}% ({} mode).",
+                self.capacity_value,
+                self.resolve_capacity_profile()
+            ),
+        );
+        self.snapshot()
+    }
+
+    fn resolve_capacity_profile(&self) -> &'static str {
+        let value = self.capacity_value;
+        if value < 80.0 {
+            "canary"
+        } else if value < 110.0 {
+            "baseline"
+        } else {
+            "burst"
+        }
+    }
+}

--- a/examples/joy-yew/Cargo.toml
+++ b/examples/joy-yew/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "joy-yew"
+version = "0.1.0"
+edition = "2021"
+description = "Joy UI workflow demo rendered with Yew"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+yew.workspace = true
+wasm-bindgen.workspace = true
+mui-system = { path = "../../crates/mui-system", features = ["yew"] }
+mui-joy = { path = "../../crates/mui-joy", features = ["yew"] }
+joy-workflows-core = { path = "../joy-workflows-core" }
+tokio = { workspace = true, optional = true }
+web-sys = { workspace = true, optional = true, features = ["HtmlInputElement"] }
+
+[features]
+default = ["csr"]
+csr = ["web-sys"]
+ssr = ["tokio"]

--- a/examples/joy-yew/README.md
+++ b/examples/joy-yew/README.md
@@ -1,0 +1,39 @@
+# Joy workflow – Yew
+
+This demo renders the shared [`joy-workflows-core`](../joy-workflows-core)
+blueprint with the Yew adapter from `mui-joy`. The entire pipeline – stepper
+state, snackbar logic, analytics identifiers, and Joy design tokens – lives in
+the shared crate so every framework emits identical automation hooks.
+
+## Highlights
+
+- **Single source of truth** – Buttons, slider thresholds, and the release
+  checklist are all described in `joy-workflows-core`. The Yew component simply
+  maps callbacks to `JoyWorkflowMachine::apply` and re-renders the snapshot.
+- **Joy design tokens** – The example resolves surface tokens via
+  `mui_joy::helpers::resolve_surface_tokens` to keep styling consistent with the
+  Joy design language.
+- **Analytics ready** – Every button, chip, and snackbar exposes data/analytics
+  identifiers from the blueprint so CI can assert SSR + hydration parity.
+
+## Running the demo (CSR)
+
+```bash
+rustup target add wasm32-unknown-unknown
+cd examples/joy-yew
+trunk serve --open
+```
+
+The Trunk dev server builds the WebAssembly bundle, applies live reload, and
+hosts the Joy workflow at `http://127.0.0.1:8080`.
+
+## Server-side rendering snapshot
+
+```bash
+cargo run --manifest-path examples/joy-yew/Cargo.toml --features ssr
+```
+
+The SSR binary prints a concise snapshot summarising the active step and
+capacity allocation. Because the underlying state machine is deterministic, the
+Yew, Leptos, Dioxus, and Sycamore variants all emit the same lifecycle log and
+analytics identifiers.

--- a/examples/joy-yew/Trunk.toml
+++ b/examples/joy-yew/Trunk.toml
@@ -1,0 +1,5 @@
+[build]
+release = true
+
+[serve]
+port = 8080

--- a/examples/joy-yew/index.html
+++ b/examples/joy-yew/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Joy workflow – Yew</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- Trunk injects the compiled WebAssembly bundle. -->
+    <link data-trunk rel="rust" href="Cargo.toml" />
+  </body>
+</html>

--- a/examples/joy-yew/src/main.rs
+++ b/examples/joy-yew/src/main.rs
@@ -1,0 +1,270 @@
+use joy_workflows_core::{
+    JoyWorkflowEvent, JoyWorkflowMachine, JoyWorkflowSnapshot, SnackbarSeverity,
+};
+use mui_joy::helpers::resolve_surface_tokens;
+use mui_joy::{Button, ButtonProps, Card, Color, Variant};
+use mui_system::theme_provider::{CssBaseline, ThemeProvider};
+use wasm_bindgen::JsCast;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+/// Translate the Joy stepper status into a short label for the demo UI.
+fn status_label(status: &mui_joy::stepper::StepStatus) -> &'static str {
+    use mui_joy::stepper::StepStatus::{Active, Completed, Pending};
+    match status {
+        Completed => "Completed",
+        Active => "In progress",
+        Pending => "Pending",
+        _ => "Disabled",
+    }
+}
+
+/// Determine the Joy color/variant pairing to use for snackbar payloads.
+fn snackbar_tokens(severity: &SnackbarSeverity) -> (Color, Variant) {
+    match severity {
+        SnackbarSeverity::Info => (Color::Neutral, Variant::Soft),
+        SnackbarSeverity::Success => (Color::Primary, Variant::Solid),
+        SnackbarSeverity::Warning => (Color::Danger, Variant::Soft),
+    }
+}
+
+/// Yew component rendering the shared Joy workflow.
+#[function_component(App)]
+fn app() -> Html {
+    // Centralise the workflow machine in a mutable ref so callbacks can mutate it
+    // without forcing full re-renders until the snapshot state is replaced.
+    let machine = use_mut_ref(JoyWorkflowMachine::new);
+    let snapshot_state = use_state(|| machine.borrow().snapshot());
+
+    // Clone the blueprint once per render. The struct only stores `'static`
+    // strings plus a theme clone so this is cheap and keeps the templates tidy.
+    let blueprint = { machine.borrow().blueprint().clone() };
+    let snapshot: JoyWorkflowSnapshot = (*snapshot_state).clone();
+    let capacity_profile = { machine.borrow().capacity_profile() };
+
+    // Primary action: advance the workflow stepper.
+    let on_advance = {
+        let machine = machine.clone();
+        let snapshot_state = snapshot_state.clone();
+        Callback::from(move |_| {
+            let snapshot = machine.borrow_mut().apply(JoyWorkflowEvent::Advance);
+            snapshot_state.set(snapshot);
+        })
+    };
+
+    // Secondary action: roll the workflow back.
+    let on_rollback = {
+        let machine = machine.clone();
+        let snapshot_state = snapshot_state.clone();
+        Callback::from(move |_| {
+            let snapshot = machine.borrow_mut().apply(JoyWorkflowEvent::Rollback);
+            snapshot_state.set(snapshot);
+        })
+    };
+
+    // Capacity slider handler keeps the logic inside the shared machine so SSR
+    // and hydration reuse the same validation + logging.
+    let on_capacity_change = {
+        let machine = machine.clone();
+        let snapshot_state = snapshot_state.clone();
+        Callback::from(move |event: InputEvent| {
+            if let Some(input) = event
+                .target()
+                .and_then(|target| target.dyn_into::<HtmlInputElement>().ok())
+            {
+                if let Ok(value) = input.value().parse::<f64>() {
+                    let snapshot = machine
+                        .borrow_mut()
+                        .apply(JoyWorkflowEvent::SetCapacity(value));
+                    snapshot_state.set(snapshot);
+                }
+            }
+        })
+    };
+
+    // Expose a dismiss button for snackbar payloads so automation can verify the
+    // analytics hooks even when the message is cleared.
+    let dismiss_snackbar = {
+        let machine = machine.clone();
+        let snapshot_state = snapshot_state.clone();
+        Callback::from(move |_| {
+            let snapshot = machine
+                .borrow_mut()
+                .apply(JoyWorkflowEvent::DismissSnackbar);
+            snapshot_state.set(snapshot);
+        })
+    };
+
+    // Style helpers derived from the Joy tokens so the example feels native.
+    let card_container_style = "max-width:960px;margin:48px auto;box-shadow:0 30px 70px rgba(15,23,42,0.35);border-radius:12px;";
+
+    let environment_style = resolve_surface_tokens(
+        &blueprint.theme,
+        blueprint.environment.color.clone(),
+        blueprint.environment.variant.clone(),
+    )
+    .compose([
+        ("display", "inline-flex".to_string()),
+        ("align-items", "center".to_string()),
+        ("gap", "8px".to_string()),
+        ("padding", "6px 12px".to_string()),
+        ("font-weight", "600".to_string()),
+    ]);
+
+    let snackbar_view = snapshot.snackbar.as_ref().map(|payload| {
+        let (color, variant) = snackbar_tokens(&payload.severity);
+        let style = resolve_surface_tokens(&blueprint.theme, color, variant).compose([
+            ("padding", "12px 16px".to_string()),
+            ("border-radius", "8px".to_string()),
+            ("display", "flex".to_string()),
+            ("align-items", "center".to_string()),
+            ("justify-content", "space-between".to_string()),
+            ("gap", "16px".to_string()),
+        ]);
+        html! {
+            <div
+                style={style}
+                data-analytics-id={blueprint.automation.snackbar_id}
+                role="status"
+                aria-live="polite"
+            >
+                <span>{format!("{} — {}", blueprint.snackbar.success_label, payload.message)}</span>
+                <button type="button" onclick={dismiss_snackbar.clone()}>{"Dismiss"}</button>
+            </div>
+        }
+    });
+
+    let approve_button = ButtonProps {
+        color: blueprint.approve_action.color.clone(),
+        variant: blueprint.approve_action.variant.clone(),
+        label: blueprint.approve_action.label.to_string(),
+        onclick: on_advance.clone(),
+        throttle_ms: blueprint.approve_action.throttle_ms,
+        disabled: snapshot.completed,
+    };
+
+    let rollback_button = ButtonProps {
+        color: blueprint.rollback_action.color.clone(),
+        variant: blueprint.rollback_action.variant.clone(),
+        label: blueprint.rollback_action.label.to_string(),
+        onclick: on_rollback.clone(),
+        throttle_ms: blueprint.rollback_action.throttle_ms,
+        disabled: snapshot.completed && snapshot.active_step.is_none(),
+    };
+
+    html! {
+        <ThemeProvider theme={blueprint.theme.clone()}>
+            <CssBaseline />
+            <main style="min-height:100vh;background:#0f172a;padding:32px;box-sizing:border-box;">
+                <div style={card_container_style}>
+                    <Card color={Color::Neutral} variant={Variant::Soft}>
+                        <div
+                            style="display:flex;flex-direction:column;gap:16px;"
+                            data-analytics-id={blueprint.automation.card_id}
+                        >
+                        <header style="display:flex;flex-direction:column;gap:12px;">
+                            <div style={environment_style.clone()} data-analytics-id={blueprint.automation.environment_chip_id}>
+                                <span>{blueprint.environment.label}</span>
+                                <span style="font-weight:400;font-size:0.875rem;">{blueprint.environment.description}</span>
+                            </div>
+                            <div>
+                                <h1 style="margin:0;font-size:2rem;">{blueprint.release_title}</h1>
+                                <p style="margin:4px 0 0;max-width:60ch;">{blueprint.release_summary}</p>
+                            </div>
+                        </header>
+
+                        if let Some(snackbar) = snackbar_view {
+                            <section>{snackbar}</section>
+                        }
+
+                        <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;">
+                            { for blueprint.metrics.iter().map(|metric| html! {
+                                <article style="display:flex;flex-direction:column;gap:4px;">
+                                    <span style="font-size:0.75rem;letter-spacing:0.08em;text-transform:uppercase;color:#94a3b8;">{metric.label}</span>
+                                    <strong style="font-size:1.5rem;">{metric.value}</strong>
+                                    <span style="font-size:0.9rem;color:#cbd5f5;opacity:0.9;">{metric.detail}</span>
+                                </article>
+                            }) }
+                        </section>
+
+                        <section style="display:flex;flex-direction:column;gap:12px;">
+                            <label for="joy-capacity" style="font-weight:600;">{"Deployment capacity"}</label>
+                            <input
+                                id="joy-capacity"
+                                type="range"
+                                min={blueprint.capacity.min.to_string()}
+                                max={blueprint.capacity.max.to_string()}
+                                step={blueprint.capacity.step.to_string()}
+                                value={format!("{:.0}", snapshot.capacity_value)}
+                                style={format!("width:100%;appearance:none;background:linear-gradient(90deg,#38bdf8 0%,#3b82f6 {:.2}%,rgba(148,163,184,0.3) {:.2}%);
+                                    height:8px;border-radius:6px;outline:none;", snapshot.capacity_percent, snapshot.capacity_percent)}
+                                oninput={on_capacity_change.clone()}
+                                data-analytics-id={blueprint.automation.capacity_slider_id}
+                            />
+                            <div style="display:flex;justify-content:space-between;font-size:0.85rem;color:#94a3b8;">
+                                { for blueprint.capacity.marks.iter().map(|mark| html! {
+                                    <span>{format!("{}% — {}", mark.value, mark.label)}</span>
+                                }) }
+                            </div>
+                            <p style="margin:0;font-weight:500;">{format!("Current allocation: {:.0}% ({})", snapshot.capacity_value, capacity_profile)}</p>
+                        </section>
+
+                        <section style="display:flex;flex-direction:column;gap:12px;">
+                            <h2 style="margin:0;font-size:1.25rem;">{"Release checklist"}</h2>
+                            <ol style="margin:0;padding-left:18px;display:flex;flex-direction:column;gap:8px;">
+                                { for blueprint.steps.iter().enumerate().map(|(index, step)| {
+                                    let status = snapshot.step_status.get(index).cloned().unwrap_or(mui_joy::stepper::StepStatus::Pending);
+                                    html! {
+                                        <li>
+                                            <div style="display:flex;flex-direction:column;gap:4px;">
+                                                <div style="display:flex;align-items:center;gap:8px;">
+                                                    <span style="font-weight:600;">{step.title}</span>
+                                                    <span style="font-size:0.8rem;color:#94a3b8;">{status_label(&status)}</span>
+                                                </div>
+                                                <p style="margin:0;color:#cbd5f5;">{step.detail}</p>
+                                            </div>
+                                        </li>
+                                    }
+                                }) }
+                            </ol>
+                        </section>
+
+                        <section style="display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;">
+                            <div data-analytics-id={blueprint.approve_action.analytics_id}>
+                                <Button ..approve_button.clone() />
+                                <p style="margin:4px 0 0;font-size:0.85rem;color:#94a3b8;max-width:28ch;">{blueprint.approve_action.description}</p>
+                            </div>
+                            <div data-analytics-id={blueprint.rollback_action.analytics_id}>
+                                <Button ..rollback_button.clone() />
+                                <p style="margin:4px 0 0;font-size:0.85rem;color:#94a3b8;max-width:28ch;">{blueprint.rollback_action.description}</p>
+                            </div>
+                        </section>
+
+                        <section style="display:flex;flex-direction:column;gap:8px;">
+                            <h3 style="margin:0;font-size:1rem;">{"Lifecycle journal"}</h3>
+                            <ul style="margin:0;padding-left:18px;display:flex;flex-direction:column;gap:4px;">
+                                { for snapshot.lifecycle_log.iter().map(|entry| html! { <li>{entry}</li> }) }
+                            </ul>
+                        </section>
+                        </div>
+                    </Card>
+                </div>
+            </main>
+        </ThemeProvider>
+    }
+}
+
+#[cfg(feature = "csr")]
+fn main() {
+    yew::Renderer::<App>::new().render();
+}
+
+#[cfg(feature = "ssr")]
+#[tokio::main]
+async fn main() {
+    let snapshot = JoyWorkflowMachine::new().snapshot();
+    println!(
+        "Joy workflow SSR snapshot: step {:?}, capacity {:.0}%",
+        snapshot.active_step_label, snapshot.capacity_value
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared `joy-workflows-core` crate so every framework example reuses the same Joy workflow machine and analytics identifiers
- scaffold Joy workflow demos for Yew, Leptos, Dioxus, and Sycamore that consume the shared machine and ship runnable build instructions
- refresh Joy documentation with installation guidance, feature matrices, example snippets, and docs links that surface the parity inventory report

## Testing
- cargo check --manifest-path examples/joy-yew/Cargo.toml
- cargo check --manifest-path examples/joy-leptos/Cargo.toml
- cargo check --manifest-path examples/joy-dioxus/Cargo.toml
- cargo check --manifest-path examples/joy-sycamore/Cargo.toml
- cargo check --workspace *(fails: mui-material expects older theme hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e0e71dc8832ea3366dcc29544062