### PR TITLE
Add xtask flag to check wasm examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Lint with Clippy
         run: cargo xtask clippy
       - name: Run workspace tests
-        run: cargo xtask test
+        run: cargo xtask test --examples
       - name: Build Rust-first docs
         run: cargo xtask build-docs

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -55,8 +55,11 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
+          target: wasm32-unknown-unknown
       # Reuse build artifacts between runs
       - uses: Swatinem/rust-cache@v2
+      # Compile the workspace and wasm examples before collecting coverage
+      - run: cargo xtask test --examples
       # Execute tests and generate coverage in one step
       - run: cargo xtask coverage
       # Publish coverage statistics to external service

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The Rust workspace CI expects every pull request to validate the full adapter ma
 
 ```bash
 cargo test --workspace --all-features
+cargo xtask test --examples
 cargo xtask wasm-test
 cargo test -p mui-material --test joy_yew --features yew
 cargo test -p mui-material --test joy_leptos --features leptos

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -58,10 +58,16 @@ enum Commands {
     Deny,
     /// Execute the default test suites for all crates.
     ///
-    /// After the workspace tests finish we compile the `joy-*` WebAssembly
-    /// examples (`examples/joy-yew`, `examples/joy-leptos`, etc.) to guarantee
-    /// each renderer remains compatible with the shared RusticUI APIs.
-    Test,
+    /// Pass `--examples` to also compile every Rust example (`examples/mui-*`,
+    /// `examples/select-menu-*`, etc.) for `wasm32-unknown-unknown`. This keeps
+    /// the example gallery aligned with the published crates without forcing
+    /// every contributor to pay the additional compile time unless they
+    /// explicitly opt in.
+    Test {
+        /// Also compile every Rust example crate for `wasm32-unknown-unknown`.
+        #[arg(long)]
+        examples: bool,
+    },
     /// Run WebAssembly tests via `wasm-pack` for selected crates.
     ///
     /// This exercises the `rustic-ui-material` and `rustic-ui-joy` crates across
@@ -156,7 +162,7 @@ fn main() -> Result<()> {
         Commands::Fmt { check } => fmt(check),
         Commands::Clippy => clippy(),
         Commands::Deny => deny(),
-        Commands::Test => test(),
+        Commands::Test { examples } => test(examples),
         Commands::WasmTest => wasm_test(),
         Commands::Doc => doc(),
         Commands::RefreshIcons => refresh_icons(),
@@ -261,30 +267,132 @@ fn deny() -> Result<()> {
     run(cmd)
 }
 
-fn test() -> Result<()> {
+fn test(include_examples: bool) -> Result<()> {
     let mut cmd = Command::new("cargo");
     cmd.arg("test").arg("--workspace").arg("--all-features");
     run(cmd)?;
-    // Also ensure each example still compiles for the WebAssembly target.
-    // We prioritise the joy-* demos because they double as regression
-    // coverage for the RusticUI bindings across all supported renderers.
-    let examples = [
-        "examples/joy-yew",
-        "examples/joy-leptos",
-        "examples/joy-dioxus",
-        "examples/joy-sycamore",
-    ];
-    for ex in &examples {
+
+    if !include_examples {
+        return Ok(());
+    }
+
+    let workspace = workspace_root();
+    let examples_root = workspace.join("examples");
+    let example_crates = discover_example_crates(&examples_root)?;
+
+    if example_crates.is_empty() {
+        println!(
+            "[xtask][examples] no Rust example manifests found under {}",
+            examples_root.display()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "[xtask][examples] validating {} Rust example(s) for wasm32-unknown-unknown",
+        example_crates.len()
+    );
+
+    for example in example_crates {
+        println!(
+            "[xtask][examples] verifying `{}` against wasm32-unknown-unknown",
+            example.name
+        );
+
         let mut check = Command::new("cargo");
         check
             .arg("check")
             .arg("--target")
             .arg("wasm32-unknown-unknown")
             .arg("--manifest-path")
-            .arg(format!("{ex}/Cargo.toml"));
-        run(check)?;
+            .arg(&example.manifest);
+        run(check).with_context(|| {
+            format!(
+                "wasm cargo check failed for example `{}` at {}",
+                example.name,
+                example.manifest.display()
+            )
+        })?;
+        println!(
+            "[xtask][examples] `{}` passed cargo check for wasm32-unknown-unknown",
+            example.name
+        );
+
+        let mut test = Command::new("cargo");
+        test.arg("test")
+            .arg("--target")
+            .arg("wasm32-unknown-unknown")
+            .arg("--no-run")
+            .arg("--manifest-path")
+            .arg(&example.manifest);
+        run(test).with_context(|| {
+            format!(
+                "wasm cargo test --no-run failed for example `{}` at {}",
+                example.name,
+                example.manifest.display()
+            )
+        })?;
+        println!(
+            "[xtask][examples] `{}` passed cargo test --no-run for wasm32-unknown-unknown",
+            example.name
+        );
     }
+
+    println!(
+        "[xtask][examples] all Rust examples compiled successfully for wasm32-unknown-unknown"
+    );
     Ok(())
+}
+
+/// Metadata for a Rust example crate under `examples/`.
+///
+/// Capturing both the human-readable name and the `Cargo.toml` path keeps the
+/// logging consistent across CI and local runs while avoiding repetitive path
+/// joins throughout the verification loop.
+#[derive(Debug, Clone)]
+struct ExampleCrate {
+    name: String,
+    manifest: PathBuf,
+}
+
+/// Enumerate Rust example crates that opt into the automation pipeline.
+///
+/// We intentionally restrict the search to direct children of `examples/` so the
+/// task remains predictable even as the gallery evolves with supporting assets
+/// (React shells, screenshots, etc.). Only directories that expose a
+/// `Cargo.toml` are returned, allowing hybrid demo folders to coexist without
+/// tripping the Rust verification logic.
+fn discover_example_crates(examples_root: &Path) -> Result<Vec<ExampleCrate>> {
+    if !examples_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut crates = Vec::new();
+    let entries = fs::read_dir(examples_root).with_context(|| {
+        format!(
+            "failed to read examples directory at {}",
+            examples_root.display()
+        )
+    })?;
+
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let manifest = entry.path().join("Cargo.toml");
+        if !manifest.exists() {
+            continue;
+        }
+
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        crates.push(ExampleCrate { name, manifest });
+    }
+
+    crates.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(crates)
 }
 
 fn wasm_test() -> Result<()> {
@@ -544,7 +652,7 @@ fn build_docs() -> Result<()> {
 
 fn coverage() -> Result<()> {
     // Run tests first so that coverage data is produced.
-    test()?;
+    test(false)?;
     let mut cmd = Command::new("grcov");
     cmd.arg(".")
         .arg("--binary-path")

--- a/docs/migrations/npm-to-rust.md
+++ b/docs/migrations/npm-to-rust.md
@@ -215,7 +215,7 @@ jobs:
           cargo xtask fmt --check
           cargo xtask clippy
       - name: Test workspace
-        run: cargo xtask test
+        run: cargo xtask test --examples
       - name: Component metadata
         run: cargo xtask update-components
       - name: Bundle icons

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -10,7 +10,7 @@ repeatable and low-friction.
 2. Ensure the repository is clean and tests pass:
 
    ```bash
