### PR TITLE
Update xtask CLI for RusticUI workflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ serde_json = "1.0"
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 wasm-bindgen-test = "0.3"
 # Tooling dependencies powering `cargo xtask`.
-clap = { version = "4.5", features = ["derive", "std"], default-features = false }
+clap = { version = "4.5", features = ["derive", "std", "help"], default-features = false }
 anyhow = "1.0"
 usvg = "0.45.1"
 quote = "1.0"

--- a/crates/xtask/tests/cli_help.rs
+++ b/crates/xtask/tests/cli_help.rs
@@ -1,0 +1,78 @@
+//! Smoke tests that assert the CLI help output reflects the RusticUI
+//! branding and directories referenced by automation tasks.
+//!
+//! The assertions here intentionally operate on `--help` output so we avoid
+//! invoking heavyweight commands (like Playwright) during `cargo test` while
+//! still guaranteeing that contributors receive accurate documentation.
+
+use anyhow::Result;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::{Path, PathBuf};
+
+/// Mirrors the runtime helper so the tests execute in the workspace root.
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("xtask is nested two levels below the workspace root")
+        .to_path_buf()
+}
+
+#[test]
+fn root_help_mentions_rustic_branding() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("run")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Rust-first automation"))
+        .stdout(predicate::str::contains("Rustic icon bindings"));
+
+    Ok(())
+}
+
+#[test]
+fn test_help_lists_joy_examples() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("run")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .arg("test")
+        .arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("examples/joy-yew"))
+        .stdout(predicate::str::contains("examples/joy-leptos"));
+
+    Ok(())
+}
+
+#[test]
+fn nightly_accessibility_help_mentions_env_toggle() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("run")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .arg("accessibility-nightly")
+        .arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("RUSTIC_UI_A11Y_MODE"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- align the xtask CLI with the RusticUI naming, including refreshed help text and new nightly accessibility coverage
- switch the build-docs automation to generate the Rust-first mdBook site alongside API documentation
- tighten the theme generator to respect scheme overrides and add CLI help regression coverage

## Testing
- `cargo fmt`
- `cargo clippy -p xtask --all-targets`
- `cargo test -p xtask`
- `cargo run -p xtask -- icon-update --help`
- `cargo run -p xtask -- build-docs --help`
- `cargo run -p xtask -- accessibility-audit --help`
- `cargo run -p xtask -- accessibility-nightly --help`
- `cargo run -p xtask -- generate-theme --help`
- `cargo run -p xtask -- test --help`
- `cargo run -p xtask -- wasm-test --help`


------
https://chatgpt.com/codex/tasks/task_e_68d64c4d9900832ebb3c52783084dda9