### PR TITLE
Expose canonical icon-update xtask subcommand

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -142,7 +142,7 @@ jobs:
       # Regenerate component scaffolding
       - run: cargo xtask update-components
       # Refresh icon bindings from upstream Material icons
-      - run: cargo xtask refresh-icons
+      - run: cargo xtask icon-update
       # Capture the Joy UI component inventory so regressions surface quickly in diffs
       - name: Generate Joy component parity report
         run: cargo xtask joy-inventory

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ binary:
 
 ```bash
 cargo xtask scaffold-component    # scaffold a fully-instrumented component package
-cargo xtask refresh-icons         # pull the latest Rustic icon sets
+cargo xtask icon-update           # pull the latest Rustic icon sets
 cargo xtask accessibility-audit   # run Playwright accessibility tests
 cargo xtask build-docs            # build the documentation site
 ```

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -40,6 +40,15 @@ enum Commands {
     /// Build API documentation for the entire workspace.
     Doc,
     /// Refresh the Material Design icon bindings.
+    ///
+    /// Historically this task shipped under the `refresh-icons` name. We
+    /// preserve that alias so automation and bespoke scripts keep working while
+    /// providing the canonical `icon-update` entrypoint surfaced in `--help`
+    /// output for new contributors.
+    #[command(
+        name = "icon-update",
+        aliases = ["refresh-icons", "refresh_icons"]
+    )]
     RefreshIcons,
     /// Generate an `lcov.info` report using grcov.
     Coverage,


### PR DESCRIPTION
## Summary
- expose the icon maintenance task under the canonical `icon-update` name while preserving `refresh-icons` aliases for existing scripts
- update repository automation and docs to call the new canonical subcommand so contributors see consistent guidance

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets --all-features *(fails: existing cross-feature build errors in `mui-material`/`mui-joy` when all adapters compile together)*
- cargo xtask icon-update *(fails: cannot reach github.com to download upstream icon archive inside the CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d212328278832ebfda898fe7b51b58