### PR TITLE
Update verification commands for May 20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ archived Material UI change history now lives in [`docs/archives/material-ui-cha
 ### Verification
 
 - `cargo fmt`
-- `cargo clippy --workspace --all-features`
+- `cargo clippy --workspace --all-targets -D warnings --all-features`
+- `cargo test --workspace --all-features`
 - `INSTA_UPDATE=always cargo test -p rustic-ui-headless --test layout_primitives`
 - `INSTA_UPDATE=always cargo test -p rustic-ui-material --test layout_renderers`
+- `cargo xtask examples --group layout --release`
+- `cargo xtask wasm-test`
 - `cargo xtask build-docs`
 
 ## 2025-05-06 – Supply-chain automation and archive governance


### PR DESCRIPTION
## Summary
- document the full set of validation commands used for the 2025-05-20 release, including workspace tests, layout builds, and wasm test harness
- tighten the clippy invocation in the changelog to match the `--all-targets -D warnings` configuration

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68da86292214832eaf98b59b95d68890