### PR TITLE
Add layout examples build automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,7 @@ jobs:
         run: cargo xtask clippy
       - name: Run workspace tests
         run: cargo xtask test --examples
+      - name: Compile layout demos
+        run: cargo xtask examples --group layout --release
       - name: Build Rust-first docs
         run: cargo xtask build-docs

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -60,6 +60,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # Compile the workspace and wasm examples before collecting coverage
       - run: cargo xtask test --examples
+      # Compile layout demos for native and wasm targets to keep gallery builds green
+      - run: cargo xtask examples --group layout --release
       # Execute tests and generate coverage in one step
       - run: cargo xtask coverage
       # Publish coverage statistics to external service

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -16,7 +16,7 @@
 //! examples, and documentation sites each task touches.
 
 use anyhow::{anyhow, Context, Result};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use rustic_ui_design_tokens::ArtifactBundleBuilder;
 use rustic_ui_system::{
     theme::{ColorScheme, JoyTheme, Theme},
@@ -59,7 +59,7 @@ enum Commands {
     /// Execute the default test suites for all crates.
     ///
     /// Pass `--examples` to also compile every Rust example (`examples/mui-*`,
-    /// `examples/select-menu-*`, etc.) for `wasm32-unknown-unknown`. This keeps
+    /// `examples/joy-yew`, `examples/joy-leptos`, `examples/select-menu-*`, etc.) for `wasm32-unknown-unknown`. This keeps
     /// the example gallery aligned with the published crates without forcing
     /// every contributor to pay the additional compile time unless they
     /// explicitly opt in.
@@ -68,6 +68,12 @@ enum Commands {
         #[arg(long)]
         examples: bool,
     },
+    /// Compile curated Rust example collections for native and WebAssembly targets.
+    #[command(
+        about = "Compile curated Rust example collections for native and WebAssembly targets.",
+        long_about = "Compile curated Rust example collections for native and WebAssembly targets without relying on ad-hoc shell scripts. Each group is centrally defined so new demos can be enrolled in CI by appending a manifest entry instead of wiring fresh workflows.\n\nLayout demos currently validated: examples/layout-box-leptos, examples/layout-grid-yew. Update the `layout_examples` helper when shipping new layouts so CI picks them up automatically."
+    )]
+    Examples(ExamplesArgs),
     /// Run WebAssembly tests via `wasm-pack` for selected crates.
     ///
     /// This exercises the `rustic-ui-material` and `rustic-ui-joy` crates across
@@ -163,6 +169,7 @@ fn main() -> Result<()> {
         Commands::Clippy => clippy(),
         Commands::Deny => deny(),
         Commands::Test { examples } => test(examples),
+        Commands::Examples(args) => examples(args),
         Commands::WasmTest => wasm_test(),
         Commands::Doc => doc(),
         Commands::RefreshIcons => refresh_icons(),
@@ -299,39 +306,27 @@ fn test(include_examples: bool) -> Result<()> {
             example.name
         );
 
-        let mut check = Command::new("cargo");
-        check
-            .arg("check")
-            .arg("--target")
-            .arg("wasm32-unknown-unknown")
-            .arg("--manifest-path")
-            .arg(&example.manifest);
-        run(check).with_context(|| {
-            format!(
-                "wasm cargo check failed for example `{}` at {}",
-                example.name,
-                example.manifest.display()
-            )
-        })?;
+        run_example_command(
+            &example,
+            "check",
+            Some("wasm32-unknown-unknown"),
+            None,
+            &[],
+            "wasm cargo check",
+        )?;
         println!(
             "[xtask][examples] `{}` passed cargo check for wasm32-unknown-unknown",
             example.name
         );
 
-        let mut test = Command::new("cargo");
-        test.arg("test")
-            .arg("--target")
-            .arg("wasm32-unknown-unknown")
-            .arg("--no-run")
-            .arg("--manifest-path")
-            .arg(&example.manifest);
-        run(test).with_context(|| {
-            format!(
-                "wasm cargo test --no-run failed for example `{}` at {}",
-                example.name,
-                example.manifest.display()
-            )
-        })?;
+        run_example_command(
+            &example,
+            "test",
+            Some("wasm32-unknown-unknown"),
+            None,
+            &["--no-run"],
+            "wasm cargo test --no-run",
+        )?;
         println!(
             "[xtask][examples] `{}` passed cargo test --no-run for wasm32-unknown-unknown",
             example.name
@@ -353,6 +348,52 @@ fn test(include_examples: bool) -> Result<()> {
 struct ExampleCrate {
     name: String,
     manifest: PathBuf,
+}
+
+/// CLI options accepted by the `examples` subcommand.
+#[derive(Args, Debug, Clone)]
+struct ExamplesArgs {
+    /// Curated collection of example manifests to compile.
+    #[arg(value_enum, default_value_t = ExampleGroup::Layout)]
+    group: ExampleGroup,
+    /// Build artifacts in release mode for both native and wasm targets.
+    #[arg(long, conflicts_with = "profile")]
+    release: bool,
+    /// Use a named Cargo profile instead of `--release`.
+    #[arg(long)]
+    profile: Option<String>,
+}
+
+/// Supported example collections.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum ExampleGroup {
+    /// Layout demos that validate multi-surface grid and box flows.
+    Layout,
+}
+
+impl ExampleGroup {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ExampleGroup::Layout => "layout",
+        }
+    }
+}
+
+/// Build configuration flags shared across native and wasm invocations.
+#[derive(Debug, Clone, Default)]
+struct BuildOptions {
+    release: bool,
+    profile: Option<String>,
+}
+
+impl BuildOptions {
+    fn apply_to(&self, cmd: &mut Command) {
+        if let Some(profile) = &self.profile {
+            cmd.arg("--profile").arg(profile);
+        } else if self.release {
+            cmd.arg("--release");
+        }
+    }
 }
 
 /// Enumerate Rust example crates that opt into the automation pipeline.
