### PR TITLE
Add hidden, image list, and divider material renderers

### DIFF
--- a/crates/rustic-ui-material/src/divider.rs
+++ b/crates/rustic-ui-material/src/divider.rs
@@ -1,0 +1,220 @@
+//! Renderer for [`DividerState`](rustic_ui_headless::divider::DividerState).
+//!
+//! Dividers expose orientation, thickness and inset tokens.  Rendering the
+//! responsive evaluation into CSS variables ensures consistency across server
+//! and client adapters without duplicating formatting logic.
+
+use std::collections::BTreeMap;
+
+use rustic_ui_headless::divider::{DividerEvaluation, DividerState};
+
+use crate::render_helpers::{
+    collect_responsive_variables, css_variables_to_style, normalise_css_token,
+    normalise_spacing_token, CssVariableMap,
+};
+
+/// Output returned by [`render_divider`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DividerRenderOutput {
+    css_variables: CssVariableMap,
+    inline_style: String,
+}
+
+impl DividerRenderOutput {
+    /// Exposes the generated CSS variables in insertion order.
+    #[inline]
+    pub fn css_variables(&self) -> &BTreeMap<String, String> {
+        &self.css_variables
+    }
+
+    /// Inline style string derived from the CSS variable map.
+    #[inline]
+    pub fn inline_style(&self) -> &str {
+        &self.inline_style
+    }
+}
+
+/// Render the responsive [`DividerState`] into CSS variables and inline styles.
+#[must_use]
+pub fn render_divider(state: &DividerState) -> DividerRenderOutput {
+    let mut css_variables = CssVariableMap::new();
+
+    collect_responsive_variables(
+        &mut css_variables,
+        "divider",
+        state.breakpoints(),
+        |breakpoint| {
+            let evaluation = state.evaluate_for(breakpoint);
+            divider_tokens_for_breakpoint(&evaluation)
+        },
+    );
+
+    let inline_style = css_variables_to_style(&css_variables);
+
+    DividerRenderOutput {
+        css_variables,
+        inline_style,
+    }
+}
+
+fn divider_tokens_for_breakpoint(
+    evaluation: &DividerEvaluation<'_>,
+) -> Vec<(&'static str, String)> {
+    let mut tokens = Vec::with_capacity(5);
+
+    tokens.push(("orientation", evaluation.orientation.as_str().to_string()));
+    tokens.push((
+        "thickness",
+        normalise_css_token(evaluation.thickness.as_str(), "1px"),
+    ));
+    tokens.push(("inset", normalise_spacing_token(evaluation.inset.as_str())));
+    tokens.push(("role", evaluation.role.as_str().to_string()));
+
+    if matches!(
+        evaluation.breakpoint,
+        rustic_ui_headless::layout::Breakpoint::Base
+    ) {
+        tokens.push((
+            "active_breakpoint",
+            evaluation.breakpoint.as_token().to_string(),
+        ));
+    }
+
+    tokens
+}
+
+/// Adapter props shared by all frameworks.
+#[derive(Clone, Copy, Debug)]
+pub struct DividerAdapterProps<'a> {
+    /// Headless divider state describing orientation/thickness/inset.
+    pub state: &'a DividerState,
+}
+
+impl<'a> DividerAdapterProps<'a> {
+    /// Helper constructor so integration code can express intent succinctly.
+    #[inline]
+    pub fn new(state: &'a DividerState) -> Self {
+        Self { state }
+    }
+}
+
+#[cfg_attr(
+    not(any(
+        feature = "react",
+        feature = "yew",
+        feature = "leptos",
+        feature = "dioxus",
+        feature = "sycamore"
+    )),
+    allow(dead_code)
+)]
+fn render_divider_with_props(props: DividerAdapterProps<'_>) -> DividerRenderOutput {
+    render_divider(props.state)
+}
+
+/// React adapter delegating to the shared renderer.
+#[cfg(feature = "react")]
+pub mod react {
+    use super::*;
+
+    /// Run the renderer during React SSR or client renders for deterministic CSS variables.
+    pub fn render(props: DividerAdapterProps<'_>) -> DividerRenderOutput {
+        super::render_divider_with_props(props)
+    }
+}
+
+/// Yew adapter bridging to [`render_divider`].
+#[cfg(feature = "yew")]
+pub mod yew {
+    use super::*;
+
+    /// Produce CSS variables for Yew components without replicating orientation
+    /// math in user land code.
+    pub fn render(props: DividerAdapterProps<'_>) -> DividerRenderOutput {
+        super::render_divider_with_props(props)
+    }
+}
+
+/// Leptos adapter forwarding to the canonical renderer.
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Feed the [`DividerState`] into the renderer from reactive signals.
+    pub fn render(props: DividerAdapterProps<'_>) -> DividerRenderOutput {
+        super::render_divider_with_props(props)
+    }
+}
+
+/// Dioxus adapter.
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Invoke during Dioxus renders to retrieve deterministic CSS variables.
+    pub fn render(props: DividerAdapterProps<'_>) -> DividerRenderOutput {
+        super::render_divider_with_props(props)
+    }
+}
+
+/// Sycamore adapter mirroring the others.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Sycamore orchestrations can simply pass the state through this helper to
+    /// obtain SSR ready CSS variables.
+    pub fn render(props: DividerAdapterProps<'_>) -> DividerRenderOutput {
+        super::render_divider_with_props(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::divider::{DividerState, DividerTokens};
+    use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+
+    #[test]
+    fn divider_renderer_emits_orientation_and_thickness() {
+        let tokens = DividerTokens {
+            orientation: ResponsiveValue::new(
+                rustic_ui_headless::divider::DividerOrientation::Horizontal,
+            )
+            .with_override(
+                Breakpoint::Lg,
+                rustic_ui_headless::divider::DividerOrientation::Vertical,
+            ),
+            thickness: ResponsiveValue::from(String::from("2px")),
+            inset: ResponsiveValue::from(String::from("8px")),
+        };
+        let state = DividerState::new(tokens, BreakpointConfig::material());
+
+        let output = render_divider(&state);
+
+        assert_eq!(
+            output
+                .css_variables()
+                .get("--rustic_ui_divider_orientation")
+                .map(String::as_str),
+            Some("horizontal"),
+        );
+        assert!(output
+            .css_variables()
+            .contains_key("--rustic_ui_divider_orientation-lg"));
+        assert!(output
+            .inline_style()
+            .contains("--rustic_ui_divider_thickness"));
+    }
+
+    #[test]
+    fn adapter_delegates_to_renderer() {
+        let tokens = DividerTokens::horizontal("1px");
+        let state = DividerState::new(tokens, BreakpointConfig::material());
+
+        let base = render_divider(&state);
+        let adapter = super::render_divider_with_props(DividerAdapterProps::new(&state));
+
+        assert_eq!(base.inline_style(), adapter.inline_style());
+    }
+}

--- a/crates/rustic-ui-material/src/hidden.rs
+++ b/crates/rustic-ui-material/src/hidden.rs
@@ -1,0 +1,224 @@
+//! Renderer for the responsive [`HiddenState`](rustic_ui_headless::hidden::HiddenState).
+//!
+//! Enterprise applications often hide layouts responsively while still exposing
+//! them to assistive technologies.  Centralising the translation from the
+//! headless `HiddenState` into deterministic CSS variables ensures every
+//! framework adapter (React, Yew, Leptos, etc.) preserves the exact same SSR
+//! footprint which keeps hydration and automated screenshot pipelines aligned.
+
+use std::collections::BTreeMap;
+
+use rustic_ui_headless::hidden::{HiddenEvaluation, HiddenState};
+
+use crate::render_helpers::{
+    bool_to_css_flag, collect_responsive_variables, css_variables_to_style, visibility_to_display,
+    visibility_to_visibility, CssVariableMap,
+};
+
+/// Output returned by [`render_hidden`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HiddenRenderOutput {
+    css_variables: CssVariableMap,
+    inline_style: String,
+}
+
+impl HiddenRenderOutput {
+    /// Access the generated CSS variable map so adapters can forward it to
+    /// CSS-in-Rust abstractions or attribute builders.
+    #[inline]
+    pub fn css_variables(&self) -> &BTreeMap<String, String> {
+        &self.css_variables
+    }
+
+    /// Serialised inline style string suitable for SSR attribute injection.
+    #[inline]
+    pub fn inline_style(&self) -> &str {
+        &self.inline_style
+    }
+}
+
+/// Render the provided [`HiddenState`] into deterministic CSS variables and an
+/// inline style string.  The renderer walks every breakpoint configured on the
+/// state machine and stores visibility, ARIA and inert flags under the
+/// `--rustic_ui_hidden_*` namespace.
+#[must_use]
+pub fn render_hidden(state: &HiddenState) -> HiddenRenderOutput {
+    let mut css_variables = CssVariableMap::new();
+
+    collect_responsive_variables(
+        &mut css_variables,
+        "hidden",
+        state.breakpoints(),
+        |breakpoint| {
+            let evaluation = state.evaluate_for(breakpoint);
+            hidden_tokens_for_breakpoint(&evaluation)
+        },
+    );
+
+    let inline_style = css_variables_to_style(&css_variables);
+
+    HiddenRenderOutput {
+        css_variables,
+        inline_style,
+    }
+}
+
+fn hidden_tokens_for_breakpoint(evaluation: &HiddenEvaluation) -> Vec<(&'static str, String)> {
+    let mut tokens = Vec::with_capacity(6);
+
+    tokens.push(("display", visibility_to_display(evaluation.hidden)));
+    tokens.push(("visibility", visibility_to_visibility(evaluation.hidden)));
+    tokens.push(("aria_hidden", bool_to_css_flag(evaluation.hidden)));
+    tokens.push(("role", evaluation.role.as_str().to_string()));
+    tokens.push(("inert", bool_to_css_flag(evaluation.inert)));
+
+    if matches!(
+        evaluation.breakpoint,
+        rustic_ui_headless::layout::Breakpoint::Base
+    ) {
+        tokens.push((
+            "active_breakpoint",
+            evaluation.breakpoint.as_token().to_string(),
+        ));
+    }
+
+    tokens
+}
+
+/// Adapter props shared across framework specific shims.
+#[derive(Clone, Copy, Debug)]
+pub struct HiddenAdapterProps<'a> {
+    /// Headless hidden state driving responsive visibility.
+    pub state: &'a HiddenState,
+}
+
+impl<'a> HiddenAdapterProps<'a> {
+    /// Convenience constructor so integrations can write `HiddenAdapterProps::new(&state)`.
+    #[inline]
+    pub fn new(state: &'a HiddenState) -> Self {
+        Self { state }
+    }
+}
+
+/// Internal helper leveraged by the framework adapters.  The indirection keeps
+/// the adapter shims tiny while ensuring every runtime delegates to the shared
+/// renderer.
+#[cfg_attr(
+    not(any(
+        feature = "react",
+        feature = "yew",
+        feature = "leptos",
+        feature = "dioxus",
+        feature = "sycamore"
+    )),
+    allow(dead_code)
+)]
+fn render_hidden_with_props(props: HiddenAdapterProps<'_>) -> HiddenRenderOutput {
+    render_hidden(props.state)
+}
+
+/// React adapter invoking [`render_hidden`].
+#[cfg(feature = "react")]
+pub mod react {
+    use super::*;
+
+    /// Execute the canonical renderer during React's render lifecycle so SSR and
+    /// hydration both observe identical inline style payloads.
+    pub fn render(props: HiddenAdapterProps<'_>) -> HiddenRenderOutput {
+        super::render_hidden_with_props(props)
+    }
+}
+
+/// Yew adapter exposing the same renderer behind the `yew` feature flag.
+#[cfg(feature = "yew")]
+pub mod yew {
+    use super::*;
+
+    /// Produce CSS variables for Yew based applications.  Controlled and
+    /// uncontrolled flows both delegate to the shared renderer which keeps
+    /// automation hooks consistent across runtimes.
+    pub fn render(props: HiddenAdapterProps<'_>) -> HiddenRenderOutput {
+        super::render_hidden_with_props(props)
+    }
+}
+
+/// Leptos adapter bridging signal driven updates to the canonical renderer.
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Feed the [`HiddenState`] from Leptos signals into the shared renderer so
+    /// SSR streams and client hydration stay perfectly aligned.
+    pub fn render(props: HiddenAdapterProps<'_>) -> HiddenRenderOutput {
+        super::render_hidden_with_props(props)
+    }
+}
+
+/// Dioxus adapter forwarding to [`render_hidden`].
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Dioxus orchestrators call this helper to obtain deterministic CSS
+    /// variables before streaming markup or mounting on the client.
+    pub fn render(props: HiddenAdapterProps<'_>) -> HiddenRenderOutput {
+        super::render_hidden_with_props(props)
+    }
+}
+
+/// Sycamore adapter mirroring the other framework integrations.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Whether the [`HiddenState`] lives inside a Sycamore signal or plain Rust
+    /// struct, this helper returns the canonical CSS variables for SSR.
+    pub fn render(props: HiddenAdapterProps<'_>) -> HiddenRenderOutput {
+        super::render_hidden_with_props(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::hidden::{HiddenRole, HiddenState};
+    use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+
+    #[test]
+    fn hidden_renderer_serialises_visibility_flags() {
+        let state = HiddenState::new(
+            ResponsiveValue::new(false)
+                .with_override(Breakpoint::Md, true)
+                .with_override(Breakpoint::Xl, false),
+            BreakpointConfig::material(),
+        )
+        .with_role(HiddenRole::Group)
+        .inert(true);
+
+        let output = render_hidden(&state);
+
+        assert_eq!(
+            output
+                .css_variables()
+                .get("--rustic_ui_hidden_visibility")
+                .map(String::as_str),
+            Some("visible"),
+        );
+        assert!(output
+            .css_variables()
+            .contains_key("--rustic_ui_hidden_visibility-md"));
+        assert!(output
+            .inline_style()
+            .contains("--rustic_ui_hidden_aria_hidden"));
+    }
+
+    #[test]
+    fn adapter_delegates_to_shared_renderer() {
+        let state = HiddenState::new(ResponsiveValue::new(true), BreakpointConfig::material());
+
+        let base = render_hidden(&state);
+        let adapter = super::render_hidden_with_props(HiddenAdapterProps::new(&state));
+
+        assert_eq!(base.inline_style(), adapter.inline_style());
+    }
+}

--- a/crates/rustic-ui-material/src/image_list.rs
+++ b/crates/rustic-ui-material/src/image_list.rs
@@ -1,0 +1,218 @@
+//! Renderer for [`ImageListState`](rustic_ui_headless::image_list::ImageListState).
+//!
+//! Image lists combine responsive column counts, spacing and row height tokens.
+//! Centralising the renderer keeps CSS variable naming stable across adapters
+//! which is critical when enterprises diff SSR output across frameworks.
+
+use std::collections::BTreeMap;
+
+use rustic_ui_headless::image_list::{ImageListEvaluation, ImageListState};
+
+use crate::render_helpers::{
+    collect_responsive_variables, css_variables_to_style, grid_template, normalise_spacing_token,
+    CssVariableMap,
+};
+
+/// Result returned by [`render_image_list`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageListRenderOutput {
+    css_variables: CssVariableMap,
+    inline_style: String,
+}
+
+impl ImageListRenderOutput {
+    /// Ordered CSS variables keyed by `--rustic_ui_image_list_*`.
+    #[inline]
+    pub fn css_variables(&self) -> &BTreeMap<String, String> {
+        &self.css_variables
+    }
+
+    /// Inline `style` string derived from [`css_variables`].
+    #[inline]
+    pub fn inline_style(&self) -> &str {
+        &self.inline_style
+    }
+}
+
+/// Render the provided [`ImageListState`] into CSS variables that work across
+/// SSR and CSR pipelines.
+#[must_use]
+pub fn render_image_list(state: &ImageListState) -> ImageListRenderOutput {
+    let mut css_variables = CssVariableMap::new();
+
+    collect_responsive_variables(
+        &mut css_variables,
+        "image_list",
+        state.breakpoints(),
+        |breakpoint| {
+            let evaluation = state.evaluate_for(breakpoint);
+            image_list_tokens_for_breakpoint(&evaluation)
+        },
+    );
+
+    let inline_style = css_variables_to_style(&css_variables);
+
+    ImageListRenderOutput {
+        css_variables,
+        inline_style,
+    }
+}
+
+fn image_list_tokens_for_breakpoint(
+    evaluation: &ImageListEvaluation<'_>,
+) -> Vec<(&'static str, String)> {
+    let mut tokens = Vec::with_capacity(6);
+
+    tokens.push(("columns", evaluation.columns.to_string()));
+    tokens.push(("template", grid_template(evaluation.columns)));
+    tokens.push(("gap", normalise_spacing_token(evaluation.gap.as_str())));
+    tokens.push(("row_height", format!("{}px", evaluation.row_height)));
+    tokens.push(("role", evaluation.role.as_str().to_string()));
+    tokens.push(("variant", evaluation.variant.as_str().to_string()));
+
+    if matches!(
+        evaluation.breakpoint,
+        rustic_ui_headless::layout::Breakpoint::Base
+    ) {
+        tokens.push((
+            "active_breakpoint",
+            evaluation.breakpoint.as_token().to_string(),
+        ));
+    }
+
+    tokens
+}
+
+/// Adapter props shared across framework integrations.
+#[derive(Clone, Copy, Debug)]
+pub struct ImageListAdapterProps<'a> {
+    /// Headless image list state controlling responsive layout metadata.
+    pub state: &'a ImageListState,
+}
+
+impl<'a> ImageListAdapterProps<'a> {
+    /// Convenience constructor for integration code.
+    #[inline]
+    pub fn new(state: &'a ImageListState) -> Self {
+        Self { state }
+    }
+}
+
+#[cfg_attr(
+    not(any(
+        feature = "react",
+        feature = "yew",
+        feature = "leptos",
+        feature = "dioxus",
+        feature = "sycamore"
+    )),
+    allow(dead_code)
+)]
+fn render_image_list_with_props(props: ImageListAdapterProps<'_>) -> ImageListRenderOutput {
+    render_image_list(props.state)
+}
+
+/// React adapter invoking the shared renderer.
+#[cfg(feature = "react")]
+pub mod react {
+    use super::*;
+
+    /// Execute the canonical renderer during React SSR so hydration sees the
+    /// same CSS variable payload.
+    pub fn render(props: ImageListAdapterProps<'_>) -> ImageListRenderOutput {
+        super::render_image_list_with_props(props)
+    }
+}
+
+/// Yew adapter forwarding to [`render_image_list`].
+#[cfg(feature = "yew")]
+pub mod yew {
+    use super::*;
+
+    /// Generate CSS variables from within Yew components without duplicating
+    /// layout logic.
+    pub fn render(props: ImageListAdapterProps<'_>) -> ImageListRenderOutput {
+        super::render_image_list_with_props(props)
+    }
+}
+
+/// Leptos adapter bridging signals to the renderer.
+#[cfg(feature = "leptos")]
+pub mod leptos {
+    use super::*;
+
+    /// Feed the [`ImageListState`] stored in signals through the shared
+    /// renderer.  SSR snapshots and client recomputation will remain identical.
+    pub fn render(props: ImageListAdapterProps<'_>) -> ImageListRenderOutput {
+        super::render_image_list_with_props(props)
+    }
+}
+
+/// Dioxus adapter mirroring other frameworks.
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Invoke the shared renderer inside Dioxus' lifecycle to obtain
+    /// deterministic CSS variables for streaming or hydration.
+    pub fn render(props: ImageListAdapterProps<'_>) -> ImageListRenderOutput {
+        super::render_image_list_with_props(props)
+    }
+}
+
+/// Sycamore adapter hooking into the canonical renderer.
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Sycamore orchestrations simply borrow the headless state and delegate to
+    /// the renderer, keeping SSR deterministic across ecosystems.
+    pub fn render(props: ImageListAdapterProps<'_>) -> ImageListRenderOutput {
+        super::render_image_list_with_props(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::image_list::{ImageListState, ImageListTokens, ImageListVariant};
+    use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+
+    #[test]
+    fn image_list_renderer_emits_columns_and_gap() {
+        let tokens = ImageListTokens {
+            columns: ResponsiveValue::new(2).with_override(Breakpoint::Lg, 6),
+            gap: ResponsiveValue::from(String::from("24px")),
+            row_height: ResponsiveValue::from(320),
+        };
+        let state = ImageListState::new(tokens, BreakpointConfig::material())
+            .variant(ImageListVariant::Masonry);
+
+        let output = render_image_list(&state);
+
+        assert_eq!(
+            output
+                .css_variables()
+                .get("--rustic_ui_image_list_columns")
+                .map(String::as_str),
+            Some("2"),
+        );
+        assert!(output
+            .css_variables()
+            .contains_key("--rustic_ui_image_list_template-lg"));
+        assert!(output
+            .inline_style()
+            .contains("--rustic_ui_image_list_row_height"));
+    }
+
+    #[test]
+    fn adapter_delegates_to_renderer() {
+        let tokens = ImageListTokens::uniform(ResponsiveValue::new(3), "8px", 240);
+        let state = ImageListState::new(tokens, BreakpointConfig::material());
+
+        let base = render_image_list(&state);
+        let adapter = super::render_image_list_with_props(ImageListAdapterProps::new(&state));
+
+        assert_eq!(base.inline_style(), adapter.inline_style());
+    }
+}

--- a/crates/rustic-ui-material/src/lib.rs
+++ b/crates/rustic-ui-material/src/lib.rs
@@ -30,8 +30,11 @@ pub mod checkbox;
 pub mod chip;
 pub mod container;
 pub mod dialog;
+pub mod divider;
 pub mod drawer;
 pub mod grid;
+pub mod hidden;
+pub mod image_list;
 pub mod list;
 pub mod macros;
 pub mod menu;
@@ -54,7 +57,10 @@ pub use rustic_ui_styled_engine::Theme;
 
 pub use crate::r#box::{render_box, BoxAdapterProps, BoxRenderOutput};
 pub use container::{render_container, ContainerAdapterProps, ContainerRenderOutput};
+pub use divider::{render_divider, DividerAdapterProps, DividerRenderOutput};
 pub use grid::{render_grid, GridAdapterProps, GridRenderOutput};
+pub use hidden::{render_hidden, HiddenAdapterProps, HiddenRenderOutput};
+pub use image_list::{render_image_list, ImageListAdapterProps, ImageListRenderOutput};
 pub use stack::{render_stack, StackAdapterProps, StackRenderOutput};
 
 /// Confirms that the crate links to `rustic_ui_styled_engine` and compiles.

--- a/crates/rustic-ui-material/src/render_helpers.rs
+++ b/crates/rustic-ui-material/src/render_helpers.rs
@@ -139,6 +139,46 @@ pub(crate) fn normalise_css_token(token: &str, fallback: &str) -> String {
     }
 }
 
