### PR TITLE
Add design token bundling automation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2200,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,7 +2494,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3040,6 +3063,22 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustic-ui-design-tokens"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "flate2",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tempfile",
+ "walkdir",
+ "zip",
+]
 
 [[package]]
 name = "rustic-ui-headless"
@@ -3958,6 +3997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4722,7 +4771,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4731,7 +4780,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -4749,14 +4807,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4766,10 +4841,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4778,10 +4865,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4790,10 +4889,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4802,10 +4913,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -4851,9 +4974,12 @@ dependencies = [
  "assert_cmd",
  "clap",
  "predicates",
+ "rustic-ui-design-tokens",
  "rustic-ui-system",
  "serde_json",
+ "tempfile",
  "toml 0.8.23",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,9 @@ members = [
     "crates/rustic-ui-material",
     "crates/rustic-ui-joy",
     "crates/rustic-ui-lab",
-    "crates/rustic-ui-icons",
+    "crates/rustic-ui-icons", 
     "crates/rustic-ui-icons-material",
+    "crates/rustic-ui-design-tokens",
     "crates/rustic-ui-utils",
     "crates/xtask",
     "tools/material-parity",
@@ -107,6 +108,8 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 walkdir = "2.5"
 sha2 = { version = "0.10", default-features = false }
 heck = "0.5"
+tar = { version = "0.4", default-features = false }
+flate2 = "1.0"
 
 [profile.dev]
 # Development builds prioritize compile time over runtime performance.

--- a/crates/rustic-ui-design-tokens/Cargo.toml
+++ b/crates/rustic-ui-design-tokens/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rustic-ui-design-tokens"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Shared helpers for packaging RusticUI design token bundles."
+
+[dependencies]
+anyhow.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
+walkdir.workspace = true
+zip.workspace = true
+tar = { workspace = true }
+flate2.workspace = true
+chrono.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+tempfile = "3"

--- a/crates/rustic-ui-design-tokens/src/lib.rs
+++ b/crates/rustic-ui-design-tokens/src/lib.rs
@@ -1,0 +1,377 @@
+#![deny(missing_docs)]
+#![doc = r"RusticUI design token helpers
+=================================
+
+This crate centralizes the serialization and packaging logic used by the
+`cargo xtask` automation. Historically these responsibilities lived in
+multiple npm packages—`@mui/material`, `@mui/system`, and
+`@mui/icons-material`—that exposed pre-baked JSON, CSS, and SVG bundles.
+Enterprise users relied on those bundles to hydrate design systems inside
+monorepos or CI pipelines. As the Rust-first toolchain matured we ported the
+artifact generation to strongly typed binaries. The helper APIs exposed here
+make that migration explicit by documenting how each output maps back to the
+legacy npm deliverables.
+
+The modules intentionally provide verbose documentation so integrators can
+trace which function to call when they need to reproduce a former npm bundle.
+They are heavily annotated because most consumers interact with them through
+automation in CI/CD environments."]
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use flate2::{write::GzEncoder, Compression};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fmt;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tar::Builder as TarBuilder;
+use walkdir::WalkDir;
+use zip::write::FileOptions;
+
+/// Builder that stages individual design token files before writing archive bundles.
+///
+/// The builder owns a dedicated payload directory where raw assets are copied so we can
+/// calculate deterministic checksums and compose ZIP/TAR archives without mutating the
+/// source tree. Each ingested file records metadata that mirrors the manifests published
+/// by the former npm packages.
+#[derive(Debug)]
+pub struct ArtifactBundleBuilder {
+    root: PathBuf,
+    payload_dir: PathBuf,
+    archive_stem: String,
+    entries: Vec<ManifestEntry>,
+}
+
+/// Summary describing the bundle that was written to disk.
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleSummary {
+    /// Directory containing the raw payload alongside the manifest and archives.
+    pub bundle_root: PathBuf,
+    /// Directory containing just the raw payload files.
+    pub payload_dir: PathBuf,
+    /// Manifest describing every emitted artifact.
+    pub manifest: PathBuf,
+    /// Archives produced for distribution. Typically includes both ZIP and TAR.GZ variants.
+    pub archives: Vec<PathBuf>,
+    /// Manifest entries so downstream automation can inspect them without reading the JSON again.
+    pub entries: Vec<ManifestEntry>,
+    /// High level metadata stored alongside the manifest.
+    pub metadata: Value,
+    archive_stem: String,
+}
+
+impl BundleSummary {
+    /// Recursively synchronises the bundle into a compatibility directory.
+    ///
+    /// Legacy automation expects the archived assets to mirror the npm bundle layout. We copy the
+    /// entire bundle directory (manifest, payload, and archives) so the contract remains intact.
+    pub fn sync_to<P: AsRef<Path>>(&self, destination_root: P) -> Result<PathBuf> {
+        let destination_root = destination_root.as_ref();
+        fs::create_dir_all(destination_root).with_context(|| {
+            format!(
+                "failed to create compatibility root at {}",
+                destination_root.display()
+            )
+        })?;
+        let bundle_destination = destination_root.join(&self.archive_stem);
+        if bundle_destination.exists() {
+            fs::remove_dir_all(&bundle_destination).with_context(|| {
+                format!(
+                    "failed to remove stale bundle at {} before sync",
+                    bundle_destination.display()
+                )
+            })?;
+        }
+        copy_directory(&self.bundle_root, &bundle_destination)?;
+        Ok(bundle_destination)
+    }
+}
+
+impl ArtifactBundleBuilder {
+    /// Creates a new bundle builder rooted at `bundle_root` and names archives using `archive_stem`.
+    ///
+    /// The constructor clears any previous payload so repeated runs (for example in CI) always emit a
+    /// clean bundle. A `payload/` directory is created inside the bundle root where raw files are
+    /// staged before manifests and archives are generated.
+    pub fn new<P: AsRef<Path>>(bundle_root: P, archive_stem: impl Into<String>) -> Result<Self> {
+        let bundle_root = bundle_root.as_ref().to_path_buf();
+        if bundle_root.exists() {
+            fs::remove_dir_all(&bundle_root).with_context(|| {
+                format!(
+                    "failed to clear existing bundle directory at {}",
+                    bundle_root.display()
+                )
+            })?;
+        }
+        fs::create_dir_all(&bundle_root)?;
+        let payload_dir = bundle_root.join("payload");
+        fs::create_dir_all(&payload_dir)?;
+        Ok(Self {
+            root: bundle_root,
+            payload_dir,
+            archive_stem: archive_stem.into(),
+            entries: Vec::new(),
+        })
+    }
+
+    /// Adds a single file to the bundle and records manifest metadata.
+    ///
+    /// * `source` – path to the file that should be copied into the payload directory.
+    /// * `relative_path` – path relative to the payload root where the file should be staged.
+    /// * `kind` – human-readable classification (for example `material-theme-json`).
+    /// * `media_type` – MIME-like descriptor so downstream tooling can route the asset appropriately.
+    /// * `metadata` – any additional JSON blob that should accompany the manifest entry. This keeps the
+    ///   manifest extensible without changing the schema.
+    pub fn ingest_file<S: AsRef<Path>, R: AsRef<Path>, K: Into<String>, M: Into<String>>(
+        &mut self,
+        source: S,
+        relative_path: R,
+        kind: K,
+        media_type: M,
+        metadata: Value,
+    ) -> Result<PathBuf> {
+        let source = source.as_ref();
+        let relative_path = relative_path.as_ref();
+        let destination = self.payload_dir.join(relative_path);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let bytes = fs::read(source).with_context(|| {
+            format!(
+                "failed to read source file {} while preparing bundle",
+                source.display()
+            )
+        })?;
+        fs::write(&destination, &bytes).with_context(|| {
+            format!(
+                "failed to copy payload file into bundle at {}",
+                destination.display()
+            )
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let checksum = format!("{:x}", hasher.finalize());
+        let entry = ManifestEntry {
+            relative_path: unix_string(relative_path),
+            bytes: bytes.len() as u64,
+            sha256: checksum,
+            kind: kind.into(),
+            media_type: media_type.into(),
+            source: unix_string(source),
+            metadata,
+        };
+        self.entries.push(entry);
+        Ok(destination)
+    }
+
+    /// Recursively ingests a directory, mirroring its structure under the payload root.
+    ///
+    /// The entire directory tree is copied so the resulting archives remain deterministic even if the
+    /// source location contains nested folders. Each file inherits the provided `kind` and
+    /// `media_type`; callers can attach additional metadata via the closure.
+    pub fn ingest_directory<S: AsRef<Path>, R: AsRef<Path>, F: Fn(&Path) -> Value>(
+        &mut self,
+        source_dir: S,
+        relative_root: R,
+        kind: &str,
+        media_type: &str,
+        metadata: F,
+    ) -> Result<()> {
+        let source_dir = source_dir.as_ref();
+        let relative_root = relative_root.as_ref();
+        for entry in WalkDir::new(source_dir).into_iter().filter_map(|e| e.ok()) {
+            if entry.file_type().is_file() {
+                let relative_path = entry
+                    .path()
+                    .strip_prefix(source_dir)
+                    .map_err(|error| anyhow!(error))?;
+                let destination_relative = relative_root.join(relative_path);
+                let metadata_blob = metadata(entry.path());
+                self.ingest_file(
+                    entry.path(),
+                    destination_relative,
+                    kind.to_string(),
+                    media_type.to_string(),
+                    metadata_blob,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Finalises the bundle by writing the manifest and producing ZIP + TAR.GZ archives.
+    ///
+    /// The returned [`BundleSummary`] includes every emitted artifact so callers can surface
+    /// machine-readable summaries to CI systems or copy the outputs elsewhere.
+    pub fn finalize(self, metadata: Value) -> Result<BundleSummary> {
+        let manifest_path = self
+            .root
+            .join(format!("{}.manifest.json", self.archive_stem));
+        let manifest = BundleManifest {
+            schema_version: "1".to_string(),
+            generated_at: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            bundle: self.archive_stem.clone(),
+            metadata: metadata.clone(),
+            entries: self.entries.clone(),
+        };
+        let manifest_json = serde_json::to_string_pretty(&manifest)? + "\n";
+        fs::write(&manifest_path, manifest_json).with_context(|| {
+            format!(
+                "failed to write bundle manifest at {}",
+                manifest_path.display()
+            )
+        })?;
+
+        let mut archives = Vec::new();
+        let zip_path = self.root.join(format!("{}.zip", self.archive_stem));
+        write_zip(&self.payload_dir, &zip_path)?;
+        archives.push(zip_path);
+
+        let tar_path = self.root.join(format!("{}.tar.gz", self.archive_stem));
+        write_tar_gz(&self.payload_dir, &tar_path)?;
+        archives.push(tar_path);
+
+        Ok(BundleSummary {
+            bundle_root: self.root,
+            payload_dir: self.payload_dir,
+            manifest: manifest_path,
+            archives,
+            entries: self.entries,
+            metadata,
+            archive_stem: self.archive_stem,
+        })
+    }
+}
+
+/// Internal manifest structure written alongside each bundle.
+#[derive(Debug, Clone, Serialize)]
+struct BundleManifest {
+    schema_version: String,
+    generated_at: String,
+    bundle: String,
+    metadata: Value,
+    entries: Vec<ManifestEntry>,
+}
+
+/// Record describing a single asset inside a bundle.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManifestEntry {
+    /// Path relative to the payload root (`payload/`).
+    pub relative_path: String,
+    /// Size of the file in bytes.
+    pub bytes: u64,
+    /// SHA-256 checksum for integrity verification.
+    pub sha256: String,
+    /// High level classification for the asset (for example `icon-svg`).
+    pub kind: String,
+    /// Media type / MIME hint used by downstream automation.
+    pub media_type: String,
+    /// Original source path prior to staging.
+    pub source: String,
+    /// Additional metadata, typically referencing upstream npm package names or framework hints.
+    pub metadata: Value,
+}
+
+impl fmt::Display for ManifestEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} ({} bytes, {})",
+            self.relative_path, self.bytes, self.kind
+        )
+    }
+}
+
+fn write_zip(payload_dir: &Path, destination: &Path) -> Result<()> {
+    let file = fs::File::create(destination)
+        .with_context(|| format!("failed to create ZIP archive at {}", destination.display()))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+    for entry in WalkDir::new(payload_dir).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let relative = path
+            .strip_prefix(payload_dir)
+            .map_err(|error| anyhow!(error))?;
+        if entry.file_type().is_dir() {
+            if !relative.as_os_str().is_empty() {
+                zip.add_directory(unix_string(relative), options)?;
+            }
+            continue;
+        }
+        zip.start_file(unix_string(relative), options)?;
+        let bytes = fs::read(path)?;
+        zip.write_all(&bytes)?;
+    }
+    zip.finish()?;
+    Ok(())
+}
+
+fn write_tar_gz(payload_dir: &Path, destination: &Path) -> Result<()> {
+    let file = fs::File::create(destination).with_context(|| {
+        format!(
+            "failed to create TAR.GZ archive at {}",
+            destination.display()
+        )
+    })?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut tar = TarBuilder::new(encoder);
+    tar.append_dir_all(".", payload_dir)?;
+    tar.finish()?;
+    Ok(())
+}
+
+fn unix_string(path: &Path) -> String {
+    path.components()
+        .map(|comp| comp.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> Result<()> {
+    for entry in WalkDir::new(source).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let relative = path.strip_prefix(source).map_err(|error| anyhow!(error))?;
+        let dest_path = destination.join(relative);
+        if entry.file_type().is_dir() {
+            fs::create_dir_all(&dest_path)?;
+        } else {
+            if let Some(parent) = dest_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(path, &dest_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn builder_writes_manifest_and_archives() -> Result<()> {
+        let temp = tempdir()?;
+        let bundle_root = temp.path().join("bundle-test");
+        let mut builder = ArtifactBundleBuilder::new(&bundle_root, "test")?;
+        let input_dir = temp.path().join("inputs");
+        fs::create_dir_all(&input_dir)?;
+        let json_path = input_dir.join("theme.json");
+        fs::write(&json_path, b"{}")?;
+        builder.ingest_file(
+            &json_path,
+            "material/theme.json",
+            "material-theme-json",
+            "application/json",
+            serde_json::json!({ "legacy": "@mui/material" }),
+        )?;
+        let summary = builder.finalize(serde_json::json!({ "bundle": "unit-test" }))?;
+        assert!(summary.manifest.exists());
+        assert_eq!(summary.entries.len(), 1);
+        assert!(summary.archives.iter().all(|path| path.exists()));
+        Ok(())
+    }
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,7 +10,10 @@ anyhow = { workspace = true }
 serde_json.workspace = true
 toml.workspace = true
 rustic-ui-system = { path = "../rustic-ui-system" }
+rustic-ui-design-tokens = { path = "../rustic-ui-design-tokens" }
+walkdir.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+tempfile = "3"

--- a/crates/xtask/tests/bundle_artifacts.rs
+++ b/crates/xtask/tests/bundle_artifacts.rs
@@ -1,0 +1,221 @@
+//! Regression tests covering the new bundle-oriented xtask subcommands.
+//!
+//! The legacy npm distribution shipped prebuilt ZIPs and manifests that CI pipelines consumed.
+//! These tests guarantee the Rust-first automation keeps emitting the same machine-readable
+//! contracts so enterprise adopters can flip between ecosystems without rewriting pipelines.
+
+use anyhow::Result;
+use assert_cmd::Command;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+use walkdir::WalkDir;
+
+#[derive(Debug)]
+struct FileSnapshot {
+    path: PathBuf,
+    original_bytes: Option<Vec<u8>>,
+}
+
+impl FileSnapshot {
+    fn new(path: PathBuf) -> Self {
+        let original_bytes = fs::read(&path).ok();
+        Self {
+            path,
+            original_bytes,
+        }
+    }
+
+    fn restore(&self) {
+        match &self.original_bytes {
+            Some(bytes) => {
+                if let Err(error) = fs::write(&self.path, bytes) {
+                    eprintln!("[test] failed to restore {}: {error}", self.path.display());
+                }
+            }
+            None => match fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    eprintln!(
+                        "[test] failed to remove {} during cleanup: {error}",
+                        self.path.display()
+                    );
+                }
+            },
+        }
+    }
+}
+
+impl Drop for FileSnapshot {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("xtask is nested two levels below the workspace root")
+        .to_path_buf()
+}
+
+#[test]
+fn icons_bundle_emits_single_manifest_and_unique_entries() -> Result<()> {
+    let workspace = workspace_root();
+    let fixture_dir = workspace.join("crates/rustic-ui-icons/icons/__xtask_fixture");
+    if fixture_dir.exists() {
+        fs::remove_dir_all(&fixture_dir)?;
+    }
+    let temp = tempdir()?;
+    let out_dir = temp.path().join("icons-artifacts");
+
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("xtask")
+        .arg("icons-bundle")
+        .arg("--out-dir")
+        .arg(&out_dir);
+
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("[xtask][icons-bundle] summary="));
+
+    let bundle_dir = out_dir.join("icons");
+    let manifest_path = bundle_dir.join("icons.manifest.json");
+    assert!(
+        manifest_path.exists(),
+        "manifest missing at {manifest_path:?}"
+    );
+
+    let manifest_json = fs::read_to_string(&manifest_path)?;
+    let manifest: Value = serde_json::from_str(&manifest_json)?;
+    assert_eq!(manifest["bundle"], Value::String("icons".into()));
+    assert_eq!(
+        manifest["metadata"]["bundle_kind"].as_str(),
+        Some("icon-assets")
+    );
+
+    let entries = manifest["entries"]
+        .as_array()
+        .expect("entries array present");
+    assert!(
+        !entries.is_empty(),
+        "expected at least one SVG payload in the manifest"
+    );
+    let unique_paths: HashSet<_> = entries
+        .iter()
+        .map(|entry| entry["relative_path"].as_str().expect("path string"))
+        .collect();
+    assert_eq!(
+        entries.len(),
+        unique_paths.len(),
+        "duplicate entries detected"
+    );
+
+    for entry in entries {
+        let legacy_packages = entry["metadata"]["legacy_packages"]
+            .as_array()
+            .expect("legacy package list present");
+        assert!(
+            legacy_packages
+                .iter()
+                .any(|value| value == "@mui/icons-material"),
+            "entry missing legacy package metadata"
+        );
+        assert_eq!(entry["media_type"].as_str(), Some("image/svg+xml"));
+    }
+
+    if fixture_dir.exists() {
+        fs::remove_dir_all(&fixture_dir)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn themes_bundle_emits_css_and_json_with_overrides() -> Result<()> {
+    let workspace = workspace_root();
+    let temp = tempdir()?;
+    let out_dir = temp.path().join("themes-artifacts");
+    let overrides = workspace.join("crates/xtask/tests/fixtures/material_overrides.json");
+    assert!(overrides.exists(), "fixture missing: {overrides:?}");
+
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("xtask")
+        .arg("themes-bundle")
+        .arg("--overrides")
+        .arg(&overrides)
+        .arg("--joy")
+        .arg("--out-dir")
+        .arg(&out_dir);
+
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("[xtask][themes-bundle] summary="));
+
+    let bundle_dir = out_dir.join("themes");
+    let templates_dir = workspace.join("crates/rustic-ui-system/templates");
+    let _snapshots: Vec<FileSnapshot> = WalkDir::new(&templates_dir)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| FileSnapshot::new(entry.path().to_path_buf()))
+        .collect();
+    let manifest_path = bundle_dir.join("themes.manifest.json");
+    assert!(
+        manifest_path.exists(),
+        "manifest missing: {manifest_path:?}"
+    );
+
+    let manifest_json = fs::read_to_string(&manifest_path)?;
+    let manifest: Value = serde_json::from_str(&manifest_json)?;
+    assert_eq!(manifest["bundle"], Value::String("themes".into()));
+    assert_eq!(
+        manifest["metadata"]["bundle_kind"].as_str(),
+        Some("theme-assets")
+    );
+    assert_eq!(manifest["metadata"]["joy"].as_bool(), Some(true));
+
+    if let Some(Value::String(path)) = manifest["metadata"].get("overrides") {
+        assert!(
+            path.ends_with("crates/xtask/tests/fixtures/material_overrides.json"),
+            "manifest should reference the overrides fixture"
+        );
+    } else {
+        panic!("manifest should include the overrides path metadata");
+    }
+
+    let entries = manifest["entries"]
+        .as_array()
+        .expect("entries array present");
+    assert!(entries.len() >= 4, "expected multiple theme outputs");
+    let unique_paths: HashSet<_> = entries
+        .iter()
+        .map(|entry| entry["relative_path"].as_str().expect("path string"))
+        .collect();
+    assert_eq!(
+        entries.len(),
+        unique_paths.len(),
+        "duplicate entries detected"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["media_type"].as_str() == Some("text/css")),
+        "CSS baselines must be present in the bundle"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["media_type"].as_str() == Some("application/json")),
+        "JSON payloads must be present in the bundle"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a reusable `rustic-ui-design-tokens` helper crate that stages assets, emits manifests, and builds ZIP/TAR bundles
- extend `cargo xtask` with `icons-bundle` and `themes-bundle` subcommands that sync artifacts and log machine-readable summaries
- add regression coverage that executes the new bundle commands in temporary directories to verify manifests and metadata

## Testing
- cargo test -p rustic-ui-design-tokens
- cargo test -p xtask

------
https://chatgpt.com/codex/tasks/task_e_68d80a2ca474832eb716e34ee473075d