@@ -393,6 +434,145 @@ fn discover_example_crates(examples_root: &Path) -> Result<Vec<ExampleCrate>> {
 
     crates.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(crates)
+}
+
+fn examples(args: ExamplesArgs) -> Result<()> {
+    let workspace = workspace_root();
+    let build_opts = BuildOptions {
+        release: args.release,
+        profile: args.profile.clone(),
+    };
+
+    println!(
+        "[xtask][examples] compiling `{}` group with {} profile",
+        args.group.as_str(),
+        if let Some(profile) = &build_opts.profile {
+            format!("profile `{}`", profile)
+        } else if build_opts.release {
+            "--release".to_string()
+        } else {
+            "default dev".to_string()
+        }
+    );
+
+    let crates = match args.group {
+        ExampleGroup::Layout => layout_examples(&workspace)?,
+    };
+
+    if crates.is_empty() {
+        println!(
+            "[xtask][examples] no example manifests registered for the `{}` group",
+            args.group.as_str()
+        );
+        return Ok(());
+    }
+
+    for example in crates {
+        println!(
+            "[xtask][examples] building `{}` for native host target",
+            example.name
+        );
+        run_example_command(
+            &example,
+            "build",
+            None,
+            Some(&build_opts),
+            &[],
+            "native cargo build",
+        )?;
+        println!(
+            "[xtask][examples] `{}` compiled successfully for the native host",
+            example.name
+        );
+
+        println!(
+            "[xtask][examples] building `{}` for wasm32-unknown-unknown",
+            example.name
+        );
+        run_example_command(
+            &example,
+            "build",
+            Some("wasm32-unknown-unknown"),
+            Some(&build_opts),
+            &[],
+            "wasm cargo build",
+        )?;
+        println!(
+            "[xtask][examples] `{}` compiled successfully for wasm32-unknown-unknown",
+            example.name
+        );
+    }
+
+    println!(
+        "[xtask][examples] completed `{}` compilation set",
+        args.group.as_str()
+    );
+
+    Ok(())
+}
+
+fn layout_examples(workspace: &Path) -> Result<Vec<ExampleCrate>> {
+    // Add new layout demos here to keep CI coverage centralized. Keeping the
+    // manifests in a single list ensures that nightly pipelines only require a
+    // pull request touching this function, rather than bespoke workflow YAML.
+    const LAYOUT_MANIFESTS: &[(&str, &str)] = &[
+        ("layout-box-leptos", "examples/layout-box-leptos/Cargo.toml"),
+        ("layout-grid-yew", "examples/layout-grid-yew/Cargo.toml"),
+    ];
+
+    let mut crates = Vec::with_capacity(LAYOUT_MANIFESTS.len());
+    for (name, manifest) in LAYOUT_MANIFESTS {
+        let manifest_path = workspace.join(manifest);
+        if !manifest_path.exists() {
+            return Err(anyhow!(
+                "layout example `{}` manifest missing at {}",
+                name,
+                manifest_path.display()
+            ));
+        }
+
+        crates.push(ExampleCrate {
+            name: (*name).to_string(),
+            manifest: manifest_path,
+        });
+    }
+
+    Ok(crates)
+}
+
+fn run_example_command(
+    example: &ExampleCrate,
+    cargo_subcommand: &str,
+    target: Option<&str>,
+    build_opts: Option<&BuildOptions>,
+    extra_args: &[&str],
+    context: &str,
+) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg(cargo_subcommand);
+
+    if let Some(target) = target {
+        cmd.arg("--target").arg(target);
+    }
+
+    if let Some(opts) = build_opts {
+        opts.apply_to(&mut cmd);
+    }
+
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+
+    cmd.arg("--manifest-path").arg(&example.manifest);
+
+    run(cmd).with_context(|| {
+        format!(
+            "{} failed for example `{}` at {}",
+            context,
+            example.name,
+            example.manifest.display(),
+        )
+    })
 }
 
 fn wasm_test() -> Result<()> {

--- a/crates/xtask/tests/cli_help.rs
+++ b/crates/xtask/tests/cli_help.rs
@@ -121,6 +121,26 @@ fn icons_bundle_help_mentions_schema_bridge() -> Result<()> {
 }
 
 #[test]
+fn examples_help_highlights_layout_group() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("run")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .arg("examples")
+        .arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("curated Rust example collections"))
+        .stdout(predicate::str::contains("layout-box-leptos"));
+
+    Ok(())
+}
+
+#[test]
 fn accessibility_audit_help_mentions_config_manifest() -> Result<()> {
     let workspace = workspace_root();
     let mut cmd = Command::new("cargo");

--- a/crates/xtask/tests/examples.rs
+++ b/crates/xtask/tests/examples.rs
@@ -1,0 +1,84 @@
+//! Integration coverage for the curated example automation pipeline.
+//!
+//! These tests stub the underlying `cargo` binary so we can validate the
+//! argument flow without compiling the entire workspace during `cargo test`.
+//! The same entry point is exercised in CI without the stub to produce real
+//! native and wasm artifacts.
+
+use anyhow::Result;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("xtask is nested two levels below the workspace root")
+        .to_path_buf()
+}
+
+#[cfg(unix)]
+#[test]
+fn layout_examples_invoke_cargo_for_native_and_wasm() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = workspace_root();
+    let stub_dir = tempdir()?;
+    let log_path = stub_dir.path().join("cargo-invocations.log");
+    let cargo_stub = stub_dir.path().join("cargo");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\n",
+        log_path.display()
+    );
+    fs::write(&cargo_stub, script)?;
+    let mut perms = fs::metadata(&cargo_stub)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&cargo_stub, perms)?;
+
+    let mut cmd = Command::cargo_bin("xtask")?;
+    let path_env = std::env::var("PATH").unwrap_or_default();
+    cmd.current_dir(&workspace).arg("examples").env(
+        "PATH",
+        format!("{}:{}", stub_dir.path().display(), path_env),
+    );
+
+    cmd.assert().success();
+
+    let log = fs::read_to_string(&log_path)?;
+    let lines: Vec<&str> = log.lines().collect();
+    assert_eq!(lines.len(), 4, "expected two targets per layout example");
+
+    // Ensure the first pair targets the Leptos demo without a wasm target flag.
+    assert!(lines[0].contains("layout-box-leptos"));
+    assert!(!lines[0].contains("--target"));
+    assert!(lines[1].contains("layout-box-leptos"));
+    assert!(lines[1].contains("--target wasm32-unknown-unknown"));
+
+    // And the second pair should focus on the Yew layout gallery.
+    assert!(lines[2].contains("layout-grid-yew"));
+    assert!(!lines[2].contains("--target"));
+    assert!(lines[3].contains("layout-grid-yew"));
+    assert!(lines[3].contains("--target wasm32-unknown-unknown"));
+
+    Ok(())
+}
+
+#[test]
+fn examples_conflict_release_and_profile() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::cargo_bin("xtask")?;
+    cmd.current_dir(&workspace)
+        .arg("examples")
+        .arg("--release")
+        .arg("--profile")
+        .arg("ci");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+
+    Ok(())
+}

