### PR TITLE
Add layout adapter wrappers for framework renderers

### DIFF
--- a/crates/rustic-ui-material/Cargo.toml
+++ b/crates/rustic-ui-material/Cargo.toml
@@ -31,6 +31,7 @@ gloo-utils = "0.2"
 [features]
 default = []
 compat-mui = []
+react = []
 yew = ["dep:yew", "dep:wasm-bindgen", "rustic-ui-system/yew", "rustic-ui-styled-engine/yew", "dep:web-sys"]
 leptos = ["dep:leptos", "dep:wasm-bindgen", "rustic-ui-system/leptos"]
 dioxus = ["rustic-ui-system/dioxus", "rustic-ui-styled-engine/dioxus"]

--- a/crates/rustic-ui-material/src/box.rs
+++ b/crates/rustic-ui-material/src/box.rs
@@ -113,6 +113,126 @@ fn box_tokens_for_breakpoint(evaluation: &BoxEvaluation<'_>) -> Vec<(&'static st
     tokens
 }
 
+/// Props shared by every framework adapter.
+///
+/// The [`BoxState`] already abstracts controlled and uncontrolled usage through
+/// its internal control strategy.  Adapters accept a reference to the state so
+/// reactive frameworks can either hold the state in a signal (controlled) or
+/// let the state live locally inside the adapter (uncontrolled).  The renderer
+/// simply reads the latest snapshot which keeps the mapping to the headless API
+/// deterministic.
+#[derive(Clone, Copy, Debug)]
+pub struct BoxAdapterProps<'a> {
+    /// Headless box state machine driving layout evaluation.
+    pub state: &'a BoxState,
+}
+
+impl<'a> BoxAdapterProps<'a> {
+    /// Convenience constructor so integrators can express intent without struct
+    /// literal syntax.
+    #[inline]
+    pub fn new(state: &'a BoxState) -> Self {
+        Self { state }
+    }
+}
+
+/// Internal helper used by every adapter module.
+///
+/// The function keeps the controlled/uncontrolled behaviour consistent by
+/// always delegating to [`render_box`].  Framework specific wrappers simply call
+/// this helper so server rendered React, client side Yew or signal driven
+/// Sycamore pipelines all render identical CSS variables.
+#[cfg_attr(
+    not(any(
+        feature = "react",
+        feature = "yew",
+        feature = "leptos",
+        feature = "dioxus",
+        feature = "sycamore"
+    )),
+    allow(dead_code)
+)]
+fn render_box_with_props(props: BoxAdapterProps<'_>) -> BoxRenderOutput {
+    // Delegating straight to the shared renderer ensures the adapter never goes
+    // out of sync with the canonical SSR output and keeps hydration byte-perfect.
+    render_box(props.state)
+}
+
+/// React SSR adapter wrapping [`render_box`].
+#[cfg(feature = "react")]
+pub mod react {
+    use super::*;
+
+    /// Generate deterministic CSS variables for React's server rendering stage.
+    ///
+    /// Enterprise teams often run this inside Node based renderers before
+    /// handing control to React on the client.  The adapter intentionally avoids
+    /// mutating the state; React should own the control flow and provide updated
+    /// [`BoxState`] snapshots whenever props change.  On hydration the browser
+    /// sees the exact same inline style string which prevents checksum
+    /// mismatches.
+    pub fn render(props: BoxAdapterProps<'_>) -> BoxRenderOutput {
+        super::render_box_with_props(props)
+    }
+}
+
+/// Yew adapter exposing [`render_box`] behind the `yew` feature flag.
+#[cfg(feature = "yew")]
+pub mod yew {
+    use super::*;
+
+    /// Produce CSS variables for inclusion in a `<style>` tag or inline `style`
+    /// attribute while respecting Yew's reactive lifecycles.  Callers typically
+    /// store the [`BoxState`] inside `use_state` (controlled) or build it on the
+    /// fly per render (uncontrolled); both flows surface the latest snapshot to
+    /// this helper which in turn mirrors the shared SSR renderer.
+    pub fn render(props: BoxAdapterProps<'_>) -> BoxRenderOutput {
+        super::render_box_with_props(props)
+    }
+}
+
+/// Leptos adapter bridging reactive signals to [`render_box`].
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Invoke the shared renderer using the latest headless snapshot.  Because
+    /// Leptos signals re-run dependents automatically, feeding the [`BoxState`]
+    /// through this helper keeps controlled signal driven flows aligned with the
+    /// headless behaviour without writing imperative glue code.
+    pub fn render(props: BoxAdapterProps<'_>) -> BoxRenderOutput {
+        super::render_box_with_props(props)
+    }
+}
+
+/// Dioxus adapter for layout SSR/hydration pipelines.
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Dioxus ships the same [`BoxState`] between server and client.  The
+    /// adapter simply calls into the shared renderer, guaranteeing that the
+    /// inline style string matches across SSR and subsequent mutations triggered
+    /// by controlled props.
+    pub fn render(props: BoxAdapterProps<'_>) -> BoxRenderOutput {
+        super::render_box_with_props(props)
+    }
+}
+
+/// Sycamore adapter mirroring the other framework implementations.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Sycamore's reactive scopes can own the [`BoxState`] directly or receive
+    /// it from a parent owner.  In both cases we route through the shared
+    /// renderer so SSR output and client side recomputation stay perfectly
+    /// aligned for enterprise grade snapshot testing.
+    pub fn render(props: BoxAdapterProps<'_>) -> BoxRenderOutput {
+        super::render_box_with_props(props)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,5 +253,20 @@ mod tests {
             .css_variables()
             .contains_key("--rustic_ui_box_padding"));
         assert!(output.inline_style().contains("--rustic_ui_box_padding"));
+    }
+
+    #[test]
+    fn adapter_props_delegate_to_shared_renderer() {
+        let tokens = rustic_ui_headless::r#box::BoxTokens {
+            padding: ResponsiveValue::from(String::from("2rem")),
+            margin: ResponsiveValue::from(String::from("1rem")),
+            background: ResponsiveValue::from(String::from("var(--surface)")),
+        };
+        let state = BoxState::new(tokens, BreakpointConfig::material());
+
+        let base = render_box(&state);
+        let adapter = super::render_box_with_props(BoxAdapterProps::new(&state));
+
+        assert_eq!(base.inline_style(), adapter.inline_style());
     }
 }

