### PR TITLE
docs: surface responsive divider hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ files remain as read-only references for parity investigations.
 ## Responsive layout primitives
 
 Enterprise adopters migrating from the legacy `mui_*` layout helpers can now rely on the Rust-first
-`Box`, `Container`, `Grid`, `Stack`, `Hidden`, and `ImageList` state machines shipped in
+`Box`, `Container`, `Grid`, `Stack`, `Hidden`, `Divider`, and `ImageList` state machines shipped in
 `rustic-ui-headless`. Each primitive exposes:
 
 - **Responsive breakpoint APIs** – Every state machine accepts a shared `BreakpointConfig` and `ResponsiveValue`
@@ -97,6 +97,8 @@ Enterprise adopters migrating from the legacy `mui_*` layout helpers can now rel
   QA pipelines. When migrating from custom wrappers, prefer the fluent builders exposed on each state machine and
   pipe the resulting tuples into your adapter’s attribute map. Hidden content can opt into `data-inert` markers so
   focus management remains deterministic even when sections collapse at specific breakpoints.【F:crates/rustic-ui-headless/src/hidden.rs†L1-L120】
+  Divider’s responsive orientation tokens automatically flip the computed `role` between block separators and
+  presentation-only dividers, so assistive technology can respect layout changes without extra glue code.
 
 Refer to the new migration notes in the Rust book for a step-by-step walkthrough that maps legacy layout props to
 the responsive primitives, demonstrates the new automation helpers (`EMPTY_SEGMENTS` and friends), and codifies

--- a/docs/rust-book/src/layout-primitives.md
+++ b/docs/rust-book/src/layout-primitives.md
@@ -7,8 +7,8 @@ adapter.
 ## Mapping legacy props to state machines
 
 1. **Import the headless state** matching your component (`BoxState`,
-   `ContainerState`, `GridState`, `StackState`, `HiddenState`, or
-   `ImageListState`). Each state accepts a shared
+   `ContainerState`, `GridState`, `StackState`, `HiddenState`,
+   `DividerState`, or `ImageListState`). Each state accepts a shared
    [`BreakpointConfig`](../../crates/rustic-ui-headless/src/layout.rs) and
    [`ResponsiveValue`](../../crates/rustic-ui-headless/src/layout.rs) so you can
    describe breakpoint overrides in a single place.
@@ -28,6 +28,31 @@ adapter.
    framework adapter. The integration tests in
    `crates/rustic-ui-material/tests/layout_renderers.rs` snapshot the generated
    markup to keep SSR and hydration in sync.【F:crates/rustic-ui-material/tests/layout_renderers.rs†L1-L126】
+
+   ```rust
+   use rustic_ui_headless::divider::{
+       DividerOrientation, DividerRole, DividerState, DividerTokens,
+   };
+   use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+   use rustic_ui_material::divider::render_divider;
+
+   let tokens = DividerTokens {
+       orientation: ResponsiveValue::new(DividerOrientation::Horizontal)
+           .with_override(Breakpoint::Md, DividerOrientation::Vertical),
+       thickness: ResponsiveValue::from(String::from("1px")),
+       inset: ResponsiveValue::from(String::from("0px")),
+   };
+
+   let state = DividerState::new(tokens, BreakpointConfig::material())
+       .with_role(DividerRole::Presentation);
+
+   let evaluation = state.evaluate_for(Breakpoint::Md);
+   assert_eq!(evaluation.orientation, DividerOrientation::Vertical);
+   assert_eq!(evaluation.role.as_str(), "presentation");
+
+   let render_output = render_divider(&state);
+   // Feed `render_output` into your adapter's attribute map once implemented.
+   ```
 
 ## Automation and accessibility hooks
 


### PR DESCRIPTION
## Summary
- highlight `Divider` support and its responsive orientation/role hooks in the README layout primitives overview
- extend the Rust book layout chapter with `DividerState` import guidance and a renderer snippet for responsive tokens

## Testing
- cargo xtask build-docs *(fails: document output filename collision between example `bootstrap` binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68da14ef6e44832eab2533883e9fa6ad