### PR TITLE
Add divider layout primitive snapshot test

### DIFF
--- a/crates/rustic-ui-headless/tests/layout_primitives.rs
+++ b/crates/rustic-ui-headless/tests/layout_primitives.rs
@@ -201,6 +201,60 @@ fn stack_breakpoint_evaluations_snapshot() {
 }
 
 #[test]
+fn divider_breakpoint_evaluations_snapshot() {
+    use rustic_ui_headless::divider::{
+        DividerOrientation, DividerRole, DividerState, DividerTokens,
+    };
+
+    let tokens = DividerTokens {
+        orientation: ResponsiveValue::new(DividerOrientation::Horizontal)
+            .with_override(Breakpoint::Md, DividerOrientation::Vertical)
+            .with_override(Breakpoint::Xl, DividerOrientation::Horizontal),
+        thickness: ResponsiveValue::new(String::from("1px"))
+            .with_override(Breakpoint::Lg, String::from("2px")),
+        inset: ResponsiveValue::new(String::from("0"))
+            .with_override(Breakpoint::Sm, String::from("8px"))
+            .with_override(Breakpoint::Xl, String::from("16px")),
+    };
+
+    let state = DividerState::new(tokens, BreakpointConfig::material())
+        .with_role(DividerRole::Presentation);
+    let attrs = state
+        .attributes()
+        .id("analytics-divider")
+        .class("rustic-divider");
+
+    let evaluations = state
+        .breakpoints()
+        .iter()
+        .map(|(breakpoint, min_width)| {
+            let evaluation = state.evaluate_for(breakpoint);
+            json!({
+                "breakpoint": breakpoint.as_token(),
+                "min_width": min_width,
+                "orientation": evaluation.orientation.as_str(),
+                "thickness": evaluation.thickness,
+                "inset": evaluation.inset,
+                "role": evaluation.role.as_str(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let snapshot = json!({
+        "attributes": {
+            "role": attrs.role().1,
+            "id": attrs.id_attr().map(|(_, value)| value.to_string()),
+            "class": attrs.class_attr().map(|(_, value)| value.to_string()),
+            "data_orientation@480": attrs.data_orientation(480).1,
+            "data_orientation@1920": attrs.data_orientation(1920).1,
+        },
+        "evaluations": evaluations,
+    });
+
+    assert_json_snapshot!("headless_divider_breakpoints", snapshot);
+}
+
+#[test]
 fn image_list_breakpoint_evaluations_snapshot() {
     use rustic_ui_headless::image_list::{
         ImageListRole, ImageListState, ImageListTokens, ImageListVariant,

--- a/crates/rustic-ui-headless/tests/snapshots/layout_primitives__headless_divider_breakpoints.snap
+++ b/crates/rustic-ui-headless/tests/snapshots/layout_primitives__headless_divider_breakpoints.snap
@@ -1,0 +1,63 @@
+---
+source: crates/rustic-ui-headless/tests/layout_primitives.rs
+expression: snapshot
+---
+{
+  "attributes": {
+    "class": "rustic-divider",
+    "data_orientation@1920": "horizontal",
+    "data_orientation@480": "horizontal",
+    "id": "analytics-divider",
+    "role": "presentation"
+  },
+  "evaluations": [
+    {
+      "breakpoint": "base",
+      "inset": "0",
+      "min_width": 0,
+      "orientation": "horizontal",
+      "role": "presentation",
+      "thickness": "1px"
+    },
+    {
+      "breakpoint": "sm",
+      "inset": "8px",
+      "min_width": 600,
+      "orientation": "horizontal",
+      "role": "presentation",
+      "thickness": "1px"
+    },
+    {
+      "breakpoint": "md",
+      "inset": "8px",
+      "min_width": 900,
+      "orientation": "vertical",
+      "role": "presentation",
+      "thickness": "1px"
+    },
+    {
+      "breakpoint": "lg",
+      "inset": "8px",
+      "min_width": 1200,
+      "orientation": "vertical",
+      "role": "presentation",
+      "thickness": "2px"
+    },
+    {
+      "breakpoint": "xl",
+      "inset": "16px",
+      "min_width": 1536,
+      "orientation": "horizontal",
+      "role": "presentation",
+      "thickness": "2px"
+    },
+    {
+      "breakpoint": "xxl",
+      "inset": "16px",
+      "min_width": 1800,
+      "orientation": "horizontal",
+      "role": "presentation",
+      "thickness": "2px"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a headless divider breakpoint snapshot test covering responsive orientation, thickness, inset, and role metadata
- record the serialized attributes and evaluations in a new Insta snapshot for layout primitives

## Testing
- INSTA_UPDATE=always cargo test -p rustic-ui-headless --test layout_primitives

------
https://chatgpt.com/codex/tasks/task_e_68da13b5a244832ea6072f1a3dd9ed8f