--- a/crates/rustic-ui-material/src/container.rs
+++ b/crates/rustic-ui-material/src/container.rs
@@ -87,6 +87,111 @@ fn container_tokens_for_breakpoint(
     tokens
 }
 
+/// Props consumed by every framework adapter.
+///
+/// [`ContainerState`] embeds its own control strategy so adapters simply borrow
+/// the state.  Controlled flows keep the state in a reactive signal and pass a
+/// reference while uncontrolled usage can let the adapter own the state.  The
+/// renderer always evaluates the most recent snapshot which keeps the mapping to
+/// the headless API identical across frameworks.
+#[derive(Clone, Copy, Debug)]
+pub struct ContainerAdapterProps<'a> {
+    /// Headless state describing the container's responsive geometry.
+    pub state: &'a ContainerState,
+}
+
+impl<'a> ContainerAdapterProps<'a> {
+    /// Helper so integrators can construct props fluently.
+    #[inline]
+    pub fn new(state: &'a ContainerState) -> Self {
+        Self { state }
+    }
+}
+
+/// Shared implementation invoked by every adapter module.
+#[cfg_attr(
+    not(any(
+        feature = "react",
+        feature = "yew",
+        feature = "leptos",
+        feature = "dioxus",
+        feature = "sycamore"
+    )),
+    allow(dead_code)
+)]
+fn render_container_with_props(props: ContainerAdapterProps<'_>) -> ContainerRenderOutput {
+    // Delegating to the canonical renderer keeps SSR output deterministic and
+    // ensures hydration diffing remains stable regardless of framework.
+    render_container(props.state)
+}
+
+/// React focused adapter exposing [`render_container`].
+#[cfg(feature = "react")]
+pub mod react {
+    use super::*;
+
+    /// Run the container renderer during React's server render lifecycle.  The
+    /// returned CSS variable map can be fed into CSS-in-JS systems while the
+    /// inline style string is ideal for streaming HTML responses.
+    pub fn render(props: ContainerAdapterProps<'_>) -> ContainerRenderOutput {
+        super::render_container_with_props(props)
+    }
+}
+
+/// Yew adapter wrapping [`render_container`] and gated behind `yew`.
+#[cfg(feature = "yew")]
+pub mod yew {
+    use super::*;
+
+    /// Produce SSR identical CSS variables for Yew components.  Consumers can
+    /// keep the [`ContainerState`] in `UseStateHandle`s for controlled updates or
+    /// instantiate it on the fly for uncontrolled flows; both strategies surface
+    /// the same snapshot to the shared renderer.
+    pub fn render(props: ContainerAdapterProps<'_>) -> ContainerRenderOutput {
+        super::render_container_with_props(props)
+    }
+}
+
+/// Leptos adapter bridging signals to the shared renderer.
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Invoke the renderer each time Leptos re-computes the container state.
+    /// The output feeds nicely into `view!` macros via inline styles or dynamic
+    /// `<style>` tags for enterprise grade SSR pipelines.
+    pub fn render(props: ContainerAdapterProps<'_>) -> ContainerRenderOutput {
+        super::render_container_with_props(props)
+    }
+}
+
+/// Dioxus adapter maintaining SSR parity.
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Dioxus orchestrators can call this during the `render` phase to derive
+    /// CSS variables for streaming SSR.  Because the adapter never mutates the
+    /// state it respects both controlled and uncontrolled ownership models.
+    pub fn render(props: ContainerAdapterProps<'_>) -> ContainerRenderOutput {
+        super::render_container_with_props(props)
+    }
+}
+
+/// Sycamore adapter mirroring the other frameworks.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Compute the CSS variables using the canonical renderer so Sycamore's
+    /// reactive scopes can hydrate without diff noise.  Passing the state by
+    /// reference makes it trivial to bridge controlled signals into the headless
+    /// API.
+    pub fn render(props: ContainerAdapterProps<'_>) -> ContainerRenderOutput {
+        super::render_container_with_props(props)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,5 +217,19 @@ mod tests {
         assert!(output
             .inline_style()
             .contains("--rustic_ui_container_fixed"));
+    }
+
+    #[test]
+    fn adapter_delegates_to_shared_renderer() {
+        let tokens = rustic_ui_headless::container::ContainerTokens {
+            max_width: ResponsiveValue::new("1200px".to_string()),
+            padding_inline: ResponsiveValue::from(String::from("24px")),
+        };
+        let state = ContainerState::new(tokens, BreakpointConfig::material());
+
+        let base = render_container(&state);
+        let adapter = super::render_container_with_props(ContainerAdapterProps::new(&state));
+
+        assert_eq!(base.inline_style(), adapter.inline_style());
     }
 }

