### PR TITLE
Document Rust example scaffolding workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,14 +151,18 @@ so keeping them accurate is a release gate.
 
 ## Documentation and demo workflow
 
-Use the scripted scaffolding to avoid manual setup:
+Use the automation shipped with each example to avoid manual setup:
 
-```bash
-cargo xtask scaffold-demo --component button --framework leptos
-```
-
-The generator produces the doc page, localized strings, Playwright tests, and analytics markers. Update the generated markdown
-with narrative context, but keep the structural conventions intact so the translation pipeline succeeds.
+1. Pick the closest blueprint in [`examples/`](examples/). The
+   [Rust example gallery](docs/src/pages/examples/index.md) lists every demo,
+   their automation hooks, and parity guarantees.
+2. Run the documented bootstrap command (for example
+   `./examples/navigation-tabs-yew/scripts/bootstrap.sh` or `cargo run --bin bootstrap --manifest-path examples/feedback-tooltips/Cargo.toml`).
+   These scripts materialise a ready-to-run workspace with SSR snapshots,
+   hydration stubs, analytics markers, and framework manifests.
+3. Update the generated markdown or README copy with narrative context, keeping
+   the automation IDs and translation scaffolding intact so localisation and QA
+   pipelines remain deterministic.
 
 ## Component development checklist
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ For fine-grained routines the repository exposes a companion CLI via `cargo xtas
 binary:
 
 ```bash
-cargo xtask scaffold-component    # scaffold a fully-instrumented component package
 cargo xtask icon-update           # pull the latest Rustic icon sets
 cargo xtask update-components     # emit the Rust-native component metadata manifest
 cargo xtask accessibility-audit   # lint Markdown docs for accessibility regressions
