### PR TITLE
Document archive manifest contract and template

### DIFF
--- a/archives/README.md
+++ b/archives/README.md
@@ -19,6 +19,22 @@ All of those flows are replaced by Rust-first crates plus automation in `scripts
 `scripts/migrate-crate-prefix.sh`, `scripts/build.mjs`, and `scripts/validateTypescriptDeclarations.mts`). These scripts
 keep any remaining Node-based interop reproducible while avoiding the hand-maintained bundle sprawl that existed before.
 
+## Archive manifest contract
+
+Every new snapshot under `archives/mui-packages/<package-name>/` must ship with an
+`archive.manifest.toml` file. The manifest is the single automation contract consumed by
+enterprise orchestrators so they can build, test, publish, or resync the snapshot without
+sprinkling bespoke scripts throughout CI pipelines.
+
+- Copy the scaffold in `archives/mui-packages/_template/archive.manifest.toml` whenever a package
+  snapshot is committed. Replace the placeholder values with real command invocations, upstream
+  Git metadata, and successor Rust crates.
+- Keep the inline comments up to date. They document how downstream teams can override the
+  automation by editing only the manifest (or layering a checked-in override file).
+- If a package relies on shared tooling, reference the canonical script under `scripts/` or
+  `tools/`. This keeps every manifest consistent and allows orchestrators to route jobs to the
+  correct shared automation entrypoint.
+
 ## Automation notes for legacy packages
 
 Archived packages should remain inert unless a resurrection is warranted. To minimize manual toil:

--- a/archives/mui-packages/_template/archive.manifest.toml
+++ b/archives/mui-packages/_template/archive.manifest.toml
@@ -1,0 +1,82 @@
+# archive.manifest.toml codifies the orchestration contract for a legacy Material UI package.
+# Copy this file into every new `archives/mui-packages/<package-name>/` directory and replace the
+# placeholder values. Because the manifest is single-source-of-truth, enterprise automation teams
+# can override workflows by editing only this file (or layering an override file in CI) instead of
+# touching multiple scripts spread across the repository.
+
+[package]
+# The package name should match the directory name. This helps orchestrators emit consistent log
+# streams and route notifications. For example: "mui-material".
+name = "mui-<package-name>"
+# The runtime of every archive package remains JavaScript/TypeScript, but by documenting it here
+# tooling can automatically choose the correct build container.
+language = "typescript"
+# The status keeps downstream dashboards aware that this folder is frozen unless a migration is
+# underway. Automation pipelines can require manual approval when status != "archived".
+status = "archived"
+# Link to a primary owner (Slack group, email, or GitHub team) so incident tooling knows who to
+# page when build/test/publish steps fail. Replace this with a real contact when instantiating.
+owner = "@rustic-ui/archives"
+
+[commands.build]
+# `run` should lean on the centralized tooling under `scripts/` or `tools/`. For example, the
+# default points to the legacy pnpm filter which ultimately delegates to `scripts/build.mjs`.
+run = "pnpm --filter mui-<package-name> build"
+# `uses` anchors the command to a reusable script. Orchestrators can swap this value to redirect the
+# build to an internal runner without editing the command string. Keep the reference stable.
+uses = "scripts/build.mjs"
+# Optional environment variables are captured inline to avoid shell wrappers. Replace with
+# `['CI=1', 'NODE_OPTIONS=--max-old-space-size=8192']` when custom behavior is required.
+env = []
+
+[commands.test]
+# Keep the test run aligned with the workspace-level runner. Downstream systems can override the
+# command (e.g., to use `make wasm-test`) by editing the manifest in deployment pipelines.
+run = "pnpm --filter mui-<package-name> test"
+# Document the canonical script reference for test orchestration. This ensures programmatic
+# consumers know that `scripts/test.mjs` already wires coverage and environment bootstrapping.
+uses = "scripts/test.mjs"
+# Flag optional test suites that orchestrators may toggle on/off. Common values: ["unit", "e2e"].
+tags = ["unit"]
+
+[commands.publish]
+# Publishing from the archive should happen rarely and only through automation. Keep the command
+# pointed at `release:pack` so that dry-runs stay reproducible. Replace `<package-name>` when
+# copying the manifest into a real package.
+run = "pnpm --filter mui-<package-name> exec pnpm release:pack"
+# `channel` communicates which npm dist-tag automation should push. Internal mirrors can swap this
+# to `nightly` or `internal` without rewriting the entire publish block.
+channel = "legacy"
+# Attach the supporting script so the orchestrator can resolve dependencies and read usage docs.
+uses = "scripts/releasePack.mts"
+
+[[sync.sources]]
+# Enumerate every upstream location that can rehydrate this archive. Most packages will point to the
+# original Material UI monorepo and a commit SHA that produced the snapshot.
+name = "material-ui"
+# `type` lets automation choose the correct sync strategy (git mirror, tarball, artifact registry).
+type = "git"
+# `url` references the canonical upstream repository.
+url = "https://github.com/mui/material-ui"
+# `revision` captures the commit or tag that aligns with the archived snapshot. Replace with a real
+# value when instantiating (for example, `v5.15.20`).
+revision = "<commit-or-tag>"
+# `path` points to the package folder inside the upstream repository, enabling partial checkouts.
+path = "packages/<package-name>"
+
+[[relationships.crates]]
+# Link to successor Rust crates so migration tooling can suggest the modern replacement when
+# developers inspect this archive. Add multiple entries if several crates supersede the package.
+name = "crates/rustic-ui-<crate-name>"
+# `role` clarifies how the crate relates to the archive (e.g., "successor", "shim", "dependency").
+role = "successor"
+# Provide context so automation can surface guidance in dashboards and documentation.
+notes = "Tracks the Rust-first port of the legacy component library."
+
+[relationships.compatibility]
+# Document compatibility guarantees (semver ranges, browser support) so automated diffing can
+# detect regressions when syncing upstream. Adjust when the archive is instantiated.
+target_semver = "^5"
+# Capture any feature flags required to run the legacy bundle. Orchestrators can reuse this list to
+# prime test environments without custom scripting.
+feature_flags = []

--- a/docs/archives/archive-manifests.md
+++ b/docs/archives/archive-manifests.md
@@ -1,0 +1,61 @@
+# Archive manifest playbook
+
+The legacy Material UI packages that live under `archives/mui-packages/` now rely on a lightweight
+`archive.manifest.toml` contract. This document explains how to author, extend, and consume those
+manifests so enterprise automation remains single-sourced and easy to override.
+
+## Goals
+
+1. **Codify automation per package** – Centralize build, test, and publish commands in the manifest
+   so teams never have to chase down bespoke scripts.
+2. **Capture provenance** – Track the upstream snapshot (git URL, revision, path) used to populate
+   the archive.
+3. **Document the migration path** – Link the historical package to its Rust-first successor crates
+   so engineers know where to continue development.
+4. **Enable overrides** – Provide a single file downstream release pipelines can patch to align with
+   enterprise policies (custom registries, alternate test suites, etc.).
+
+## Authoring checklist
+
+Follow this checklist whenever adding a new archive folder:
+
+1. **Copy the template** – Start with `archives/mui-packages/_template/archive.manifest.toml` and
+   commit it alongside the archived sources.
+2. **Fill in package metadata** – Update the `[package]` block with the real package name, owner,
+   and status. The `language` field lets orchestrators pick the correct build container.
+3. **Wire the commands** – Point `build`, `test`, and `publish` to the workspace-level scripts. When
+   specialized behavior is required, add environment variables or tags to that manifest section
+   rather than baking logic into shell scripts.
+4. **Record sync sources** – For each upstream location, add a `[[sync.sources]]` entry with the git
+   URL, revision, and path. This allows automation to rehydrate the archive on demand.
+5. **Map crate relationships** – Populate `[[relationships.crates]]` with the Rust crates that
+   replace or depend on the legacy package. Include notes explaining how the crate and archive fit
+   together.
+6. **Note compatibility requirements** – Update `[relationships.compatibility]` with the semver range
+   and any necessary feature flags so downstream QA tools know which environments to emulate.
+7. **Review inline comments** – Keep the descriptive comments current. They are consumed by both
+   humans and documentation automation to generate onboarding guides.
+
+## Consuming manifests
+
+Automation services read `archive.manifest.toml` files to orchestrate builds without manual wiring.
+The following conventions keep the experience consistent:
+
+- **Command delegation** – The `uses` field in each `[commands.*]` block points to the canonical
+  script under `scripts/` or `tools/`. Orchestrators can swap this value when routing jobs to
+  internal runners, leaving the `run` string untouched.
+- **Environment capture** – Use the `env` array to define required environment variables instead of
+  referencing ad-hoc wrapper scripts. This keeps environment drift visible in code review.
+- **Override layering** – Downstream teams may check in an override manifest (for example,
+  `archive.manifest.override.toml`) and merge it with the template using `tools/archive-manifests`
+  utilities. Avoid editing automation scripts in place when a manifest tweak will suffice.
+
+## Validation and linting
+
+- Run `pnpm exec prettier --check <manifest>` to ensure the TOML remains formatted according to the
+  repository standards.
+- Manifest-aware tooling lives under `tools/archive-manifests`. Review that directory for schema
+  updates, validation utilities, and additional examples.
+
+Keeping the manifest authoritative dramatically reduces the toil required to reanimate or audit the
+legacy packages while preserving room for enterprise-scale automation.

--- a/tools/archive-manifests/README.md
+++ b/tools/archive-manifests/README.md
@@ -1,0 +1,25 @@
+# Archive manifest tooling
+
+Utilities that understand `archive.manifest.toml` live in this directory. They provide a single
+entrypoint for validation, override layering, and documentation generation so enterprise automation
+can process every archive manifest the same way.
+
+## Planned utilities
+
+- **`schema.toml`** – Machine-readable description of valid keys and types. Downstream pipelines can
+  pull this file to validate manifests without duplicating logic.
+- **`merge.ts`** – Helper script that merges `archive.manifest.toml` with optional
+  `archive.manifest.override.toml` files to support environment-specific overrides.
+- **`lint.ts`** – Static checks that ensure command strings reference approved scripts and that
+  required fields (build/test/publish, sync sources, crate relationships) are present.
+
+## Usage guidelines
+
+1. **Keep manifests source-of-truth** – Tooling should read instructions from the manifest rather
+   than inferring behavior from directory structure.
+2. **Prefer reusable scripts** – When commands need to change, update or extend the shared scripts in
+   `scripts/` instead of adding ad-hoc shell commands to manifests.
+3. **Fail fast** – Validation scripts should exit non-zero when required sections are missing. This
+   allows CI systems to block misconfigured archives before they reach production workflows.
+
+Refer to `docs/archives/archive-manifests.md` for authoring guidance and adoption playbooks.


### PR DESCRIPTION
## Summary
- add a reusable archive.manifest.toml template under archives/mui-packages for new legacy snapshots
- document the manifest workflow in archives/README.md and dedicated docs/archives guidance
- outline future validation utilities under tools/archive-manifests to standardize automation entrypoints

## Testing
- pnpm exec prettier --check archives/mui-packages/_template/archive.manifest.toml docs/archives/archive-manifests.md tools/archive-manifests/README.md archives/README.md *(fails: Cannot find package '@mui/internal-code-infra' imported from prettier.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d73ca82e4c832e92ff6980b6ca24d7