--- a/crates/rustic-ui-material/src/grid.rs
+++ b/crates/rustic-ui-material/src/grid.rs
@@ -84,6 +84,109 @@ fn grid_tokens_for_breakpoint(evaluation: &GridEvaluation<'_>) -> Vec<(&'static 
     tokens
 }
 
+/// Props passed to the framework specific adapters.
+///
+/// [`GridState`] encapsulates responsive evaluation along with the control
+/// strategy, so adapters merely borrow it.  Controlled integrations keep the
+/// state in a signal or hook while uncontrolled flows construct it on demand;
+/// both converge on the same renderer which reads the most recent evaluation.
+#[derive(Clone, Copy, Debug)]
+pub struct GridAdapterProps<'a> {
+    /// Headless grid state driving track and spacing values.
+    pub state: &'a GridState,
+}
+
+impl<'a> GridAdapterProps<'a> {
+    /// Helper for ergonomic construction in integration code.
+    #[inline]
+    pub fn new(state: &'a GridState) -> Self {
+        Self { state }
+    }
+}
+
+/// Internal helper shared by all adapter modules.
+#[cfg_attr(
+    not(any(
+        feature = "react",
+        feature = "yew",
+        feature = "leptos",
+        feature = "dioxus",
+        feature = "sycamore"
+    )),
+    allow(dead_code)
+)]
+fn render_grid_with_props(props: GridAdapterProps<'_>) -> GridRenderOutput {
+    // Delegate to the canonical renderer so SSR and hydration are byte-identical
+    // regardless of which framework hosts the layout component.
+    render_grid(props.state)
+}
+
+/// React adapter for grid rendering.
+#[cfg(feature = "react")]
+pub mod react {
+    use super::*;
+
+    /// Run the shared renderer during React's server-side render lifecycle.
+    /// Enterprises often stash the CSS variable map inside orchestration layers
+    /// so design systems can compose layouts without bespoke glue code.
+    pub fn render(props: GridAdapterProps<'_>) -> GridRenderOutput {
+        super::render_grid_with_props(props)
+    }
+}
+
+/// Yew adapter bridging to [`render_grid`].
+#[cfg(feature = "yew")]
+pub mod yew {
+    use super::*;
+
+    /// Produce deterministic grid CSS variables for Yew components.  By routing
+    /// through the shared renderer, controlled props (state stored in hooks) and
+    /// uncontrolled props (state created per render) both respect the same
+    /// headless evaluation.
+    pub fn render(props: GridAdapterProps<'_>) -> GridRenderOutput {
+        super::render_grid_with_props(props)
+    }
+}
+
+/// Leptos adapter mirroring other frameworks.
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Leptos signals trigger this renderer automatically when inputs change.
+    /// The inline style string can be injected into SSR templates to guarantee
+    /// hydration parity.
+    pub fn render(props: GridAdapterProps<'_>) -> GridRenderOutput {
+        super::render_grid_with_props(props)
+    }
+}
+
+/// Dioxus adapter for SSR/hydration pipelines.
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Dioxus orchestrators should call this during render to obtain the CSS
+    /// variables before streaming markup.  The shared helper keeps controlled and
+    /// uncontrolled ownership models aligned without extra bookkeeping.
+    pub fn render(props: GridAdapterProps<'_>) -> GridRenderOutput {
+        super::render_grid_with_props(props)
+    }
+}
+
+/// Sycamore adapter forwarding to the canonical renderer.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Sycamore's signals or stored state can both drive this helper which then
+    /// formats the CSS variables for SSR snapshots.  Enterprise automation suites
+    /// can diff the resulting markup across frameworks with confidence.
+    pub fn render(props: GridAdapterProps<'_>) -> GridRenderOutput {
+        super::render_grid_with_props(props)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,5 +214,20 @@ mod tests {
             .css_variables()
             .contains_key("--rustic_ui_grid_template-lg"));
         assert!(output.inline_style().contains("--rustic_ui_grid_auto_flow"));
+    }
+
+    #[test]
+    fn adapter_mirrors_shared_renderer() {
+        let tokens = rustic_ui_headless::grid::GridTokens {
+            columns: ResponsiveValue::new(3),
+            column_gap: ResponsiveValue::from(String::from("8px")),
+            row_gap: ResponsiveValue::from(String::from("12px")),
+        };
+        let state = GridState::new(tokens, BreakpointConfig::material());
+
+        let base = render_grid(&state);
+        let adapter = super::render_grid_with_props(GridAdapterProps::new(&state));
+
+        assert_eq!(base.inline_style(), adapter.inline_style());
     }
 }

