### PR TITLE
chore: wire cargo deny automation

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -34,10 +34,15 @@ jobs:
           components: rustfmt, clippy
       # Cache dependencies to speed up repeated CI runs
       - uses: Swatinem/rust-cache@v2
+      # Install cargo-deny so the xtask supply-chain audit can execute
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
       # Enforce consistent style across the workspace
       - run: cargo xtask fmt --check
       # Fail on any warnings to keep code quality high
       - run: cargo xtask clippy
+      # Audit the dependency graph for advisories, bans, and license drift
+      - run: cargo xtask deny
 
   test:
     name: Test and Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 RusticUI documents every step of the transition from Material UI for Rust to the Apotheon.ai–stewarded RusticUI platform. The
 archived Material UI change history now lives in [`docs/archives/material-ui-changelog.md`](docs/archives/material-ui-changelog.md).
 
+## 2025-05-06 – Supply-chain automation and archive governance
+
+### Highlights
+
+- Finalized the JavaScript package archival plan by wiring the new `deny` make target and xtask guardrail into CI, ensuring the Rust crates and frozen npm snapshots stay coordinated for regulated adopters.
+- Added a `cargo xtask deny` subcommand that wraps `cargo deny check` with workspace-aware logging so dependency advisories, license drift, and yanked crates surface alongside the existing `fmt` and `clippy` checks.
+- Updated the npm-to-Rust migration guide and contributor playbook to call out the new audit requirement, making it clear that every migration run must finish with a Rust-native supply-chain review.
+
+### Breaking changes
+
+- CI and local workflows now require the `cargo-deny` binary. Downstream pipelines must install the tool (for example via `cargo install cargo-deny --locked`) before invoking `cargo xtask deny`, otherwise the lint stage will fail fast.
+
+### Backlog
+
+- [ ] Automate cargo-deny database caching in CI so nightly runs avoid re-downloading the advisory index on large monorepos.
+
 ## 2025-04-22 – RusticUI styling macros only
 
 ### Highlights

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ Before starting large efforts, open a GitHub discussion or issue so the maintain
 ## Development setup
 
 1. Install the latest stable Rust toolchain and ensure `wasm32-unknown-unknown` is available via `rustup target add`.
-2. Install supporting CLI tools with Cargo: `cargo install mdbook grcov wasm-pack` (the automation will leverage them when
-   present).
+2. Install supporting CLI tools with Cargo: `cargo install mdbook grcov wasm-pack cargo-deny` (the automation will leverage
+   them when present).
 3. Run `make bootstrap` to install workspace prerequisites and run quick smoke tests.
 
 > **Important:** The root pnpm workspace has been retired. Do not run `pnpm install` from the repository root and ignore any
@@ -141,8 +141,9 @@ changes so CI stays green and local developers avoid manual cleanup.
 
 - Fork the repository and branch from `main`.
 - Ensure commits are logically grouped and reference any related issues.
-- Run `make fmt lint test` to execute the standard formatting, linting, and test suite. The command fan-outs to Rust, TypeScript,
-  and Markdown checks as appropriate.
+- Run `make fmt clippy deny test` to execute formatting, linting, supply-chain auditing, and the full test suite. The `deny`
+  target wraps `cargo xtask deny` so dependency advisories or license drift fail fast before review. Execute the command prior
+  to pushing branches so CI mirrors a known-good local run.
 - Fill in the PR template, summarizing the change, testing evidence, and migration considerations.
 
 Pull requests must pass CI and include relevant documentation updates. Enterprise consumers rely on our docs to automate upgrades,

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # underlying commands so contributors and CI use the same logic.
 
 .RECIPEPREFIX := >
-.PHONY: build fmt clippy test wasm-test doc icon-update coverage bench
+.PHONY: build fmt clippy deny test wasm-test doc icon-update coverage bench
 
 # Format the entire workspace. Use `cargo xtask fmt --check` in CI.
 fmt:
@@ -12,6 +12,10 @@ fmt:
 # Lint all crates with Clippy and deny warnings.
 clippy:
 > @cargo xtask clippy
+
+# Audit dependencies for advisories, yanked crates, and license drift.
+deny:
+> @cargo xtask deny
 
 # Run the standard test suites for every crate.
 test:

--- a/crates/rustic-ui-design-tokens/Cargo.toml
+++ b/crates/rustic-ui-design-tokens/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustic-ui-design-tokens"
 version = "0.1.0"
 edition = "2021"
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "Shared helpers for packaging RusticUI design token bundles."
 
 [dependencies]

