### PR TITLE
feat: add cached Material icon updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boolinator"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +597,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -659,6 +687,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dioxus"
@@ -1089,6 +1127,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2298,9 +2346,15 @@ dependencies = [
 name = "mui-icons-material"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "clap",
  "once_cell",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
  "ureq",
  "usvg",
  "zip",
@@ -3397,6 +3451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared-dialog-state-core"
 version = "0.1.0"
 dependencies = [
@@ -4165,6 +4230,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ time = { version = "0.3", default-features = false, features = ["formatting", "m
 ureq = { version = "2.9", features = ["tls"], default-features = false }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 walkdir = "2.5"
+sha2 = { version = "0.10", default-features = false }
 heck = "0.5"
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ cargo xtask build-docs            # build the documentation site
 
 Each task emits verbose logs and returns a non-zero exit code on failure so it can be safely wired into CI pipelines.
 
+The Material icon updater persists ETag/Last-Modified metadata in
+`target/.icon-cache` so repeated runs skip unnecessary downloads. To bypass the
+cache or test alternate archives, call the binary directly:
+
+```bash
+cargo run -p mui-icons-material --features update-icons --bin update_icons -- \
+  --force-refresh --source-url https://internal.example/icons.zip
+```
+
 ### Rust CI quick reference
 
 The Rust workspace CI expects every pull request to validate the full adapter matrix locally. Install Chrome/Chromium plus `wasm-pack` (see [`docs/rust-ci.md`](docs/rust-ci.md) for setup) and run:

--- a/crates/mui-icons-material/Cargo.toml
+++ b/crates/mui-icons-material/Cargo.toml
@@ -35,10 +35,23 @@ icon-10mp_24px = []
 
 # Internal feature used only for the maintenance CLI. `dep:` ensures the
 # optional network/ZIP dependencies stay isolated until explicitly requested.
-update-icons = ["dep:ureq", "dep:zip"]
+update-icons = [
+    "dep:anyhow",
+    "dep:clap",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:sha2",
+    "dep:ureq",
+    "dep:zip",
+]
 
 [dependencies]
 once_cell.workspace = true
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 ureq = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
@@ -49,6 +62,7 @@ proc-macro2.workspace = true
 
 [dev-dependencies]
 usvg.workspace = true
+tempfile = "3.10"
 
 [[bin]]
 name = "update_icons"

--- a/crates/mui-icons-material/README.md
+++ b/crates/mui-icons-material/README.md
@@ -49,5 +49,20 @@ make icons
 
 The `update_icons` utility downloads Google's latest SVGs, refreshes the
 `material-icons/` directory and rewrites the crate's feature flags so each icon
-can be enabled individually. Subsequent `cargo build` or `cargo test` invocations
-will regenerate the Rust bindings automatically.
+can be enabled individually. Subsequent `cargo build` or `cargo test`
+invocations will regenerate the Rust bindings automatically.
+
+To keep the workflow fast on CI and local machines, HTTP metadata is cached in
+`target/.icon-cache`. The cache stores the most recent ETag/Last-Modified values
+and the archive checksum so repeated runs can skip downloading or rewriting
+identical SVGs. When testing unreleased drops or debugging stale assets you can
+invoke the binary directly and opt out of the cache layer:
+
+```bash
+cargo run -p mui-icons-material --features update-icons --bin update_icons -- \
+  --force-refresh
+```
+
+The updater also accepts `--source-url <URL>` so enterprises can point at
+mirrored archives or pre-approved artifact repositories without editing source
+files.

--- a/crates/mui-icons-material/src/bin/update_icons.rs
+++ b/crates/mui-icons-material/src/bin/update_icons.rs
@@ -1,116 +1,73 @@
-// update_icons.rs - maintenance utility for downloading and refreshing the
-// Material Design SVG icon set. The goal is to keep contributors from having
-// to manually track and copy thousands of files. Instead, a single command
-// fetches the upstream repository, extracts the production-ready `24px` SVGs,
-// and writes them into the crate's `material-icons/` directory.
-//
-// Beyond copying files, the tool also regenerates the `[features]` section in
-// the crate's `Cargo.toml`. Each icon becomes an optional feature so end users
-// can selectively include only the symbols they need, keeping compile times
-// and binary sizes manageable for large applications.
-//
-// This binary is gated behind the `update-icons` feature to avoid pulling the
-// networking and ZIP dependencies into downstream builds. CI and maintainers
-// can invoke it via `make icons`.
+// update_icons.rs - managed maintenance utility for refreshing the upstream
+// Material Design SVG archive. The binary now leans heavily on shared library
+// code so unit tests can exercise the exact same execution path that CI relies
+// on.
 
-use std::{
-    fs,
-    io::{self, Cursor, Read},
-    path::Path,
+use anyhow::Result;
+use clap::Parser;
+use mui_icons_material::icon_update::{
+    run_update, HttpFetcher, UpdateOptions, UpdateOutcome, UpdateReuseReason, DEFAULT_ZIP_URL,
 };
 
-use ureq;
-use zip::ZipArchive;
-
-/// URL of the upstream Material Design icons repository as a zip archive.
-const ZIP_URL: &str =
-    "https://github.com/google/material-design-icons/archive/refs/heads/master.zip";
-/// Location where the extracted SVGs will be written.
-const ICON_DIR: &str = "crates/mui-icons-material/material-icons";
-/// Path to the crate's manifest for feature regeneration.
-const MANIFEST_PATH: &str = "crates/mui-icons-material/Cargo.toml";
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Fetching icons from {ZIP_URL} ...");
-    let response = ureq::get(ZIP_URL).call()?;
-    let mut bytes = Vec::new();
-    response.into_reader().read_to_end(&mut bytes)?;
-
-    // Extract the downloaded archive directly from memory. Using an in-memory
-    // cursor keeps the implementation straightforward while avoiding temporary
-    // files on disk.
-    let reader = Cursor::new(bytes);
-    let mut archive = ZipArchive::new(reader)?;
-
-    let dest = Path::new(ICON_DIR);
-    if dest.exists() {
-        // Remove any pre-existing icons to avoid stale files lingering after
-        // upstream deletions or renames.
-        fs::remove_dir_all(dest)?;
-    }
-    fs::create_dir_all(dest)?;
-
-    // Collect the base names of all extracted icons. This drives the feature
-    // regeneration step later on.
-    let mut icons: Vec<String> = Vec::new();
-
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
-        let name = file.name().to_string();
-        // The Google repo contains multiple formats and sizes. We only grab the
-        // production ready 24px Material icons.
-        if !name.contains("materialicons/")
-            || !name.contains("/svg/")
-            || !name.ends_with("24px.svg")
-        {
-            continue;
-        }
-        let base = name.rsplit('/').next().unwrap().to_string();
-        let out_path = dest.join(&base);
-        let mut out_file = fs::File::create(&out_path)?;
-        io::copy(&mut file, &mut out_file)?;
-        icons.push(base.trim_end_matches(".svg").to_string());
-    }
-
-    icons.sort();
-    update_features(&icons)?;
-
-    println!("Installed {} icons into {}", icons.len(), ICON_DIR);
-    Ok(())
+/// Command line interface for the icon updater.
+///
+/// The flags are intentionally automation-friendly: everything is surfaced via
+/// stdout in machine-readable key/value pairs so CI systems can parse the
+/// output without brittle scraping.
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Download and refresh Material icon assets", long_about = None)]
+struct Cli {
+    /// Override the upstream archive location. Useful for mirroring or testing
+    /// against pre-release icon drops.
+    #[arg(long, value_name = "URL", default_value = DEFAULT_ZIP_URL)]
+    source_url: String,
+    /// Ignore cached metadata and force a full refresh of icon assets.
+    #[arg(long)]
+    force_refresh: bool,
 }
 
-/// Rewrites the `[features]` section of `Cargo.toml` so each icon can be opted
-/// into individually. A helper feature `all-icons` re-enables the full set for
-/// consumers that prefer convenience over binary size.
-fn update_features(icons: &[String]) -> Result<(), Box<dyn std::error::Error>> {
-    const START: &str = "# BEGIN ICON FEATURES -- auto-generated, do not edit by hand.";
-    const END: &str = "# END ICON FEATURES";
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let mut options = UpdateOptions::default();
+    options.source_url = cli.source_url.clone();
+    options.force_refresh = cli.force_refresh;
 
-    let manifest = fs::read_to_string(MANIFEST_PATH)?;
-    let start = manifest
-        .find(START)
-        .ok_or("start marker not found in Cargo.toml")?;
-    let end = manifest
-        .find(END)
-        .ok_or("end marker not found in Cargo.toml")?;
-
-    // Compose the replacement feature block.
-    let mut block = String::new();
-    block.push_str("all-icons = [\n");
-    for icon in icons {
-        block.push_str(&format!("    \"icon-{icon}\",\n"));
-    }
-    block.push_str("]\n");
-    for icon in icons {
-        block.push_str(&format!("icon-{icon} = []\n"));
+    if cli.force_refresh {
+        println!("ICON_UPDATE_MODE=force-refresh");
     }
 
-    let new_manifest = format!(
-        "{}\n{}{}",
-        &manifest[..start + START.len()],
-        block,
-        &manifest[end..]
+    println!(
+        "ICON_UPDATE_REQUEST url={} cache={}",
+        options.source_url,
+        options.cache_dir.display()
     );
-    fs::write(MANIFEST_PATH, new_manifest)?;
+
+    let fetcher = HttpFetcher::default();
+    match run_update(&fetcher, &options)? {
+        UpdateOutcome::Reused {
+            reason: UpdateReuseReason::HttpNotModified,
+        } => {
+            println!("ICON_UPDATE_STATUS=reused-http-not-modified");
+            println!(
+                "ICON_UPDATE_MESSAGE=Upstream archive reported 304 Not Modified; local assets left untouched"
+            );
+        }
+        UpdateOutcome::Reused {
+            reason: UpdateReuseReason::ChecksumMatch,
+        } => {
+            println!("ICON_UPDATE_STATUS=reused-checksum");
+            println!(
+                "ICON_UPDATE_MESSAGE=Downloaded archive matches existing assets; skipping rewrite"
+            );
+        }
+        UpdateOutcome::Updated { installed } => {
+            println!("ICON_UPDATE_STATUS=updated");
+            println!(
+                "ICON_UPDATE_MESSAGE=Refreshed {installed} icons in {}",
+                options.icon_dir.display()
+            );
+        }
+    }
+
     Ok(())
 }

--- a/crates/mui-icons-material/src/icon_update.rs
+++ b/crates/mui-icons-material/src/icon_update.rs
@@ -1,0 +1,604 @@
+//! Maintenance utilities shared between the `update_icons` binary and its
+//! companion tests.
+//!
+//! The module is intentionally verbose with documentation so future
+//! contributors understand the data-flow at a glance. Automating the Material
+//! icon ingestion pipeline is critical for keeping this repository
+//! maintainable at scale, so every helper is carefully annotated with its
+//! responsibilities and invariants.
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+use ureq::Response;
+use zip::ZipArchive;
+
+/// Upstream GitHub archive that houses the canonical Material Design icons.
+///
+/// The binary exposes a flag so alternate mirrors or internal artifact stores
+/// can be supplied without having to modify the source code.
+pub const DEFAULT_ZIP_URL: &str =
+    "https://github.com/google/material-design-icons/archive/refs/heads/master.zip";
+
+/// Canonical cache directory used by the updater to persist HTTP metadata.
+const CACHE_FILE: &str = "metadata.json";
+
+/// Wrapper struct describing how the icon updater should behave.
+///
+/// Keeping the configuration in a single struct keeps the binary ergonomic and
+/// makes the logic easy to unit test – we can spin up temporary directories and
+/// point the updater at them without touching real workspace files.
+#[derive(Debug, Clone)]
+pub struct UpdateOptions {
+    /// Download endpoint for the ZIP archive.
+    pub source_url: String,
+    /// Skip conditional requests and force a full refresh if set.
+    pub force_refresh: bool,
+    /// Directory backing the metadata cache.
+    pub cache_dir: PathBuf,
+    /// Destination directory that stores materialized SVGs.
+    pub icon_dir: PathBuf,
+    /// Path to the `Cargo.toml` manifest that should receive regenerated
+    /// feature listings.
+    pub manifest_path: PathBuf,
+}
+
+impl Default for UpdateOptions {
+    fn default() -> Self {
+        // `CARGO_MANIFEST_DIR` resolves to `crates/mui-icons-material`. Walking up
+        // two ancestors yields the workspace root, which hosts the shared target
+        // directory. We intentionally panic if this expectation ever breaks so
+        // contributors notice the misconfiguration immediately.
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = crate_dir
+            .ancestors()
+            .nth(2)
+            .expect("mui-icons-material lives two levels below the workspace root")
+            .to_path_buf();
+        Self {
+            source_url: DEFAULT_ZIP_URL.to_string(),
+            force_refresh: false,
+            cache_dir: workspace_root.join("target/.icon-cache"),
+            icon_dir: crate_dir.join("material-icons"),
+            manifest_path: crate_dir.join("Cargo.toml"),
+        }
+    }
+}
+
+/// Signals whether the update process reused existing assets or performed a
+/// full refresh.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateOutcome {
+    /// Assets on disk were reused and no files were modified.
+    Reused { reason: UpdateReuseReason },
+    /// The archive introduced changes and the icons/manifest were rewritten.
+    Updated { installed: usize },
+}
+
+/// Specific reuse reasons exported as a separate enum so automation can report
+/// the underlying cause with fidelity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateReuseReason {
+    /// The HTTP server returned `304 Not Modified` based on the cached ETag or
+    /// Last-Modified header, so no archive download was required.
+    HttpNotModified,
+    /// A new archive was downloaded but its contents matched the existing icon
+    /// set byte-for-byte, so there was nothing to write.
+    ChecksumMatch,
+}
+
+/// Internal metadata persisted in the cache directory. Storing the `archive_hash`
+/// allows us to debug unexpected server behaviour (e.g. mismatched responses) by
+/// examining the last known digest.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct CacheMetadata {
+    etag: Option<String>,
+    last_modified: Option<String>,
+    archive_hash: Option<String>,
+}
+
+impl CacheMetadata {
+    fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let contents = fs::read_to_string(path)
+            .with_context(|| format!("failed to read cache metadata from {}", path.display()))?;
+        let meta = serde_json::from_str(&contents).with_context(|| {
+            format!("failed to deserialize cache metadata at {}", path.display())
+        })?;
+        Ok(meta)
+    }
+
+    fn store(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create cache directory {} when persisting icon metadata",
+                    parent.display()
+                )
+            })?;
+        }
+        let payload = serde_json::to_string_pretty(self)
+            .context("failed to serialize icon cache metadata to JSON")?;
+        fs::write(path, payload)
+            .with_context(|| format!("failed to write cache metadata to {}", path.display()))?;
+        Ok(())
+    }
+}
+
+/// Abstraction over the HTTP client so tests can inject deterministic
+/// responses. The implementation used by the binary simply wraps `ureq`.
+pub trait Fetcher {
+    fn fetch(&self, url: &str, headers: &[(String, String)]) -> Result<FetchResponse>;
+}
+
+/// Lightweight response wrapper returned by [`Fetcher::fetch`].
+#[derive(Debug, Clone)]
+pub struct FetchResponse {
+    pub status: u16,
+    pub body: Vec<u8>,
+    pub etag: Option<String>,
+    pub last_modified: Option<String>,
+}
+
+/// Production HTTP client that speaks over TLS using `ureq`.
+#[derive(Default)]
+pub struct HttpFetcher;
+
+impl Fetcher for HttpFetcher {
+    fn fetch(&self, url: &str, headers: &[(String, String)]) -> Result<FetchResponse> {
+        let mut request = ureq::get(url);
+        for (name, value) in headers {
+            request = request.set(name, value);
+        }
+        let response = request
+            .call()
+            .with_context(|| format!("failed to download icon archive from {url}"))?;
+        parse_response(response, url)
+    }
+}
+
+fn parse_response(response: Response, url: &str) -> Result<FetchResponse> {
+    let status = response.status();
+    let etag = response.header("ETag").map(|value| value.to_string());
+    let last_modified = response
+        .header("Last-Modified")
+        .map(|value| value.to_string());
+
+    if status == 304 {
+        return Ok(FetchResponse {
+            status,
+            body: Vec::new(),
+            etag,
+            last_modified,
+        });
+    }
+
+    if !(200..300).contains(&status) {
+        return Err(anyhow!(
+            "unexpected status code {status} when downloading Material icons from {url}"
+        ));
+    }
+
+    let mut bytes = Vec::new();
+    response
+        .into_reader()
+        .read_to_end(&mut bytes)
+        .context("failed to read icon archive body into memory")?;
+
+    Ok(FetchResponse {
+        status,
+        body: bytes,
+        etag,
+        last_modified,
+    })
+}
+
+/// Entry point used by the binary and tests. Handles downloading, caching and
+/// manifest regeneration. The function is intentionally side-effect free until
+/// it knows the archive is newer than what is already on disk.
+pub fn run_update<F: Fetcher>(fetcher: &F, options: &UpdateOptions) -> Result<UpdateOutcome> {
+    let cache_file = options.cache_dir.join(CACHE_FILE);
+    let mut metadata = CacheMetadata::load(&cache_file)?;
+
+    let mut headers = Vec::new();
+    if !options.force_refresh {
+        if let Some(tag) = &metadata.etag {
+            headers.push(("If-None-Match".to_string(), tag.clone()));
+        }
+        if let Some(modified) = &metadata.last_modified {
+            headers.push(("If-Modified-Since".to_string(), modified.clone()));
+        }
+    }
+
+    let response = fetcher.fetch(&options.source_url, &headers)?;
+    if response.status == 304 {
+        // Persist metadata so downstream tooling can inspect the cache even if no
+        // download was required.
+        metadata.store(&cache_file)?;
+        return Ok(UpdateOutcome::Reused {
+            reason: UpdateReuseReason::HttpNotModified,
+        });
+    }
+
+    let archive_hash = compute_sha256(&response.body);
+    metadata.etag = response.etag;
+    metadata.last_modified = response.last_modified;
+    metadata.archive_hash = Some(archive_hash);
+
+    let extracted = extract_icons(&response.body)?;
+    let existing = load_existing_icons(&options.icon_dir)?;
+
+    let icons_identical = !options.force_refresh && extracted == existing;
+    if icons_identical {
+        metadata.store(&cache_file)?;
+        return Ok(UpdateOutcome::Reused {
+            reason: UpdateReuseReason::ChecksumMatch,
+        });
+    }
+
+    write_icons(&options.icon_dir, &extracted)?;
+    let icons: Vec<String> = extracted
+        .keys()
+        .map(|name| name.trim_end_matches(".svg").to_string())
+        .collect();
+    update_manifest_features(&options.manifest_path, &icons)?;
+    metadata.store(&cache_file)?;
+
+    Ok(UpdateOutcome::Updated {
+        installed: icons.len(),
+    })
+}
+
+fn compute_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    format!("{:x}", digest)
+}
+
+fn extract_icons(bytes: &[u8]) -> Result<BTreeMap<String, Vec<u8>>> {
+    let reader = Cursor::new(bytes);
+    let mut archive =
+        ZipArchive::new(reader).context("failed to parse icon archive as a ZIP file")?;
+    let mut icons = BTreeMap::new();
+
+    for index in 0..archive.len() {
+        let mut file = archive
+            .by_index(index)
+            .with_context(|| format!("failed to read entry {index} from icon archive"))?;
+        let name = file.name().to_string();
+        if !name.contains("materialicons/")
+            || !name.contains("/svg/")
+            || !name.ends_with("24px.svg")
+        {
+            continue;
+        }
+        let base = name
+            .rsplit('/')
+            .next()
+            .expect("zip entries always include a filename")
+            .to_string();
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)
+            .with_context(|| format!("failed to read {name} from the icon archive"))?;
+        icons.insert(base, data);
+    }
+
+    Ok(icons)
+}
+
+fn load_existing_icons(dir: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
+    let mut icons = BTreeMap::new();
+    if !dir.exists() {
+        return Ok(icons);
+    }
+
+    for entry in fs::read_dir(dir)
+        .with_context(|| format!("failed to iterate icon directory at {}", dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow!("icon filename contained invalid UTF-8"))?;
+        if !name.ends_with(".svg") {
+            continue;
+        }
+        let bytes = fs::read(entry.path())
+            .with_context(|| format!("failed to read existing icon {}", entry.path().display()))?;
+        icons.insert(name, bytes);
+    }
+
+    Ok(icons)
+}
+
+fn write_icons(dir: &Path, icons: &BTreeMap<String, Vec<u8>>) -> Result<()> {
+    if dir.exists() {
+        fs::remove_dir_all(dir).with_context(|| {
+            format!(
+                "failed to clear out existing icons directory {}",
+                dir.display()
+            )
+        })?;
+    }
+    fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create icons directory {}", dir.display()))?;
+
+    for (name, data) in icons {
+        let path = dir.join(name);
+        fs::write(&path, data)
+            .with_context(|| format!("failed to write extracted icon {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn update_manifest_features(manifest_path: &Path, icons: &[String]) -> Result<()> {
+    const START: &str = "# BEGIN ICON FEATURES -- auto-generated, do not edit by hand.";
+    const END: &str = "# END ICON FEATURES";
+
+    let manifest = fs::read_to_string(manifest_path).with_context(|| {
+        format!(
+            "failed to read manifest at {} when regenerating icon features",
+            manifest_path.display()
+        )
+    })?;
+
+    let start = manifest
+        .find(START)
+        .ok_or_else(|| anyhow!("start marker not found in {}", manifest_path.display()))?;
+    let end = manifest
+        .find(END)
+        .ok_or_else(|| anyhow!("end marker not found in {}", manifest_path.display()))?;
+
+    if start >= end {
+        return Err(anyhow!(
+            "icon feature markers are in an unexpected order within {}",
+            manifest_path.display()
+        ));
+    }
+
+    let mut block = String::new();
+    block.push_str("all-icons = [\n");
+    for icon in icons {
+        block.push_str(&format!("    \"icon-{icon}\",\n"));
+    }
+    block.push_str("]\n");
+    for icon in icons {
+        block.push_str(&format!("icon-{icon} = []\n"));
+    }
+
+    let new_manifest = format!(
+        "{}\n{}{}",
+        &manifest[..start + START.len()],
+        block,
+        &manifest[end..]
+    );
+
+    fs::write(manifest_path, new_manifest).with_context(|| {
+        format!(
+            "failed to rewrite manifest at {} with refreshed icon features",
+            manifest_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    struct MockFetcher {
+        responses: RefCell<Vec<FetchResponse>>,
+        recorded_headers: RefCell<Vec<Vec<(String, String)>>>,
+    }
+
+    impl MockFetcher {
+        fn new(responses: Vec<FetchResponse>) -> Self {
+            Self {
+                responses: RefCell::new(responses),
+                recorded_headers: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn last_headers(&self) -> Vec<(String, String)> {
+            self.recorded_headers
+                .borrow()
+                .last()
+                .cloned()
+                .unwrap_or_default()
+        }
+    }
+
+    impl Fetcher for MockFetcher {
+        fn fetch(&self, _url: &str, headers: &[(String, String)]) -> Result<FetchResponse> {
+            self.recorded_headers.borrow_mut().push(headers.to_vec());
+            self.responses
+                .borrow_mut()
+                .pop()
+                .ok_or_else(|| anyhow!("mock fetcher exhausted"))
+        }
+    }
+
+    fn base_manifest() -> String {
+        r#"[features]
+# BEGIN ICON FEATURES -- auto-generated, do not edit by hand.
+placeholder
+# END ICON FEATURES
+"#
+        .to_string()
+    }
+
+    fn write_manifest(dir: &TempDir) -> PathBuf {
+        let path = dir.path().join("Cargo.toml");
+        fs::write(&path, base_manifest()).expect("manifest write succeeds");
+        path
+    }
+
+    fn write_icons_fixture(dir: &TempDir, icons: &[(&str, &str)]) -> PathBuf {
+        let icon_dir = dir.path().join("icons");
+        fs::create_dir_all(&icon_dir).unwrap();
+        for (name, data) in icons {
+            fs::write(icon_dir.join(name), data).unwrap();
+        }
+        icon_dir
+    }
+
+    fn zip_bytes(entries: &[(&str, &str)]) -> Vec<u8> {
+        let cursor = Cursor::new(Vec::new());
+        let mut zip = zip::ZipWriter::new(cursor);
+        let options = zip::write::FileOptions::default();
+        for &(name, data) in entries {
+            zip.start_file(name, options).unwrap();
+            zip.write_all(data.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn cache_hit_skips_download() {
+        let temp = TempDir::new().unwrap();
+        let manifest = write_manifest(&temp);
+        let icons_dir = write_icons_fixture(&temp, &[("10k_24px.svg", "<svg />")]);
+        let cache_dir = temp.path().join("cache");
+        fs::create_dir_all(&cache_dir).unwrap();
+        CacheMetadata {
+            etag: Some("abc".to_string()),
+            last_modified: Some("Mon, 01 Jan 2024 00:00:00 GMT".to_string()),
+            archive_hash: Some("deadbeef".to_string()),
+        }
+        .store(&cache_dir.join(CACHE_FILE))
+        .unwrap();
+
+        let fetcher = MockFetcher::new(vec![FetchResponse {
+            status: 304,
+            body: Vec::new(),
+            etag: None,
+            last_modified: None,
+        }]);
+
+        let mut options = UpdateOptions::default();
+        options.cache_dir = cache_dir;
+        options.icon_dir = icons_dir;
+        options.manifest_path = manifest;
+        options.source_url = "https://example.test/icons.zip".to_string();
+
+        let outcome = run_update(&fetcher, &options).unwrap();
+        assert_eq!(
+            outcome,
+            UpdateOutcome::Reused {
+                reason: UpdateReuseReason::HttpNotModified
+            }
+        );
+        let headers = fetcher.last_headers();
+        assert!(headers.iter().any(|(name, _)| name == "If-None-Match"));
+        assert!(headers.iter().any(|(name, _)| name == "If-Modified-Since"));
+
+        let manifest_contents = fs::read_to_string(&options.manifest_path).unwrap();
+        assert!(manifest_contents.contains("placeholder"));
+    }
+
+    #[test]
+    fn identical_archive_reuses_existing_assets() {
+        let temp = TempDir::new().unwrap();
+        let manifest = write_manifest(&temp);
+        let icons_dir = write_icons_fixture(&temp, &[("10k_24px.svg", "<svg />")]);
+        let cache_dir = temp.path().join("cache");
+
+        let archive = zip_bytes(&[(
+            "material-design-icons/src/materialicons/svg/production/10k_24px.svg",
+            "<svg />",
+        )]);
+        let fetcher = MockFetcher::new(vec![FetchResponse {
+            status: 200,
+            body: archive,
+            etag: Some("etag".to_string()),
+            last_modified: Some("Tue, 02 Jan 2024 00:00:00 GMT".to_string()),
+        }]);
+
+        let mut options = UpdateOptions::default();
+        options.cache_dir = cache_dir.clone();
+        options.icon_dir = icons_dir.clone();
+        options.manifest_path = manifest.clone();
+        options.source_url = "https://example.test/icons.zip".to_string();
+
+        let outcome = run_update(&fetcher, &options).unwrap();
+        assert_eq!(
+            outcome,
+            UpdateOutcome::Reused {
+                reason: UpdateReuseReason::ChecksumMatch
+            }
+        );
+
+        let manifest_contents = fs::read_to_string(&options.manifest_path).unwrap();
+        assert!(manifest_contents.contains("placeholder"));
+
+        let metadata = CacheMetadata::load(&cache_dir.join(CACHE_FILE)).unwrap();
+        assert_eq!(metadata.etag.as_deref(), Some("etag"));
+    }
+
+    #[test]
+    fn archive_changes_trigger_full_refresh() {
+        let temp = TempDir::new().unwrap();
+        let manifest = write_manifest(&temp);
+        let icons_dir = write_icons_fixture(&temp, &[("10k_24px.svg", "<svg />")]);
+        let cache_dir = temp.path().join("cache");
+
+        let archive = zip_bytes(&[
+            (
+                "material-design-icons/src/materialicons/svg/production/10k_24px.svg",
+                "<svg>updated</svg>",
+            ),
+            (
+                "material-design-icons/src/materialicons/svg/production/20mp_24px.svg",
+                "<svg>new</svg>",
+            ),
+        ]);
+        let fetcher = MockFetcher::new(vec![FetchResponse {
+            status: 200,
+            body: archive,
+            etag: Some("fresh".to_string()),
+            last_modified: Some("Wed, 03 Jan 2024 00:00:00 GMT".to_string()),
+        }]);
+
+        let mut options = UpdateOptions::default();
+        options.cache_dir = cache_dir.clone();
+        options.icon_dir = icons_dir.clone();
+        options.manifest_path = manifest.clone();
+        options.source_url = "https://example.test/icons.zip".to_string();
+
+        let outcome = run_update(&fetcher, &options).unwrap();
+        assert_eq!(outcome, UpdateOutcome::Updated { installed: 2 });
+
+        let refreshed = fs::read_dir(&options.icon_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(refreshed.len(), 2);
+        assert!(refreshed.contains(&"10k_24px.svg".to_string()));
+        assert!(refreshed.contains(&"20mp_24px.svg".to_string()));
+
+        let manifest_contents = fs::read_to_string(&options.manifest_path).unwrap();
+        assert!(manifest_contents.contains("icon-10k_24px"));
+        assert!(manifest_contents.contains("icon-20mp_24px"));
+
+        let metadata = CacheMetadata::load(&cache_dir.join(CACHE_FILE)).unwrap();
+        assert_eq!(metadata.etag.as_deref(), Some("fresh"));
+        assert!(metadata
+            .archive_hash
+            .as_ref()
+            .map(|hash| !hash.is_empty())
+            .unwrap_or(false));
+    }
+}

--- a/crates/mui-icons-material/src/lib.rs
+++ b/crates/mui-icons-material/src/lib.rs
@@ -18,6 +18,13 @@
 // Include the generated icon functions and the `material_icon!` macro.
 include!(concat!(env!("OUT_DIR"), "/icons.rs"));
 
+// Expose the maintenance helpers only when the optional `update-icons` feature
+// is enabled. This keeps the production build lean while still allowing the
+// binary and its tests to share rich logic for caching, HTTP retrieval and
+// manifest updates.
+#[cfg(feature = "update-icons")]
+pub mod icon_update;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- introduce a shared `icon_update` module that caches HTTP metadata, skips redundant extractions, and regenerates features only when SVG payloads change
- expose force-refresh and custom source URL flags in the `update_icons` CLI while emitting machine-readable status logs
- add optional maintenance dependencies, document the caching workflow, and cover cache hit/miss flows with unit tests

## Testing
- `cargo fmt`
- `cargo test -p mui-icons-material --features update-icons`
- `cargo clippy --workspace --all-targets --all-features` *(fails: existing mui-material and mui-headless warnings/errors unrelated to this change)*
- `cargo xtask icon-update` *(fails: network is unreachable inside CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d29286f074832e9169f969274ab13a