-   cargo xtask test
+   cargo xtask test --examples
    ```
 
 3. Validate the package manifests via dry run:

--- a/docs/rust-ci.md
+++ b/docs/rust-ci.md
@@ -35,7 +35,15 @@ Running `cargo xtask fmt --check` mirrors the CI lint job by wrapping the two co
 cargo test --workspace --all-features
 ```
 
-This is the quickest way to surface failures in the shared headless state machines, Material adapter suites, and the Joy headless unit tests under `crates/rustic-ui-joy/tests/headless_state_tests.rs`. CI calls the same entrypoint via `cargo xtask test`, which additionally checks that each example still compiles for `wasm32-unknown-unknown`.
+This is the quickest way to surface failures in the shared headless state machines, Material adapter suites, and the Joy headless unit tests under `crates/rustic-ui-joy/tests/headless_state_tests.rs`. CI calls the same entrypoint via `cargo xtask test --examples`, which additionally compiles every Rust example crate for `wasm32-unknown-unknown`.
+
+To reproduce the example verification locally (mirroring CI), install the WebAssembly target and run:
+
+```bash
+cargo xtask test --examples
+```
+
+The command enumerates every `examples/*/Cargo.toml`, runs `cargo check --target wasm32-unknown-unknown`, and executes `cargo test --target wasm32-unknown-unknown --no-run` for deterministic build coverage. Each example logs its own status block and the task exits non-zero if any example fails to compile.
 
 ### Joy snapshot parity suites
 Joy UI ships SSR renderers for every supported framework. The parity suites compare each adapter to the canonical React output so teams can guarantee hydration-safe markup whenever Joy tokens evolve. Target a single framework or run the whole matrix:


### PR DESCRIPTION
## Summary
- add an `--examples` flag to `cargo xtask test` that enumerates Rust example crates and compiles them for `wasm32-unknown-unknown`
- ensure the coverage workflow and shared CI pipeline exercise the new flag and install the wasm target ahead of time
- document the expanded example verification flow in the README and docs so contributors can mirror CI locally

## Testing
- cargo check -p xtask

------
https://chatgpt.com/codex/tasks/task_e_68d9b860abec832eb10dc5c0bb4c1b90