@@ -173,6 +172,34 @@ cargo test -p mui-material --test joy_sycamore --features sycamore
 ```
 
 Use the parity suites above to chase snapshot mismatches: rerun the failing test with `-- --nocapture --exact` to inspect the React versus adapter markup before refreshing fixtures or renderers. The [Rust CI guide](docs/rust-ci.md) documents deeper troubleshooting steps, snapshot refresh flows, and coverage tooling so teams can keep automation green without guesswork.
+
+## Rust example gallery
+
+Every maintained demo lives under `examples/` and ships automation hooks plus
+framework-specific bootstrap flows. The new
+[Rust example gallery](docs/src/pages/examples/index.md) summarises the
+supported use cases, parity guarantees, and scaffolding steps for each
+blueprint. Highlights include:
+
+- **Marketing microsite** – [`examples/mui-yew`](examples/mui-yew) and its sister
+  crates recreate the archived React marketing site with shared automation IDs,
+  SSR parity, and exhaustive inline documentation.【F:examples/mui-yew/README.md†L1-L91】【F:examples/mui-ssr-accessibility/README.md†L1-L95】
+- **Navigation bundles** – [`examples/navigation-drawer-*`](examples/navigation-drawer-yew/README.md)
+  and [`examples/navigation-tabs-*`](examples/navigation-tabs-yew/README.md)
+  include bootstrap scripts that materialise ready-to-run projects with trunk
+  manifests, axe-core wiring, and deterministic automation metadata.【F:examples/navigation-drawer-yew/README.md†L1-L52】【F:examples/navigation-tabs-yew/README.md†L1-L58】
+- **Async data entry** – [`examples/select-menu-*`](examples/select-menu-yew/README.md)
+  demonstrate controlled state, asynchronous loaders, and SSR smoke tests so
+  enterprise dashboards can reuse the automation contracts without drift.【F:examples/select-menu-yew/README.md†L1-L56】【F:examples/select-menu-yew/README.md†L80-L94】
+- **Automation-first utilities** – the feedback, data-display, Joy workflows,
+  and shared dialog blueprints emit SSR snapshots, hydration stubs, and test
+  suites to guarantee parity across frameworks while exposing stable
+  `data-rustic-*` identifiers.【F:examples/feedback-tooltips/README.md†L1-L56】【F:examples/data-display-avatar/README.md†L1-L36】【F:examples/joy-yew/README.md†L1-L42】【F:examples/shared-dialog-state-yew/README.md†L1-L33】
+
+To spin up a new example, start from the closest blueprint in `examples/`, run
+its bootstrap command (if provided), and follow the automation checklist in the
+gallery page. This keeps SSR snapshots, hydration behaviour, and analytics IDs
+aligned before adding bespoke features.
 
 ## Select and menu reference implementations
 

--- a/archives/examples/material-ui-express-ssr/README.md
+++ b/archives/examples/material-ui-express-ssr/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-gatsby/README.md
+++ b/archives/examples/material-ui-gatsby/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-nextjs-pages-router-ts/README.md
+++ b/archives/examples/material-ui-nextjs-pages-router-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-nextjs-pages-router/README.md
+++ b/archives/examples/material-ui-nextjs-pages-router/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-nextjs-ts/README.md
+++ b/archives/examples/material-ui-nextjs-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-nextjs/README.md
+++ b/archives/examples/material-ui-nextjs/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-pigment-css-nextjs-ts/README.md
+++ b/archives/examples/material-ui-pigment-css-nextjs-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-pigment-css-vite-ts/README.md
+++ b/archives/examples/material-ui-pigment-css-vite-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-preact/README.md
+++ b/archives/examples/material-ui-preact/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-react-router-ts/README.md
+++ b/archives/examples/material-ui-react-router-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-remix-ts/README.md
+++ b/archives/examples/material-ui-remix-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-via-cdn/README.md
+++ b/archives/examples/material-ui-via-cdn/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-vite-tailwind-ts/README.md
+++ b/archives/examples/material-ui-vite-tailwind-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-vite-ts/README.md
+++ b/archives/examples/material-ui-vite-ts/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/archives/examples/material-ui-vite/README.md
+++ b/archives/examples/material-ui-vite/README.md
@@ -13,6 +13,8 @@ The maintained, automation-friendly replacements are designed for enterprise sca
 - [Sycamore SPA baseline](../../../examples/mui-sycamore) – Provides an alternative reactive runtime while preserving our design tokens and accessibility harnesses.
 - [SSR + accessibility harness](../../../examples/mui-ssr-accessibility) – Covers server-rendering, hydration, and analytics wiring so the multi-tenant governance model remains intact.
 
+- [Rust example gallery overview](../../../docs/src/pages/examples/index.md) – Summarises automation hooks, parity expectations, and bootstrap commands for every maintained Rust demo.
+
 Each crate ships extensive inline notes, integration tests, and automation hooks so teams can extend them without reinventing the pipeline. Reuse those crates instead of copying legacy React templates.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,11 @@ Package managers other than pnpm (like npm or Yarn) are not supported and will n
 
 1. Open a discussion in the [RusticUI RFC board](https://github.com/apotheon-ai/rusticui/discussions/categories/rfcs) describing the
    problem the demo should solve.
-2. Once approved, use `cargo xtask scaffold-component` or `cargo xtask scaffold-demo` to generate the baseline files. The script
-   injects accessibility tests, analytics tags, and translation scaffolding automatically to minimize manual wiring.
+2. Once approved, start from the closest Rust blueprint in [`examples/`](../examples) and follow its bootstrap instructions
+   (for example `./examples/navigation-tabs-yew/scripts/bootstrap.sh` or `cargo run --bin bootstrap --manifest-path examples/feedback-tooltips/Cargo.toml`).
+   These scripts hydrate deterministic automation IDs, SSR snapshots, and framework manifests so you avoid manual wiring.
+   The [Rust example gallery](src/pages/examples/index.md) documents the available demos, parity guarantees, and
+   follow-up verification steps.
 3. Commit the generated files and update the appropriate page inside `docs/src/pages`.
 
 ## How do I help to improve the translations?

--- a/docs/src/pages/examples/index.md
+++ b/docs/src/pages/examples/index.md
@@ -1,0 +1,150 @@
+# Rust example gallery
+
+RusticUI's example suites pair shared headless state machines with framework
+adapters, deterministic automation hooks, and scripts that eliminate manual
+scaffolding. Every blueprint below documents its bootstrap command, the
+automation metadata it emits, and the parity checks you should run before
+shipping changes.
+
+## Scaffolding workflow
+
+1. **Select a baseline.** Start from the closest crate under
+   [`examples/`](../../../examples). Each README calls out the shared state
+   machines, automation identifiers, and CI expectations for that surface.
+2. **Run the bundled bootstrap.** Execute the example's script or binary (for
+   example `./examples/navigation-tabs-yew/scripts/bootstrap.sh` or
+   `cargo run --bin bootstrap --manifest-path examples/feedback-tooltips/Cargo.toml`)
+   to materialise a ready-to-run workspace with SSR snapshots, hydration stubs,
+   and analytics markers baked in.【F:examples/navigation-tabs-yew/README.md†L20-L33】【F:examples/feedback-tooltips/README.md†L9-L22】
+3. **Wire automation into CI.** Validate formatting and compile the workspace via
+   `cargo xtask fmt`, `cargo xtask clippy`, and
+   `cargo xtask test --examples` so the new blueprint participates in the shared
+   Wasm targets and parity checks.【F:crates/xtask/src/main.rs†L49-L70】
+4. **Document the flow.** Extend this gallery and the example README with any
+   bespoke analytics requirements or parity notes before running
+   `cargo xtask build-docs` to refresh the docs site for review.【F:crates/xtask/src/main.rs†L118-L119】
+
+## Marketing microsite suite (`examples/mui-*`)
+
+The Material marketing blueprints compose `mui-shared` layout primitives with
+Yew, Leptos, Dioxus, and Sycamore adapters to reproduce the archived React
+experience. Each crate documents CSR, SSR, and release builds, while the shared
+route descriptors guarantee deterministic automation IDs across frameworks.【F:examples/mui-yew/README.md†L1-L60】
+
+- **Run locally:** `trunk serve --open` for CSR bundles and
+  `cargo run --manifest-path examples/mui-*/Cargo.toml --features ssr` for the
+  HTML snapshot used in parity audits.【F:examples/mui-yew/README.md†L11-L31】
+- **Automation:** Navigation, hero, and showcase sections expose
+  `data-rustic-*` selectors sourced from `mui_shared::AutomationIdBuilder` so QA
+  suites can diff SSR and CSR output safely.【F:examples/mui-yew/README.md†L62-L70】
+- **Parity checks:** `cargo test --package rustic_ui_yew_example` and its sister
+  crates assert router wiring, hydration safety, and automation determinism
+  before merges.【F:examples/mui-yew/README.md†L33-L39】
+- **SSR harness:** `examples/mui-ssr-accessibility` streams the same shell for
+  accessibility and release snapshots, then reuses the CSR bundles for hydration
+  validation.【F:examples/mui-ssr-accessibility/README.md†L1-L39】
+
+## Navigation drawer suite (`examples/navigation-drawer-*`)
+
+These demos showcase responsive drawers with shared automation metadata, modal
+and anchored variants, and ready-to-run bootstrap scripts for every framework.【F:examples/navigation-drawer-yew/README.md†L1-L26】【F:examples/navigation-drawer-leptos/README.md†L1-L18】
+
+- **Automation:** Drawer surface, backdrop, and navigation markup carry
+  `aria-modal`, labelled headings, and deterministic data attributes so analytics
+  and accessibility audits remain stable.【F:examples/navigation-drawer-yew/README.md†L10-L18】
+- **Bootstrap:** Run the framework script (for example
+  `./examples/navigation-drawer-yew/scripts/bootstrap.sh`) to generate a Trunk
+  workspace with axe-core wiring and exhaustive inline comments.【F:examples/navigation-drawer-yew/README.md†L20-L26】
+- **Parity:** Generated projects include routing callbacks and keyboard
+  shortcuts to keep CSR and SSR behaviour aligned; review the scaffolded
+  README under `target/` to capture any framework-specific extensions.【F:examples/navigation-drawer-yew/README.md†L28-L59】【F:examples/navigation-drawer-leptos/README.md†L7-L18】
+
+## Navigation tabs suite (`examples/navigation-tabs-*`)
+
+Tab demos pair the shared headless `TabsState` with responsive layout options and
+framework routers to keep orientation, selection, and analytics markers in sync.【F:examples/navigation-tabs-yew/README.md†L1-L86】
+
+- **Bootstrap:** Execute `./examples/navigation-tabs-*/scripts/bootstrap.sh` to
+  emit a documented project with Trunk manifests and hydration stubs.【F:examples/navigation-tabs-yew/README.md†L20-L33】
+- **Automation:** Each tab uses the shared render helpers to stamp
+  `data-rustic-*` selectors, enabling QA to reuse scenarios across Yew, Leptos,
+  Dioxus, and Sycamore.【F:examples/navigation-tabs-yew/README.md†L11-L18】
+- **Parity:** The scaffolded code wires router callbacks and axe-core checks so
+  teams can assert hydration parity without hand-written harnesses.【F:examples/navigation-tabs-yew/README.md†L35-L86】
+
+## Select menu suite (`examples/select-menu-*`)
+
+Controlled listboxes demonstrate asynchronous data loading, SSR mirroring, and
+shared automation attributes centralised in `select-menu-shared`.【F:examples/select-menu-yew/README.md†L1-L26】
+
+- **CSR workflow:** Run `trunk serve --open` to hydrate the server snapshot and
+  exercise async loaders with deterministic automation IDs.【F:examples/select-menu-yew/README.md†L18-L26】
+- **Headless overrides:** Toggle option availability through `SelectState` to
+  verify how ARIA metadata and automation selectors react without touching the
+  adapter code.【F:examples/select-menu-yew/README.md†L28-L40】
+- **SSR parity:** `cargo run --manifest-path examples/select-menu-*/Cargo.toml --features ssr`
+  emits the HTML snapshot consumed by CSR bundles, ensuring parity across
+  renderers.【F:examples/select-menu-yew/README.md†L42-L50】
+
+## Selection controls (`examples/selection-controls-*`)
+
+The selection control samples wire checkbox, switch, and radio state machines
+into framework adapters via shared render helpers, keeping automation and ARIA
+contracts identical across runtimes.【F:examples/selection-controls-yew/README.md†L1-L44】
+
+Use the examples as reference implementations when integrating multiple control
+surfaces into dashboards; the snippets highlight how to reuse the headless
+machines without duplicating markup.
+
+## Feedback surfaces (`examples/feedback-*`)
+
+Feedback blueprints produce multi-framework SSR snapshots, hydration stubs, and
+automation contracts with a single bootstrap command.
+
+- **Chips:** `cargo run --bin bootstrap --manifest-path examples/feedback-chips/Cargo.toml`
+  renders dismissible and read-only variants for every framework, including
+  deterministic `data-rustic-chip-id` selectors and regression tests that guard
+  against automation drift.【F:examples/feedback-chips/README.md†L1-L45】
+- **Tooltips:** The tooltip bootstrap emits SSR HTML, hydration starters, and
+  portal metadata so analytics and monitoring can bind before hydration. Run the
+  bundled tests to confirm shared `data-rustic-tooltip-id` selectors remain
+  intact.【F:examples/feedback-tooltips/README.md†L1-L45】
+
+## Data display surfaces (`examples/data-display-*`)
+
+Data display demos illustrate how list, table, and avatar surfaces share headless
+state and automation IDs across frameworks.
+
+- **List + table:** `cargo run --package data-display-yew` renders compact list
+  and zebra-striped tables with deterministic automation selectors while reusing
+  the shared headless state machine.【F:examples/data-display-yew/README.md†L1-L24】
+- **Avatar widget:** `cargo run --bin bootstrap --manifest-path examples/data-display-avatar/Cargo.toml`
+  builds combined chip/tooltip avatars with themed overrides and shared
+  automation hooks, plus regression tests that ensure parity.【F:examples/data-display-avatar/README.md†L1-L35】
+
+## Joy workflows (`examples/joy-*`)
+
+The Joy workflow adapters consume `joy-workflows-core` to expose identical
+stepper, snackbar, and analytics behaviour across frameworks.【F:examples/joy-yew/README.md†L1-L38】
+
+- **CSR:** Serve the bundle via `trunk serve --open` (or the equivalent for other
+  frameworks) to validate Joy design tokens and lifecycle logging.【F:examples/joy-yew/README.md†L19-L28】
+- **SSR snapshot:** `cargo run --manifest-path examples/joy-*/Cargo.toml --features ssr`
+  prints deterministic lifecycle summaries for parity verification.【F:examples/joy-yew/README.md†L30-L38】
+
+## Shared dialog state (`examples/shared-dialog-state-*`)
+
+Overlay demos rely on the `shared-dialog-state-core` crate to synchronise dialogs,
+popovers, and validation flows across frameworks, with automation hooks ready for
+enterprise QA pipelines.【F:examples/shared-dialog-state-yew/README.md†L1-L47】
+
+- **Bootstrap:** Run `./examples/shared-dialog-state-*/scripts/bootstrap.sh` to
+  materialise a workspace with SSR markup, hydration hooks, analytics logging,
+  and inline documentation for lifecycle events.【F:examples/shared-dialog-state-yew/README.md†L24-L47】
+- **Parity:** Deterministic `data-*` attributes (`data-transition`,
+  `data-popover-placement`, validation markers) ensure Playwright and Cypress
+  suites stay stable as the shared overlay state evolves.【F:examples/shared-dialog-state-yew/README.md†L11-L19】
+
+By following these automation-first workflows and verifying changes through the
+shared `cargo xtask` entry points, teams can add or extend examples without
+reintroducing manual scaffolding or diverging automation hooks.


### PR DESCRIPTION
## Summary
- replace references to the unimplemented scaffold commands with the actual bootstrap-based process in the README, docs handbook, and contributing guide
- add a Rust example gallery page that catalogs every maintained demo, its automation hooks, and parity validation steps
- point every archived React example README at the new gallery so teams can navigate to the Rust counterparts and automation guidance quickly

## Testing
- pnpm --dir docs install *(fails: workspace packages such as @mui-internal/api-docs-builder are not present in this checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bc5dffa8832eaa5c342af8b537d0