--- a/docs/migrations/npm-to-rust.md
+++ b/docs/migrations/npm-to-rust.md
@@ -216,6 +216,8 @@ jobs:
           cargo xtask clippy
       - name: Test workspace
         run: cargo xtask test --examples
+      - name: Layout demos
+        run: cargo xtask examples --group layout --release
       - name: Component metadata
         run: cargo xtask update-components
       - name: Bundle icons

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -11,7 +11,9 @@ repeatable and low-friction.
 
    ```bash
    cargo xtask test --examples
+   cargo xtask examples --group layout --release
    ```
+   This ensures the curated layout demos build for both native and WebAssembly targets before publishing.【F:crates/xtask/src/main.rs†L439-L576】
 
 3. Validate the package manifests via dry run:
 

--- a/docs/rust-ci.md
+++ b/docs/rust-ci.md
@@ -45,6 +45,14 @@ cargo xtask test --examples
 
 The command enumerates every `examples/*/Cargo.toml`, runs `cargo check --target wasm32-unknown-unknown`, and executes `cargo test --target wasm32-unknown-unknown --no-run` for deterministic build coverage. Each example logs its own status block and the task exits non-zero if any example fails to compile.
 
+Compile the layout blueprints for both the native host and WebAssembly targets with:
+
+```bash
+cargo xtask examples --group layout --release
+```
+
+The curated command wraps `cargo build` for `examples/layout-box-leptos` and `examples/layout-grid-yew`, applies a consistent profile to native and wasm invocations, and fails fast if a manifest ever drifts or the cross-compile breaks.【F:crates/xtask/src/main.rs†L439-L576】
+
 ### Joy snapshot parity suites
 Joy UI ships SSR renderers for every supported framework. The parity suites compare each adapter to the canonical React output so teams can guarantee hydration-safe markup whenever Joy tokens evolve. Target a single framework or run the whole matrix:
 