+/// Convert a boolean into the canonical CSS custom property string value.
+///
+/// Multiple layout renderers expose boolean state (e.g. the Hidden primitive's
+/// `aria-hidden` toggle).  Encoding this logic in one helper keeps every
+/// renderer serialising booleans with the exact same casing which simplifies
+/// snapshot assertions and cross-language parity checks.
+#[must_use]
+pub(crate) fn bool_to_css_flag(value: bool) -> String {
+    if value {
+        String::from("true")
+    } else {
+        String::from("false")
+    }
+}
+
+/// Translate a boolean visibility flag into a display token appropriate for CSS.
+///
+/// Material components frequently model visibility as `true/false` yet need to
+/// emit explicit CSS strings for SSR.  Using `revert-layer` lets author defined
+/// display styles bubble back in when the element is visible while still
+/// allowing server rendered snapshots to capture the intent precisely.
+#[must_use]
+pub(crate) fn visibility_to_display(hidden: bool) -> String {
+    if hidden {
+        String::from("none")
+    } else {
+        String::from("revert-layer")
+    }
+}
+
+/// Convert the same visibility flag into the CSS `visibility` property value.
+#[must_use]
+pub(crate) fn visibility_to_visibility(hidden: bool) -> String {
+    if hidden {
+        String::from("hidden")
+    } else {
+        String::from("visible")
+    }
+}
+
 /// Convert a [`CssVariableMap`] into a SSR friendly inline style string.
 #[must_use]
 pub(crate) fn css_variables_to_style(map: &CssVariableMap) -> String {

--- a/crates/rustic-ui-material/src/tooltip.rs
+++ b/crates/rustic-ui-material/src/tooltip.rs
@@ -496,13 +496,10 @@ mod tests {
     fn trigger_attributes_include_expanded_state() {
         let props = TooltipProps::new("Help", "Tooltip");
         let state = TooltipState::new(TooltipConfig::default());
-        let attrs = super::trigger_attributes(
-            &props,
-            &state,
-            &tooltip_portal("rustic_ui_tooltip"),
-            &trigger_id("rustic_ui_tooltip"),
-            &surface_id("rustic_ui_tooltip"),
-        );
+        let portal = tooltip_portal(&props);
+        let trigger = trigger_id(&props);
+        let surface = surface_id(&props);
+        let attrs = super::trigger_attributes(&props, &state, &portal, &trigger, &surface);
 
         assert!(attrs.iter().any(|(k, _)| k == "aria-expanded"));
         assert!(attrs.iter().any(|(k, _)| k == "aria-describedby"));

--- a/crates/rustic-ui-material/tests/layout_renderers.rs
+++ b/crates/rustic-ui-material/tests/layout_renderers.rs
@@ -220,3 +220,176 @@ fn material_stack_renderer_snapshot() {
 
     assert_json_snapshot!("material_stack_renderer", snapshot);
 }
+
+#[test]
+fn material_hidden_renderer_snapshot() {
+    use rustic_ui_headless::hidden::{HiddenRole, HiddenState};
+
+    let visibility = ResponsiveValue::new(false)
+        .with_override(Breakpoint::Sm, true)
+        .with_override(Breakpoint::Lg, false);
+    let state = HiddenState::new(visibility, BreakpointConfig::material())
+        .with_role(HiddenRole::Group)
+        .inert(true);
+    let render = rustic_ui_material::render_hidden(&state);
+    let attrs = state
+        .attributes()
+        .id("hidden-region")
+        .class("rustic-hidden");
+
+    let mut attr_pairs = Vec::new();
+    if let Some((key, value)) = attrs.id_attr() {
+        attr_pairs.push((key, value.to_string()));
+    }
+    if let Some((key, value)) = attrs.class_attr() {
+        attr_pairs.push((key, value.to_string()));
+    }
+    if let Some((key, value)) = attrs.inert() {
+        attr_pairs.push((key, value.to_string()));
+    }
+    attr_pairs.push((attrs.role().0, attrs.role().1.to_string()));
+    let hidden_attr = attrs.hidden(360);
+    attr_pairs.push((hidden_attr.0, hidden_attr.1.to_string()));
+
+    let html = format!(
+        "<div {attrs} style=\"{style}\"></div>",
+        attrs = attr_pairs
+            .into_iter()
+            .map(|(key, value)| format!("{key}=\"{value}\""))
+            .collect::<Vec<_>>()
+            .join(" "),
+        style = render.inline_style()
+    );
+
+    let snapshot = json!({
+        "html": html,
+        "css_variables": to_value(render.css_variables()).expect("css variables serializable"),
+        "inline_style": render.inline_style(),
+        "visibility": {
+            "viewport_360": attrs.hidden(360).1,
+            "viewport_1280": attrs.hidden(1280).1,
+        },
+    });
+
+    assert_json_snapshot!("material_hidden_renderer", snapshot);
+}
+
+#[test]
+fn material_image_list_renderer_snapshot() {
+    use rustic_ui_headless::image_list::{
+        ImageListRole, ImageListState, ImageListTokens, ImageListVariant,
+    };
+
+    let tokens = ImageListTokens {
+        columns: ResponsiveValue::new(3)
+            .with_override(Breakpoint::Sm, 4)
+            .with_override(Breakpoint::Lg, 6),
+        gap: ResponsiveValue::new(String::from("12px"))
+            .with_override(Breakpoint::Md, String::from("20px")),
+        row_height: ResponsiveValue::new(200).with_override(Breakpoint::Xl, 320),
+    };
+
+    let state = ImageListState::new(tokens, BreakpointConfig::material())
+        .variant(ImageListVariant::Masonry)
+        .with_role(ImageListRole::Presentation);
+    let render = rustic_ui_material::render_image_list(&state);
+    let attrs = state
+        .attributes()
+        .id("image-collection")
+        .class("rustic-image-list");
+
+    let mut attr_pairs = Vec::new();
+    if let Some((key, value)) = attrs.id_attr() {
+        attr_pairs.push((key, value.to_string()));
+    }
+    if let Some((key, value)) = attrs.class_attr() {
+        attr_pairs.push((key, value.to_string()));
+    }
+    attr_pairs.push((attrs.role().0, attrs.role().1.to_string()));
+    attr_pairs.push((attrs.data_variant().0, attrs.data_variant().1.to_string()));
+    let breakpoint_attr = attrs.data_breakpoint(1024);
+    attr_pairs.push((breakpoint_attr.0, breakpoint_attr.1.to_string()));
+
+    let html = format!(
+        "<ul {attrs} style=\"{style}\"></ul>",
+        attrs = attr_pairs
+            .into_iter()
+            .map(|(key, value)| format!("{key}=\"{value}\""))
+            .collect::<Vec<_>>()
+            .join(" "),
+        style = render.inline_style()
+    );
+
+    let snapshot = json!({
+        "html": html,
+        "css_variables": to_value(render.css_variables()).expect("css variables serializable"),
+        "inline_style": render.inline_style(),
+        "breakpoints": {
+            "viewport_768": attrs.data_breakpoint(768).1,
+            "viewport_1600": attrs.data_breakpoint(1600).1,
+        },
+        "variant": attrs.data_variant().1,
+    });
+
+    assert_json_snapshot!("material_image_list_renderer", snapshot);
+}
+
+#[test]
+fn material_divider_renderer_snapshot() {
+    use rustic_ui_headless::divider::{DividerRole, DividerState, DividerTokens};
+
+    let tokens = DividerTokens {
+        orientation: ResponsiveValue::new(
+            rustic_ui_headless::divider::DividerOrientation::Horizontal,
+        )
+        .with_override(
+            Breakpoint::Md,
+            rustic_ui_headless::divider::DividerOrientation::Vertical,
+        ),
+        thickness: ResponsiveValue::new(String::from("1px"))
+            .with_override(Breakpoint::Lg, String::from("3px")),
+        inset: ResponsiveValue::new(String::from("0"))
+            .with_override(Breakpoint::Xl, String::from("24px")),
+    };
+
+    let state = DividerState::new(tokens, BreakpointConfig::material())
+        .with_role(DividerRole::Presentation);
+    let render = rustic_ui_material::render_divider(&state);
+    let attrs = state
+        .attributes()
+        .id("divider-shell")
+        .class("rustic-divider");
+
+    let mut attr_pairs = Vec::new();
+    if let Some((key, value)) = attrs.id_attr() {
+        attr_pairs.push((key, value.to_string()));
+    }
+    if let Some((key, value)) = attrs.class_attr() {
+        attr_pairs.push((key, value.to_string()));
+    }
+    attr_pairs.push((attrs.role().0, attrs.role().1.to_string()));
+    let orientation_attr = attrs.data_orientation(480);
+    attr_pairs.push((orientation_attr.0, orientation_attr.1.to_string()));
+
+    let html = format!(
+        "<div {attrs} style=\"{style}\"></div>",
+        attrs = attr_pairs
+            .into_iter()
+            .map(|(key, value)| format!("{key}=\"{value}\""))
+            .collect::<Vec<_>>()
+            .join(" "),
+        style = render.inline_style()
+    );
+
+    let snapshot = json!({
+        "html": html,
+        "css_variables": to_value(render.css_variables()).expect("css variables serializable"),
+        "inline_style": render.inline_style(),
+        "orientation": {
+            "viewport_480": attrs.data_orientation(480).1,
+            "viewport_1440": attrs.data_orientation(1440).1,
+        },
+    });
+
+    assert_json_snapshot!("material_divider_renderer", snapshot);
+}

--- a/crates/rustic-ui-material/tests/snapshots/layout_renderers__material_divider_renderer.snap
+++ b/crates/rustic-ui-material/tests/snapshots/layout_renderers__material_divider_renderer.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rustic-ui-material/tests/layout_renderers.rs
+assertion_line: 394
+expression: snapshot
+---
+{
+  "css_variables": {
+    "--rustic_ui_divider_active_breakpoint": "base",
+    "--rustic_ui_divider_inset": "0",
+    "--rustic_ui_divider_inset-lg": "0",
+    "--rustic_ui_divider_inset-md": "0",
+    "--rustic_ui_divider_inset-sm": "0",
+    "--rustic_ui_divider_inset-xl": "24px",
+    "--rustic_ui_divider_inset-xxl": "24px",
+    "--rustic_ui_divider_orientation": "horizontal",
+    "--rustic_ui_divider_orientation-lg": "vertical",
+    "--rustic_ui_divider_orientation-md": "vertical",
+    "--rustic_ui_divider_orientation-sm": "horizontal",
+    "--rustic_ui_divider_orientation-xl": "vertical",
+    "--rustic_ui_divider_orientation-xxl": "vertical",
+    "--rustic_ui_divider_role": "presentation",
+    "--rustic_ui_divider_role-lg": "presentation",
+    "--rustic_ui_divider_role-md": "presentation",
+    "--rustic_ui_divider_role-sm": "presentation",
+    "--rustic_ui_divider_role-xl": "presentation",
+    "--rustic_ui_divider_role-xxl": "presentation",
+    "--rustic_ui_divider_thickness": "1px",
+    "--rustic_ui_divider_thickness-lg": "3px",
+    "--rustic_ui_divider_thickness-md": "1px",
+    "--rustic_ui_divider_thickness-sm": "1px",
+    "--rustic_ui_divider_thickness-xl": "3px",
+    "--rustic_ui_divider_thickness-xxl": "3px"
+  },
+  "html": "<div id=\"divider-shell\" class=\"rustic-divider\" role=\"presentation\" data-orientation=\"horizontal\" style=\"--rustic_ui_divider_active_breakpoint: base; --rustic_ui_divider_inset: 0; --rustic_ui_divider_inset-lg: 0; --rustic_ui_divider_inset-md: 0; --rustic_ui_divider_inset-sm: 0; --rustic_ui_divider_inset-xl: 24px; --rustic_ui_divider_inset-xxl: 24px; --rustic_ui_divider_orientation: horizontal; --rustic_ui_divider_orientation-lg: vertical; --rustic_ui_divider_orientation-md: vertical; --rustic_ui_divider_orientation-sm: horizontal; --rustic_ui_divider_orientation-xl: vertical; --rustic_ui_divider_orientation-xxl: vertical; --rustic_ui_divider_role: presentation; --rustic_ui_divider_role-lg: presentation; --rustic_ui_divider_role-md: presentation; --rustic_ui_divider_role-sm: presentation; --rustic_ui_divider_role-xl: presentation; --rustic_ui_divider_role-xxl: presentation; --rustic_ui_divider_thickness: 1px; --rustic_ui_divider_thickness-lg: 3px; --rustic_ui_divider_thickness-md: 1px; --rustic_ui_divider_thickness-sm: 1px; --rustic_ui_divider_thickness-xl: 3px; --rustic_ui_divider_thickness-xxl: 3px;\"></div>",
+  "inline_style": "--rustic_ui_divider_active_breakpoint: base; --rustic_ui_divider_inset: 0; --rustic_ui_divider_inset-lg: 0; --rustic_ui_divider_inset-md: 0; --rustic_ui_divider_inset-sm: 0; --rustic_ui_divider_inset-xl: 24px; --rustic_ui_divider_inset-xxl: 24px; --rustic_ui_divider_orientation: horizontal; --rustic_ui_divider_orientation-lg: vertical; --rustic_ui_divider_orientation-md: vertical; --rustic_ui_divider_orientation-sm: horizontal; --rustic_ui_divider_orientation-xl: vertical; --rustic_ui_divider_orientation-xxl: vertical; --rustic_ui_divider_role: presentation; --rustic_ui_divider_role-lg: presentation; --rustic_ui_divider_role-md: presentation; --rustic_ui_divider_role-sm: presentation; --rustic_ui_divider_role-xl: presentation; --rustic_ui_divider_role-xxl: presentation; --rustic_ui_divider_thickness: 1px; --rustic_ui_divider_thickness-lg: 3px; --rustic_ui_divider_thickness-md: 1px; --rustic_ui_divider_thickness-sm: 1px; --rustic_ui_divider_thickness-xl: 3px; --rustic_ui_divider_thickness-xxl: 3px;",
+  "orientation": {
+    "viewport_1440": "vertical",
+    "viewport_480": "horizontal"
+  }
+}

--- a/crates/rustic-ui-material/tests/snapshots/layout_renderers__material_hidden_renderer.snap
+++ b/crates/rustic-ui-material/tests/snapshots/layout_renderers__material_hidden_renderer.snap
@@ -1,0 +1,46 @@
+---
+source: crates/rustic-ui-material/tests/layout_renderers.rs
+assertion_line: 274
+expression: snapshot
+---
+{
+  "css_variables": {
+    "--rustic_ui_hidden_active_breakpoint": "base",
+    "--rustic_ui_hidden_aria_hidden": "false",
+    "--rustic_ui_hidden_aria_hidden-lg": "false",
+    "--rustic_ui_hidden_aria_hidden-md": "true",
+    "--rustic_ui_hidden_aria_hidden-sm": "true",
+    "--rustic_ui_hidden_aria_hidden-xl": "false",
+    "--rustic_ui_hidden_aria_hidden-xxl": "false",
+    "--rustic_ui_hidden_display": "revert-layer",
+    "--rustic_ui_hidden_display-lg": "revert-layer",
+    "--rustic_ui_hidden_display-md": "none",
+    "--rustic_ui_hidden_display-sm": "none",
+    "--rustic_ui_hidden_display-xl": "revert-layer",
+    "--rustic_ui_hidden_display-xxl": "revert-layer",
+    "--rustic_ui_hidden_inert": "true",
+    "--rustic_ui_hidden_inert-lg": "true",
+    "--rustic_ui_hidden_inert-md": "true",
+    "--rustic_ui_hidden_inert-sm": "true",
+    "--rustic_ui_hidden_inert-xl": "true",
+    "--rustic_ui_hidden_inert-xxl": "true",
+    "--rustic_ui_hidden_role": "group",
+    "--rustic_ui_hidden_role-lg": "group",
+    "--rustic_ui_hidden_role-md": "group",
+    "--rustic_ui_hidden_role-sm": "group",
+    "--rustic_ui_hidden_role-xl": "group",
+    "--rustic_ui_hidden_role-xxl": "group",
+    "--rustic_ui_hidden_visibility": "visible",
+    "--rustic_ui_hidden_visibility-lg": "visible",
+    "--rustic_ui_hidden_visibility-md": "hidden",
+    "--rustic_ui_hidden_visibility-sm": "hidden",
+    "--rustic_ui_hidden_visibility-xl": "visible",
+    "--rustic_ui_hidden_visibility-xxl": "visible"
+  },
+  "html": "<div id=\"hidden-region\" class=\"rustic-hidden\" data-inert=\"true\" role=\"group\" data-hidden=\"false\" style=\"--rustic_ui_hidden_active_breakpoint: base; --rustic_ui_hidden_aria_hidden: false; --rustic_ui_hidden_aria_hidden-lg: false; --rustic_ui_hidden_aria_hidden-md: true; --rustic_ui_hidden_aria_hidden-sm: true; --rustic_ui_hidden_aria_hidden-xl: false; --rustic_ui_hidden_aria_hidden-xxl: false; --rustic_ui_hidden_display: revert-layer; --rustic_ui_hidden_display-lg: revert-layer; --rustic_ui_hidden_display-md: none; --rustic_ui_hidden_display-sm: none; --rustic_ui_hidden_display-xl: revert-layer; --rustic_ui_hidden_display-xxl: revert-layer; --rustic_ui_hidden_inert: true; --rustic_ui_hidden_inert-lg: true; --rustic_ui_hidden_inert-md: true; --rustic_ui_hidden_inert-sm: true; --rustic_ui_hidden_inert-xl: true; --rustic_ui_hidden_inert-xxl: true; --rustic_ui_hidden_role: group; --rustic_ui_hidden_role-lg: group; --rustic_ui_hidden_role-md: group; --rustic_ui_hidden_role-sm: group; --rustic_ui_hidden_role-xl: group; --rustic_ui_hidden_role-xxl: group; --rustic_ui_hidden_visibility: visible; --rustic_ui_hidden_visibility-lg: visible; --rustic_ui_hidden_visibility-md: hidden; --rustic_ui_hidden_visibility-sm: hidden; --rustic_ui_hidden_visibility-xl: visible; --rustic_ui_hidden_visibility-xxl: visible;\"></div>",
+  "inline_style": "--rustic_ui_hidden_active_breakpoint: base; --rustic_ui_hidden_aria_hidden: false; --rustic_ui_hidden_aria_hidden-lg: false; --rustic_ui_hidden_aria_hidden-md: true; --rustic_ui_hidden_aria_hidden-sm: true; --rustic_ui_hidden_aria_hidden-xl: false; --rustic_ui_hidden_aria_hidden-xxl: false; --rustic_ui_hidden_display: revert-layer; --rustic_ui_hidden_display-lg: revert-layer; --rustic_ui_hidden_display-md: none; --rustic_ui_hidden_display-sm: none; --rustic_ui_hidden_display-xl: revert-layer; --rustic_ui_hidden_display-xxl: revert-layer; --rustic_ui_hidden_inert: true; --rustic_ui_hidden_inert-lg: true; --rustic_ui_hidden_inert-md: true; --rustic_ui_hidden_inert-sm: true; --rustic_ui_hidden_inert-xl: true; --rustic_ui_hidden_inert-xxl: true; --rustic_ui_hidden_role: group; --rustic_ui_hidden_role-lg: group; --rustic_ui_hidden_role-md: group; --rustic_ui_hidden_role-sm: group; --rustic_ui_hidden_role-xl: group; --rustic_ui_hidden_role-xxl: group; --rustic_ui_hidden_visibility: visible; --rustic_ui_hidden_visibility-lg: visible; --rustic_ui_hidden_visibility-md: hidden; --rustic_ui_hidden_visibility-sm: hidden; --rustic_ui_hidden_visibility-xl: visible; --rustic_ui_hidden_visibility-xxl: visible;",
+  "visibility": {
+    "viewport_1280": "false",
+    "viewport_360": "false"
+  }
+}

--- a/crates/rustic-ui-material/tests/snapshots/layout_renderers__material_image_list_renderer.snap
+++ b/crates/rustic-ui-material/tests/snapshots/layout_renderers__material_image_list_renderer.snap
@@ -1,0 +1,53 @@
+---
+source: crates/rustic-ui-material/tests/layout_renderers.rs
+assertion_line: 334
+expression: snapshot
+---
+{
+  "breakpoints": {
+    "viewport_1600": "xl",
+    "viewport_768": "sm"
+  },
+  "css_variables": {
+    "--rustic_ui_image_list_active_breakpoint": "base",
+    "--rustic_ui_image_list_columns": "3",
+    "--rustic_ui_image_list_columns-lg": "6",
+    "--rustic_ui_image_list_columns-md": "4",
+    "--rustic_ui_image_list_columns-sm": "4",
+    "--rustic_ui_image_list_columns-xl": "6",
+    "--rustic_ui_image_list_columns-xxl": "6",
+    "--rustic_ui_image_list_gap": "12px",
+    "--rustic_ui_image_list_gap-lg": "20px",
+    "--rustic_ui_image_list_gap-md": "20px",
+    "--rustic_ui_image_list_gap-sm": "12px",
+    "--rustic_ui_image_list_gap-xl": "20px",
+    "--rustic_ui_image_list_gap-xxl": "20px",
+    "--rustic_ui_image_list_role": "presentation",
+    "--rustic_ui_image_list_role-lg": "presentation",
+    "--rustic_ui_image_list_role-md": "presentation",
+    "--rustic_ui_image_list_role-sm": "presentation",
+    "--rustic_ui_image_list_role-xl": "presentation",
+    "--rustic_ui_image_list_role-xxl": "presentation",
+    "--rustic_ui_image_list_row_height": "200px",
+    "--rustic_ui_image_list_row_height-lg": "200px",
+    "--rustic_ui_image_list_row_height-md": "200px",
+    "--rustic_ui_image_list_row_height-sm": "200px",
+    "--rustic_ui_image_list_row_height-xl": "320px",
+    "--rustic_ui_image_list_row_height-xxl": "320px",
+    "--rustic_ui_image_list_template": "repeat(3, minmax(0, 1fr))",
+    "--rustic_ui_image_list_template-lg": "repeat(6, minmax(0, 1fr))",
+    "--rustic_ui_image_list_template-md": "repeat(4, minmax(0, 1fr))",
+    "--rustic_ui_image_list_template-sm": "repeat(4, minmax(0, 1fr))",
+    "--rustic_ui_image_list_template-xl": "repeat(6, minmax(0, 1fr))",
+    "--rustic_ui_image_list_template-xxl": "repeat(6, minmax(0, 1fr))",
+    "--rustic_ui_image_list_variant": "masonry",
+    "--rustic_ui_image_list_variant-lg": "masonry",
+    "--rustic_ui_image_list_variant-md": "masonry",
+    "--rustic_ui_image_list_variant-sm": "masonry",
+    "--rustic_ui_image_list_variant-xl": "masonry",
+    "--rustic_ui_image_list_variant-xxl": "masonry"
+  },
+  "html": "<ul id=\"image-collection\" class=\"rustic-image-list\" role=\"presentation\" data-variant=\"masonry\" data-breakpoint=\"md\" style=\"--rustic_ui_image_list_active_breakpoint: base; --rustic_ui_image_list_columns: 3; --rustic_ui_image_list_columns-lg: 6; --rustic_ui_image_list_columns-md: 4; --rustic_ui_image_list_columns-sm: 4; --rustic_ui_image_list_columns-xl: 6; --rustic_ui_image_list_columns-xxl: 6; --rustic_ui_image_list_gap: 12px; --rustic_ui_image_list_gap-lg: 20px; --rustic_ui_image_list_gap-md: 20px; --rustic_ui_image_list_gap-sm: 12px; --rustic_ui_image_list_gap-xl: 20px; --rustic_ui_image_list_gap-xxl: 20px; --rustic_ui_image_list_role: presentation; --rustic_ui_image_list_role-lg: presentation; --rustic_ui_image_list_role-md: presentation; --rustic_ui_image_list_role-sm: presentation; --rustic_ui_image_list_role-xl: presentation; --rustic_ui_image_list_role-xxl: presentation; --rustic_ui_image_list_row_height: 200px; --rustic_ui_image_list_row_height-lg: 200px; --rustic_ui_image_list_row_height-md: 200px; --rustic_ui_image_list_row_height-sm: 200px; --rustic_ui_image_list_row_height-xl: 320px; --rustic_ui_image_list_row_height-xxl: 320px; --rustic_ui_image_list_template: repeat(3, minmax(0, 1fr)); --rustic_ui_image_list_template-lg: repeat(6, minmax(0, 1fr)); --rustic_ui_image_list_template-md: repeat(4, minmax(0, 1fr)); --rustic_ui_image_list_template-sm: repeat(4, minmax(0, 1fr)); --rustic_ui_image_list_template-xl: repeat(6, minmax(0, 1fr)); --rustic_ui_image_list_template-xxl: repeat(6, minmax(0, 1fr)); --rustic_ui_image_list_variant: masonry; --rustic_ui_image_list_variant-lg: masonry; --rustic_ui_image_list_variant-md: masonry; --rustic_ui_image_list_variant-sm: masonry; --rustic_ui_image_list_variant-xl: masonry; --rustic_ui_image_list_variant-xxl: masonry;\"></ul>",
+  "inline_style": "--rustic_ui_image_list_active_breakpoint: base; --rustic_ui_image_list_columns: 3; --rustic_ui_image_list_columns-lg: 6; --rustic_ui_image_list_columns-md: 4; --rustic_ui_image_list_columns-sm: 4; --rustic_ui_image_list_columns-xl: 6; --rustic_ui_image_list_columns-xxl: 6; --rustic_ui_image_list_gap: 12px; --rustic_ui_image_list_gap-lg: 20px; --rustic_ui_image_list_gap-md: 20px; --rustic_ui_image_list_gap-sm: 12px; --rustic_ui_image_list_gap-xl: 20px; --rustic_ui_image_list_gap-xxl: 20px; --rustic_ui_image_list_role: presentation; --rustic_ui_image_list_role-lg: presentation; --rustic_ui_image_list_role-md: presentation; --rustic_ui_image_list_role-sm: presentation; --rustic_ui_image_list_role-xl: presentation; --rustic_ui_image_list_role-xxl: presentation; --rustic_ui_image_list_row_height: 200px; --rustic_ui_image_list_row_height-lg: 200px; --rustic_ui_image_list_row_height-md: 200px; --rustic_ui_image_list_row_height-sm: 200px; --rustic_ui_image_list_row_height-xl: 320px; --rustic_ui_image_list_row_height-xxl: 320px; --rustic_ui_image_list_template: repeat(3, minmax(0, 1fr)); --rustic_ui_image_list_template-lg: repeat(6, minmax(0, 1fr)); --rustic_ui_image_list_template-md: repeat(4, minmax(0, 1fr)); --rustic_ui_image_list_template-sm: repeat(4, minmax(0, 1fr)); --rustic_ui_image_list_template-xl: repeat(6, minmax(0, 1fr)); --rustic_ui_image_list_template-xxl: repeat(6, minmax(0, 1fr)); --rustic_ui_image_list_variant: masonry; --rustic_ui_image_list_variant-lg: masonry; --rustic_ui_image_list_variant-md: masonry; --rustic_ui_image_list_variant-sm: masonry; --rustic_ui_image_list_variant-xl: masonry; --rustic_ui_image_list_variant-xxl: masonry;",
+  "variant": "masonry"
+}


### PR DESCRIPTION
## Summary
- add Material renderers for the hidden, image list, and divider layout states along with framework adapters
- expose the new modules from the crate root and extend shared helpers with visibility utilities
- cover the new renderers with insta snapshots to validate CSS variables and inline styling

## Testing
- cargo test -p rustic-ui-material --test layout_renderers

------
https://chatgpt.com/codex/tasks/task_e_68da0c30d35c832e860a2e3de5674f36