--- a/crates/rustic-ui-material/src/lib.rs
+++ b/crates/rustic-ui-material/src/lib.rs
@@ -52,10 +52,10 @@ pub mod tooltip;
 
 pub use rustic_ui_styled_engine::Theme;
 
-pub use crate::r#box::{render_box, BoxRenderOutput};
-pub use container::{render_container, ContainerRenderOutput};
-pub use grid::{render_grid, GridRenderOutput};
-pub use stack::{render_stack, StackRenderOutput};
+pub use crate::r#box::{render_box, BoxAdapterProps, BoxRenderOutput};
+pub use container::{render_container, ContainerAdapterProps, ContainerRenderOutput};
+pub use grid::{render_grid, GridAdapterProps, GridRenderOutput};
+pub use stack::{render_stack, StackAdapterProps, StackRenderOutput};
 
 /// Confirms that the crate links to `rustic_ui_styled_engine` and compiles.
 pub fn placeholder() {

--- a/crates/rustic-ui-material/src/stack.rs
+++ b/crates/rustic-ui-material/src/stack.rs
@@ -77,6 +77,107 @@ fn stack_tokens_for_breakpoint(evaluation: &StackEvaluation<'_>) -> Vec<(&'stati
     tokens
 }
 
+/// Shared props for framework adapters.
+///
+/// [`StackState`] carries the control strategy internally, allowing adapters to
+/// borrow the state regardless of whether the calling code is controlled or
+/// uncontrolled.  React/Yew/Leptos/Sycamore orchestrators simply pass the state
+/// reference and let the renderer emit deterministic CSS variables.
+#[derive(Clone, Copy, Debug)]
+pub struct StackAdapterProps<'a> {
+    /// Headless stack state that exposes responsive direction/gap metadata.
+    pub state: &'a StackState,
+}
+
+impl<'a> StackAdapterProps<'a> {
+    /// Convenience constructor for integration code.
+    #[inline]
+    pub fn new(state: &'a StackState) -> Self {
+        Self { state }
+    }
+}
+
+/// Internal helper leveraged by every adapter.
+#[cfg_attr(
+    not(any(
+        feature = "react",
+        feature = "yew",
+        feature = "leptos",
+        feature = "dioxus",
+        feature = "sycamore"
+    )),
+    allow(dead_code)
+)]
+fn render_stack_with_props(props: StackAdapterProps<'_>) -> StackRenderOutput {
+    // The canonical renderer centralises lifecycle handling so adapters remain
+    // thin wrappers with zero drift across frameworks.
+    render_stack(props.state)
+}
+
+/// React adapter bridging to the stack renderer.
+#[cfg(feature = "react")]
+pub mod react {
+    use super::*;
+
+    /// Render the stack during React SSR.  Enterprises can serialise the inline
+    /// style directly into streamed markup knowing hydration will compute the
+    /// same CSS variables once the [`StackState`] rehydrates on the client.
+    pub fn render(props: StackAdapterProps<'_>) -> StackRenderOutput {
+        super::render_stack_with_props(props)
+    }
+}
+
+/// Yew adapter ensuring lifecycle parity with SSR output.
+#[cfg(feature = "yew")]
+pub mod yew {
+    use super::*;
+
+    /// Invoke the shared renderer from within Yew components.  Controlled
+    /// `UseStateHandle` flows and uncontrolled per-render construction both map
+    /// to the same headless state ensuring deterministic automation hooks.
+    pub fn render(props: StackAdapterProps<'_>) -> StackRenderOutput {
+        super::render_stack_with_props(props)
+    }
+}
+
+/// Leptos adapter.
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Feed the [`StackState`] from reactive signals into the canonical renderer
+    /// so server rendered snapshots and client recomputation stay in lockstep.
+    pub fn render(props: StackAdapterProps<'_>) -> StackRenderOutput {
+        super::render_stack_with_props(props)
+    }
+}
+
+/// Dioxus adapter.
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Dioxus renderers call into this helper during the component lifecycle to
+    /// compute CSS variables for streaming SSR.  The adapter keeps controlled and
+    /// uncontrolled flows unified by delegating to the shared renderer.
+    pub fn render(props: StackAdapterProps<'_>) -> StackRenderOutput {
+        super::render_stack_with_props(props)
+    }
+}
+
+/// Sycamore adapter mirroring other frameworks.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Whether the [`StackState`] lives in a `Signal` or a plain variable, this
+    /// helper produces the same CSS variables so SSR automation harnesses remain
+    /// consistent across environments.
+    pub fn render(props: StackAdapterProps<'_>) -> StackRenderOutput {
+        super::render_stack_with_props(props)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -105,5 +206,20 @@ mod tests {
             .css_variables()
             .contains_key("--rustic_ui_stack_direction-md"));
         assert!(output.inline_style().contains("--rustic_ui_stack_gap"));
+    }
+
+    #[test]
+    fn adapter_renders_identical_inline_styles() {
+        let tokens = StackTokens {
+            direction: ResponsiveValue::from(rustic_ui_headless::stack::StackDirection::Horizontal),
+            gap: ResponsiveValue::from(String::from("16px")),
+            divider: ResponsiveValue::from(None),
+        };
+        let state = StackState::new(tokens, BreakpointConfig::material());
+
+        let base = render_stack(&state);
+        let adapter = super::render_stack_with_props(StackAdapterProps::new(&state));
+
+        assert_eq!(base.inline_style(), adapter.inline_style());
     }
 }


### PR DESCRIPTION
## Summary
- add adapter prop structs and helper functions so box, container, grid, and stack renderers expose framework-specific adapters mirroring the drawer/tabs pattern
- gate the new adapters behind framework features (including a dedicated `react` flag) and re-export the props for downstream integrations
- expand inline documentation to spell out SSR, hydration, and control strategy guidance for enterprise consumers

## Testing
- cargo fmt
- cargo test -p rustic-ui-material *(fails: existing palette field references in other modules currently break compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e098f314832ea8569c66fc192796