--- a/docs/src/pages/examples/index.md
+++ b/docs/src/pages/examples/index.md
@@ -17,9 +17,10 @@ shipping changes.
    to materialise a ready-to-run workspace with SSR snapshots, hydration stubs,
    and analytics markers baked in.【F:examples/navigation-tabs-yew/README.md†L20-L33】【F:examples/feedback-tooltips/README.md†L9-L22】
 3. **Wire automation into CI.** Validate formatting and compile the workspace via
-   `cargo xtask fmt`, `cargo xtask clippy`, and
-   `cargo xtask test --examples` so the new blueprint participates in the shared
-   Wasm targets and parity checks.【F:crates/xtask/src/main.rs†L49-L70】
+   `cargo xtask fmt`, `cargo xtask clippy`, `cargo xtask test --examples`, and
+   `cargo xtask examples --group layout --release` so the new blueprint
+   participates in the shared Wasm targets, native layout builds, and parity
+   checks.【F:crates/xtask/src/main.rs†L59-L70】【F:crates/xtask/src/main.rs†L439-L576】
 4. **Document the flow.** Extend this gallery and the example README with any
    bespoke analytics requirements or parity notes before running
    `cargo xtask build-docs` to refresh the docs site for review.【F:crates/xtask/src/main.rs†L118-L119】


### PR DESCRIPTION
## Summary
- add a `cargo xtask examples` subcommand that compiles the curated layout demos for both the host and `wasm32-unknown-unknown` targets while sharing helper plumbing with the existing example validation flow
- expand xtask coverage with assert_cmd-based integration tests, refreshed CLI help assertions, and documentation updates so contributors know how to extend and invoke the new automation
- update the CI workflows to call the layout compilation step alongside the existing workspace test matrix

## Testing
- cargo test -p xtask

------
https://chatgpt.com/codex/tasks/task_e_68d9f9fce23c832e9eed1bd5ed7f7ad0