--- a/crates/rustic-ui-icons-material/Cargo.toml
+++ b/crates/rustic-ui-icons-material/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-icons-material"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Material Icons auto-generated from SVGs for Rust front-end frameworks."
 
 # Build script performs SVG -> Rust conversion.

--- a/crates/rustic-ui-icons/Cargo.toml
+++ b/crates/rustic-ui-icons/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-icons"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Bindings to Material UI's SVG icon set for Rust front-end frameworks."
 # Build script converts SVGs into memoized Rust functions.
 build = "build.rs"

--- a/crates/rustic-ui-joy/Cargo.toml
+++ b/crates/rustic-ui-joy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-joy"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Joy UI components implemented in Rust leveraging rustic-ui-system."
 repository = "https://github.com/apotheon-ai/rusticui"
 homepage = "https://apotheon.ai/rusticui"
@@ -13,8 +14,8 @@ categories = ["gui"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-rustic-ui-system = { path = "../rustic-ui-system" }
-rustic-ui-headless = { path = "../rustic-ui-headless" }
+rustic-ui-system = { path = "../rustic-ui-system", version = "0.1.0" }
+rustic-ui-headless = { path = "../rustic-ui-headless", version = "0.1.0" }
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/rustic-ui-lab/Cargo.toml
+++ b/crates/rustic-ui-lab/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-lab"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Experimental widgets for MUI Rust. These APIs are unstable and subject to change."
 repository = "https://github.com/apotheon-ai/rusticui"
 homepage = "https://apotheon.ai/rusticui"

--- a/crates/rustic-ui-material/Cargo.toml
+++ b/crates/rustic-ui-material/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-material"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Material Design components implemented in Rust leveraging rustic_ui_system."
 repository = "https://github.com/apotheon-ai/rusticui"
 homepage = "https://apotheon.ai/rusticui"
@@ -13,14 +14,14 @@ categories = ["gui"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-rustic-ui-styled-engine = { path = "../rustic-ui-styled-engine" }
-rustic-ui-system = { path = "../rustic-ui-system" }
-rustic-ui-headless = { path = "../rustic-ui-headless" }
+rustic-ui-styled-engine = { path = "../rustic-ui-styled-engine", version = "0.1.0" }
+rustic-ui-system = { path = "../rustic-ui-system", version = "0.1.0" }
+rustic-ui-headless = { path = "../rustic-ui-headless", version = "0.1.0" }
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 stylist = { version = "0.13", default-features = false, features = ["macros", "parser"] }
-rustic-ui-utils = { path = "../rustic-ui-utils" }
+rustic-ui-utils = { path = "../rustic-ui-utils", version = "0.1.0" }
 web-sys = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/rustic-ui-styled-engine-macros/Cargo.toml
+++ b/crates/rustic-ui-styled-engine-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-styled-engine-macros"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Procedural macros for rustic-ui-styled-engine"
 repository = "https://github.com/apotheon-ai/rusticui"
 homepage = "https://apotheon.ai/rusticui"

--- a/crates/rustic-ui-styled-engine/Cargo.toml
+++ b/crates/rustic-ui-styled-engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-styled-engine"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Styling engine for Material UI Rust components providing theme primitives."
 repository = "https://github.com/apotheon-ai/rusticui"
 homepage = "https://apotheon.ai/rusticui"
@@ -13,11 +14,11 @@ categories = ["gui"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-rustic-ui-system = { path = "../rustic-ui-system" }
+rustic-ui-system = { path = "../rustic-ui-system", version = "0.1.0" }
 stylist = { version = "0.13", default-features = false, features = ["macros", "parser", "yew_integration", "ssr"] }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-rustic-ui-styled-engine-macros = { path = "../rustic-ui-styled-engine-macros" }
+rustic-ui-styled-engine-macros = { path = "../rustic-ui-styled-engine-macros", version = "0.1.0" }
 
 [features]
 default = []

--- a/crates/rustic-ui-system/Cargo.toml
+++ b/crates/rustic-ui-system/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-system"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Foundational styling primitives for the Material UI Rust ecosystem."
 repository = "https://github.com/apotheon-ai/rusticui"
 homepage = "https://apotheon.ai/rusticui"
@@ -20,8 +21,8 @@ maintenance = { status = "experimental" }
 serde.workspace = true
 serde_json.workspace = true
 stylist = { version = "0.13", default-features = false, features = ["macros", "parser", "ssr"] }
-rustic-ui-styled-engine-macros = { path = "../rustic-ui-styled-engine-macros" }
-rustic-ui-utils = { path = "../rustic-ui-utils" }
+rustic-ui-styled-engine-macros = { path = "../rustic-ui-styled-engine-macros", version = "0.1.0" }
+rustic-ui-utils = { path = "../rustic-ui-utils", version = "0.1.0" }
 leptos = { workspace = true, optional = true }
 yew = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }

--- a/crates/rustic-ui-utils/Cargo.toml
+++ b/crates/rustic-ui-utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustic-ui-utils"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 description = "Utility helpers for the Material UI Rust ecosystem."
 repository = "https://github.com/apotheon-ai/rusticui"
 homepage = "https://apotheon.ai/rusticui"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 publish = false
 
 [dependencies]
@@ -9,8 +10,8 @@ clap = { workspace = true, features = ["derive", "std"] }
 anyhow = { workspace = true }
 serde_json.workspace = true
 toml.workspace = true
-rustic-ui-system = { path = "../rustic-ui-system" }
-rustic-ui-design-tokens = { path = "../rustic-ui-design-tokens" }
+rustic-ui-system = { path = "../rustic-ui-system", version = "0.1.0" }
+rustic-ui-design-tokens = { path = "../rustic-ui-design-tokens", version = "0.1.0" }
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -54,6 +54,8 @@ enum Commands {
     },
     /// Run Clippy across the workspace and deny warnings.
     Clippy,
+    /// Audit third-party crates for advisories, bans, and license issues.
+    Deny,
     /// Execute the default test suites for all crates.
     ///
     /// After the workspace tests finish we compile the `joy-*` WebAssembly
@@ -140,6 +142,7 @@ fn main() -> Result<()> {
     match xtask.command {
         Commands::Fmt { check } => fmt(check),
         Commands::Clippy => clippy(),
+        Commands::Deny => deny(),
         Commands::Test => test(),
         Commands::WasmTest => wasm_test(),
         Commands::Doc => doc(),
@@ -231,6 +234,17 @@ fn clippy() -> Result<()> {
         .arg("--")
         .arg("-D")
         .arg("warnings");
+    run(cmd)
+}
+
+fn deny() -> Result<()> {
+    println!(
+        "[xtask] auditing dependencies for security advisories, license drift, and banned crates"
+    );
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("deny").arg("check");
+    cmd.current_dir(workspace_root());
     run(cmd)
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,92 @@
+# Supply-chain policy for the RusticUI workspace.
+#
+# The configuration focuses on actionable guardrails instead of copying the
+# full cargo-deny template. Each section is documented so contributors know how
+# CI evaluates advisories, licenses, and crate bans when `cargo xtask deny`
+# runs locally or inside automation.
+
+[graph]
+# Evaluate every workspace target so audit coverage mirrors `cargo clippy` and
+# `cargo test`. Explicit targets can be added as the workspace grows.
+all-features = false
+no-default-features = false
+
+[advisories]
+# The default lint levels already deny vulnerabilities and yanked crates while
+# warning on unmaintained packages. Keeping the field list short makes future
+# upgrades less error-prone. Document every exception directly in the ignore
+# array with rationale comments.
+# paste and proc-macro-error are still required by upstream framework
+# dependencies (Leptos/Sycamore/Yew). Track the advisories and remove these
+# entries once upstream releases replacements.
+ignore = [
+    { id = "RUSTSEC-2024-0436", reason = "Leptos/Sycamore still depend on paste; track upstream issue before removing" },
+    { id = "RUSTSEC-2024-0370", reason = "Stylist/yew depend on proc-macro-error; revisit when upstream swaps to proc-macro-error2" },
+]
+# Use the system git binary so corporate proxies and SSH configs are honoured
+# consistently across developer machines and CI runners.
+git-fetch-with-cli = true
+
+[licenses]
+# Only permit well-understood permissive and weak-copyleft licenses. This list
+# matches Apotheon.ai's internal supply-chain policy and keeps runtime
+# dependencies aligned with enterprise compliance baselines.
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+]
+# Flag strong copyleft usage so legal review can weigh in without blocking
+# day-to-day development. The allow list acts as the explicit permit list,
+# and anything else will surface as an error. Unknown licenses fail the check
+# once cargo-deny cannot map them confidently.
+confidence-threshold = 0.8
+exceptions = []
+
+[licenses.private]
+# Workspace crates inherit the root dual license. Ignoring private members keeps
+# cargo-deny focused on third-party dependencies while we gradually backfill
+# explicit `license` metadata crate-by-crate.
+ignore = true
+registries = []
+
+[bans]
+# Surface duplicate dependencies without failing immediately so maintainers can
+# de-duplicate in follow-up PRs. Wildcard requirements are denied since they
+# make supply-chain audits non-deterministic.
+multiple-versions = "allow"
+wildcards = "deny"
+allow = []
+deny = []
+skip = [
+    { crate = "windows-targets", reason = "Upstream tokio/winit dependencies still mix 0.52 and 0.53" },
+    { crate = "winnow", reason = "Toml tooling depends on both 0.5 and 0.7; awaiting ecosystem convergence" },
+    { crate = "wasi", reason = "Web tooling still pulls both legacy and preview wasi shims" },
+    { crate = "windows_x86_64_msvc", reason = "Downstream windows crates require multiple subtargets during transition" },
+]
+skip-tree = []
+
+[sources]
+# Block any registry or git source that isn't explicitly trusted. This keeps
+# CI from pulling crates hosted outside crates.io or the workspace itself.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+# Git hosts that are cleared for direct dependencies. Keep the lists empty until
+# we intentionally approve an organization and document the reasoning.
+github = []
+gitlab = []
+bitbucket = []

--- a/docs/migrations/npm-to-rust.md
+++ b/docs/migrations/npm-to-rust.md
@@ -199,6 +199,20 @@ jobs:
         run: pnpm docs:build
 ```
 
+## 7. Audit the Rust supply chain
+
+Run RusticUI's new dependency audit before finishing the migration:
+
+```bash
+cargo xtask deny
+# or
+make deny
+```
+
+The command wraps `cargo deny check` with verbose logging so regulated teams can capture advisories, yanked crates, and license
+drift alongside the rest of the migration evidence. Commit any required `deny.toml` exceptions with rationale comments and mirror
+the command in CI to keep nightly releases compliant.
+
 Because every command funnels through `cargo xtask`, the same automation runs locally, in nightly jobs, and inside release pipelines.
 
 ## 7. Troubleshooting archived npm dependencies

--- a/examples/data-display-avatar/Cargo.toml
+++ b/examples/data-display-avatar/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rustic-ui-material = { path = "../../crates/rustic-ui-material" }
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
-rustic-ui-styled-engine = { path = "../../crates/rustic-ui-styled-engine" }
-rustic-ui-system = { path = "../../crates/rustic-ui-system" }
+rustic-ui-material = { path = "../../crates/rustic-ui-material", version = "0.1.0"}
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}
+rustic-ui-styled-engine = { path = "../../crates/rustic-ui-styled-engine", version = "0.1.0"}
+rustic-ui-system = { path = "../../crates/rustic-ui-system", version = "0.1.0"}

--- a/examples/feedback-chips/Cargo.toml
+++ b/examples/feedback-chips/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rustic-ui-material = { path = "../../crates/rustic-ui-material" }
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
-rustic-ui-styled-engine = { path = "../../crates/rustic-ui-styled-engine" }
-rustic-ui-system = { path = "../../crates/rustic-ui-system" }
+rustic-ui-material = { path = "../../crates/rustic-ui-material", version = "0.1.0"}
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}
+rustic-ui-styled-engine = { path = "../../crates/rustic-ui-styled-engine", version = "0.1.0"}
+rustic-ui-system = { path = "../../crates/rustic-ui-system", version = "0.1.0"}

--- a/examples/feedback-tooltips/Cargo.toml
+++ b/examples/feedback-tooltips/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rustic-ui-material = { path = "../../crates/rustic-ui-material" }
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
-rustic-ui-styled-engine = { path = "../../crates/rustic-ui-styled-engine" }
-rustic-ui-system = { path = "../../crates/rustic-ui-system" }
+rustic-ui-material = { path = "../../crates/rustic-ui-material", version = "0.1.0"}
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}
+rustic-ui-styled-engine = { path = "../../crates/rustic-ui-styled-engine", version = "0.1.0"}
+rustic-ui-system = { path = "../../crates/rustic-ui-system", version = "0.1.0"}

--- a/examples/joy-dioxus/Cargo.toml
+++ b/examples/joy-dioxus/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 dioxus = { workspace = true, features = ["macro", "hooks", "html"] }
 dioxus-web = { workspace = true, features = ["file_engine"] }
-joy-workflows-core = { path = "../joy-workflows-core" }
-rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false, features = ["dioxus"] }
-rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["dioxus"] }
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
+joy-workflows-core = { path = "../joy-workflows-core", version = "0.1.0"}
+rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false, features = ["dioxus"] , version = "0.1.0"}
+rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["dioxus"] , version = "0.1.0"}
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}
 dioxus-ssr = { workspace = true, optional = true }
 
 [features]

--- a/examples/joy-leptos/Cargo.toml
+++ b/examples/joy-leptos/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 leptos = { workspace = true, default-features = false }
 wasm-bindgen.workspace = true
-joy-workflows-core = { path = "../joy-workflows-core" }
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
-rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false, features = ["leptos"] }
-rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["leptos"] }
+joy-workflows-core = { path = "../joy-workflows-core", version = "0.1.0"}
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}
+rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false, features = ["leptos"] , version = "0.1.0"}
+rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["leptos"] , version = "0.1.0"}
 tokio = { workspace = true, optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 

--- a/examples/joy-sycamore/Cargo.toml
+++ b/examples/joy-sycamore/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 sycamore.workspace = true
 wasm-bindgen.workspace = true
-joy-workflows-core = { path = "../joy-workflows-core" }
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
-rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false, features = ["sycamore"] }
-rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["sycamore"] }
+joy-workflows-core = { path = "../joy-workflows-core", version = "0.1.0"}
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}
+rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false, features = ["sycamore"] , version = "0.1.0"}
+rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["sycamore"] , version = "0.1.0"}
 tokio = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true, features = ["HtmlInputElement"] }
 

--- a/examples/joy-workflows-core/Cargo.toml
+++ b/examples/joy-workflows-core/Cargo.toml
@@ -6,9 +6,9 @@ description = "Shared automation-first Joy workflow state used by cross-framewor
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
-rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false }
-rustic-ui-system = { path = "../../crates/rustic-ui-system" }
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}
+rustic-ui-joy = { path = "../../crates/rustic-ui-joy", default-features = false , version = "0.1.0"}
+rustic-ui-system = { path = "../../crates/rustic-ui-system", version = "0.1.0"}
 
 [features]
 default = []

--- a/examples/joy-yew/Cargo.toml
+++ b/examples/joy-yew/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 yew.workspace = true
 wasm-bindgen.workspace = true
-rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["yew"] }
-rustic-ui-joy = { path = "../../crates/rustic-ui-joy", features = ["yew"] }
-joy-workflows-core = { path = "../joy-workflows-core" }
+rustic-ui-system = { path = "../../crates/rustic-ui-system", features = ["yew"] , version = "0.1.0"}
+rustic-ui-joy = { path = "../../crates/rustic-ui-joy", features = ["yew"] , version = "0.1.0"}
+joy-workflows-core = { path = "../joy-workflows-core", version = "0.1.0"}
 tokio = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true, features = ["HtmlInputElement"] }
 

--- a/examples/shared-dialog-state-core/Cargo.toml
+++ b/examples/shared-dialog-state-core/Cargo.toml
@@ -6,4 +6,4 @@ description = "Shared dialog/popover/text field state orchestration for cross-fr
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rustic-ui-headless = { path = "../../crates/rustic-ui-headless" }
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", version = "0.1.0"}

--- a/tools/joy-parity/Cargo.toml
+++ b/tools/joy-parity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "joy-parity"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/tools/material-parity/Cargo.toml
+++ b/tools/material-parity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "material-parity"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary
- add a supply-chain focused `cargo xtask deny` command and expose it through the Makefile and CI pipeline
- land a repository-wide `deny.toml` plus workspace manifest cleanups so cargo-deny audits produce actionable results
- document the new guardrail in the changelog, contributor playbook, and npm-to-Rust migration guide

## Testing
- cargo fmt
- cargo clippy --workspace --all-features *(fails: `rustic-ui-material` multi-framework props still duplicate types and fail to compile)*
- cargo test --workspace --all-features *(fails: same `rustic-ui-material` compilation errors as clippy)*
- cargo deny check


------
https://chatgpt.com/codex/tasks/task_e_68d820c9cdd0832eb65dd35357383a0e