### PR TITLE
Remove legacy @mui/styles alias from regression harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 RusticUI documents every step of the transition from Material UI for Rust to the Apotheon.ai–stewarded RusticUI platform. The
 archived Material UI change history now lives in [`docs/archives/material-ui-changelog.md`](docs/archives/material-ui-changelog.md).
 
+## 2025-04-01 – Regression harness styling migration guardrails
+
+### Highlights
+
+- Updated the regression Vite harness to stop aliasing the legacy `@mui/styles`
+  path, guaranteeing that contributors exercise the RusticUI styling
+  toolchain end-to-end while developing fixes.
+- Documented the change so downstream consumers can remove any remaining
+  compatibility shims and rely solely on the maintained RusticUI styling
+  adapters.
+
+### Backlog
+
+- [ ] Wire an automated alert that flags any reintroduction attempts of the
+  deprecated alias during review so the guardrail stays enforced.
+
 ## 2025-03-25 – GridLegacy removal and Grid v2 consolidation
 
 ### Highlights

--- a/test/regressions/vite.config.mts
+++ b/test/regressions/vite.config.mts
@@ -47,7 +47,15 @@ export default defineConfig({
       '@mui/lab': path.resolve(WORKSPACE_ROOT, './packages/mui-lab/src'),
       '@mui/styled-engine': path.resolve(WORKSPACE_ROOT, './packages/mui-styled-engine/src'),
       '@mui/styled-engine-sc': path.resolve(WORKSPACE_ROOT, './packages/mui-styled-engine-sc/src'),
-      '@mui/styles': path.resolve(WORKSPACE_ROOT, './packages/mui-styles/src'),
+      /**
+       * Intentionally omit an alias for the legacy `@mui/styles` package.
+       *
+       * The regression harness must mirror the production toolchain, which
+       * has fully migrated to the RusticUI styling pipeline. Dropping the
+       * alias surfaces any lingering imports immediately during local
+       * development rather than allowing stale compatibility paths to linger
+       * until CI.
+       */
       '@mui/system': path.resolve(WORKSPACE_ROOT, './packages/mui-system/src'),
       '@mui/private-theming': path.resolve(WORKSPACE_ROOT, './packages/mui-private-theming/src'),
       '@mui/utils': path.resolve(WORKSPACE_ROOT, './packages/mui-utils/src'),


### PR DESCRIPTION
## Summary
- drop the legacy `@mui/styles` alias from the regression Vite config so the harness matches the RusticUI styling toolchain
- document the guardrail in the changelog so adopters know to rely on RusticUI styling infrastructure

## Testing
- pnpm test:regressions:build *(fails: ERR_PNPM_UNSUPPORTED_ENGINE – repo requires Node >=22.18.0, env provides v20.19.4)*
- pnpm test:regressions *(fails: ERR_PNPM_UNSUPPORTED_ENGINE – repo requires Node >=22.18.0, env provides v20.19.4)*
- pnpm lint --filter test *(fails: ERR_PNPM_UNSUPPORTED_ENGINE – repo requires Node >=22.18.0, env provides v20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68d72ee6a038832e9699b0b213a7a130