### PR TITLE
Add material renderers and headless primitives for new components

### DIFF
--- a/crates/rustic-ui-headless/src/avatar.rs
+++ b/crates/rustic-ui-headless/src/avatar.rs
@@ -1,0 +1,69 @@
+//! Headless avatar utilities exposing deterministic accessibility metadata.
+//!
+//! The state machine encapsulates fallback generation (initials) and exposes a
+//! stable set of attributes that renderers translate into DOM nodes.  Keeping
+//! the logic independent from any specific framework guarantees consistency
+//! across SSR and client renderers.
+
+/// Headless configuration for avatar surfaces.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvatarState {
+    alt: Option<String>,
+    label: Option<String>,
+    fallback_initials: Option<String>,
+}
+
+impl AvatarState {
+    /// Builds a new [`AvatarState`] with optional alt text and fallback
+    /// initials.
+    pub fn new(alt: Option<String>, fallback_initials: Option<String>) -> Self {
+        Self {
+            alt,
+            label: None,
+            fallback_initials,
+        }
+    }
+
+    /// Assigns an accessible label typically surfaced via `aria-label`.
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Returns the alt text attached to the avatar image.
+    pub fn alt(&self) -> Option<&str> {
+        self.alt.as_deref()
+    }
+
+    /// Returns fallback initials used when no image is available.
+    pub fn fallback_initials(&self) -> Option<&str> {
+        self.fallback_initials.as_deref()
+    }
+
+    /// Generates accessibility attributes for the avatar root.
+    pub fn accessibility_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(1);
+        if let Some(label) = &self.label {
+            attrs.push(("aria-label", label.clone()));
+        }
+        attrs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_is_reflected_in_accessibility_attributes() {
+        let state = AvatarState::new(Some("User photo".into()), None).with_label("Profile");
+        let attrs = state.accessibility_attributes();
+        assert_eq!(attrs[0], ("aria-label", "Profile".to_string()));
+    }
+
+    #[test]
+    fn fallback_initials_round_trip() {
+        let state = AvatarState::new(None, Some("JD".into()));
+        assert_eq!(state.fallback_initials(), Some("JD"));
+    }
+}

--- a/crates/rustic-ui-headless/src/badge.rs
+++ b/crates/rustic-ui-headless/src/badge.rs
@@ -1,0 +1,104 @@
+//! Headless badge logic consolidating count formatting and ARIA semantics.
+//!
+//! The badge supports numeric counters and dot indicators.  Renderers query the
+//! evaluated tokens and merge them with theme driven styles keeping
+//! accessibility rules consistent across frameworks.
+
+/// Headless representation of a badge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BadgeState {
+    value: Option<i32>,
+    max: i32,
+    show_zero: bool,
+    dot: bool,
+}
+
+impl BadgeState {
+    /// Creates a badge with an optional numeric value.
+    pub fn new(value: Option<i32>) -> Self {
+        Self {
+            value,
+            max: 99,
+            show_zero: false,
+            dot: false,
+        }
+    }
+
+    /// Configures the maximum number shown before truncation.
+    pub fn with_max(mut self, max: i32) -> Self {
+        self.max = max.max(0);
+        self
+    }
+
+    /// Forces the badge to remain visible when the value is zero.
+    pub fn with_show_zero(mut self, show_zero: bool) -> Self {
+        self.show_zero = show_zero;
+        self
+    }
+
+    /// Configures whether the badge renders as a dot indicator.
+    pub fn with_dot(mut self, dot: bool) -> Self {
+        self.dot = dot;
+        self
+    }
+
+    /// Returns the formatted value shown by renderers.
+    pub fn display_value(&self) -> Option<String> {
+        if self.dot {
+            return None;
+        }
+
+        match self.value {
+            Some(v) if v > self.max => Some(format!("{}+", self.max)),
+            Some(v) if v == 0 && !self.show_zero => None,
+            Some(v) => Some(v.to_string()),
+            None => None,
+        }
+    }
+
+    /// Returns ARIA attributes for the badge container.
+    pub fn accessibility_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(2);
+        if let Some(display) = self.display_value() {
+            attrs.push(("aria-label", format!("{} notifications", display)));
+            attrs.push(("data-badge-count", display));
+        } else if self.dot {
+            attrs.push(("aria-label", "Notifications".to_string()));
+        }
+        attrs
+    }
+
+    /// Returns whether the badge should render.
+    pub fn is_visible(&self) -> bool {
+        self.dot || self.display_value().is_some()
+    }
+
+    /// Indicates whether the badge is configured as a dot indicator.
+    pub fn is_dot(&self) -> bool {
+        self.dot
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_value_truncates_at_max() {
+        let state = BadgeState::new(Some(120)).with_max(99);
+        assert_eq!(state.display_value(), Some("99+".to_string()));
+    }
+
+    #[test]
+    fn zero_is_hidden_by_default() {
+        let state = BadgeState::new(Some(0));
+        assert!(!state.is_visible());
+    }
+
+    #[test]
+    fn dot_badges_skip_numeric_value() {
+        let state = BadgeState::new(None).with_dot(true);
+        assert!(state.display_value().is_none());
+        assert!(state.is_visible());
+    }
+}

--- a/crates/rustic-ui-headless/src/lib.rs
+++ b/crates/rustic-ui-headless/src/lib.rs
@@ -24,6 +24,8 @@
 pub mod accordion;
 pub mod aria;
 pub mod autocomplete;
+pub mod avatar;
+pub mod badge;
 pub mod r#box;
 pub mod button;
 pub mod checkbox;
@@ -39,6 +41,7 @@ pub mod interaction;
 pub mod layout;
 pub mod list;
 pub mod menu;
+pub mod paper;
 pub mod popover;
 pub mod radio;
 pub mod select;
@@ -54,6 +57,7 @@ pub mod text_field;
 pub mod timing;
 pub mod toggle_button_group;
 pub mod tooltip;
+pub mod typography;
 
 mod selection;
 mod toggle;

--- a/crates/rustic-ui-headless/src/paper.rs
+++ b/crates/rustic-ui-headless/src/paper.rs
@@ -1,0 +1,140 @@
+//! Headless representation of the Material `Paper` surface.
+//!
+//! The state object tracks semantic configuration such as the chosen surface
+//! variant (elevated, outlined or plain), corner rounding and whether the
+//! surface participates in a grouped disclosure widget.  Renderers translate
+//! these settings into concrete CSS classes, elevation tokens and ARIA
+//! attributes without duplicating business logic.  Enterprise teams can rely on
+//! the deterministic [`PaperState::tokens`] contract to script automated visual
+//! regression checks across frameworks.
+
+/// Enumerates the supported Paper variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaperVariant {
+    /// Elevated surfaces receive a drop shadow derived from the Material
+    /// elevation ramp.
+    Elevated,
+    /// Outlined surfaces remove the drop shadow in favour of a stroked border.
+    Outlined,
+    /// Plain surfaces inherit the parent background while still exposing shape
+    /// tokens for rounded corners.
+    Plain,
+}
+
+impl PaperVariant {
+    /// Returns the stable variant identifier used by renderers and QA tooling.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Elevated => "elevated",
+            Self::Outlined => "outlined",
+            Self::Plain => "plain",
+        }
+    }
+}
+
+/// Tracks surface configuration independent from any view layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaperState {
+    variant: PaperVariant,
+    elevation: u8,
+    square: bool,
+    labelled_by: Option<String>,
+}
+
+impl PaperState {
+    /// Builds a new [`PaperState`] using the provided variant.
+    pub fn new(variant: PaperVariant) -> Self {
+        Self {
+            variant,
+            elevation: 1,
+            square: false,
+            labelled_by: None,
+        }
+    }
+
+    /// Configures the elevation level used by the renderer.
+    ///
+    /// Values above 24 clamp to 24 to match the Material guidelines. Returning
+    /// `self` enables builder style ergonomics.
+    pub fn with_elevation(mut self, level: u8) -> Self {
+        self.elevation = level.min(24);
+        self
+    }
+
+    /// Configures whether the surface should render with rounded corners.
+    pub fn with_square(mut self, square: bool) -> Self {
+        self.square = square;
+        self
+    }
+
+    /// Associates the surface with an external label for accessibility.
+    pub fn with_labelled_by(mut self, labelled_by: impl Into<String>) -> Self {
+        self.labelled_by = Some(labelled_by.into());
+        self
+    }
+
+    /// Returns the configured variant.
+    pub fn variant(&self) -> PaperVariant {
+        self.variant
+    }
+
+    /// Returns the resolved elevation level (0-24).
+    pub fn elevation(&self) -> u8 {
+        self.elevation
+    }
+
+    /// Returns whether the surface should suppress corner rounding.
+    pub fn square(&self) -> bool {
+        self.square
+    }
+
+    /// Returns the ARIA attributes required by accessibility adapters.
+    pub fn accessibility_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(2);
+        if let Some(label) = &self.labelled_by {
+            attrs.push(("aria-labelledby", label.clone()));
+        }
+        attrs
+    }
+
+    /// Returns deterministic tokens that renderers translate into CSS classes
+    /// and data attributes.
+    pub fn tokens(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("variant", self.variant.as_str().to_string()),
+            ("elevation", self.elevation.to_string()),
+            ("square", self.square.to_string()),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elevation_clamps_to_material_range() {
+        let state = PaperState::new(PaperVariant::Elevated).with_elevation(42);
+        assert_eq!(state.elevation(), 24);
+    }
+
+    #[test]
+    fn tokens_include_variant_and_square_flag() {
+        let state = PaperState::new(PaperVariant::Outlined).with_square(true);
+        let tokens = state.tokens();
+        assert!(tokens
+            .iter()
+            .any(|(k, v)| *k == "variant" && v == "outlined"));
+        assert!(tokens.iter().any(|(k, v)| *k == "square" && v == "true"));
+    }
+
+    #[test]
+    fn labelled_surfaces_emit_aria_relationship() {
+        let state = PaperState::new(PaperVariant::Plain).with_labelled_by("accordion-summary");
+        let attrs = state.accessibility_attributes();
+        assert_eq!(
+            attrs[0],
+            ("aria-labelledby", "accordion-summary".to_string())
+        );
+    }
+}

--- a/crates/rustic-ui-headless/src/typography.rs
+++ b/crates/rustic-ui-headless/src/typography.rs
@@ -1,0 +1,134 @@
+//! Headless typography contracts powering Material renderers.
+//!
+//! The state exposes deterministic mappings between design-system variants and
+//! semantic HTML tags while centralising ARIA authoring for enterprise
+//! automation.
+
+/// Material typography variants understood by the headless layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypographyVariant {
+    H1,
+    H2,
+    H3,
+    H4,
+    H5,
+    H6,
+    Subtitle1,
+    Subtitle2,
+    Body1,
+    Body2,
+    Button,
+    Caption,
+    Overline,
+}
+
+impl TypographyVariant {
+    /// Returns a stable string identifier for analytics/automation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::H1 => "h1",
+            Self::H2 => "h2",
+            Self::H3 => "h3",
+            Self::H4 => "h4",
+            Self::H5 => "h5",
+            Self::H6 => "h6",
+            Self::Subtitle1 => "subtitle1",
+            Self::Subtitle2 => "subtitle2",
+            Self::Body1 => "body1",
+            Self::Body2 => "body2",
+            Self::Button => "button",
+            Self::Caption => "caption",
+            Self::Overline => "overline",
+        }
+    }
+
+    /// Returns the default HTML tag associated with the variant.
+    pub fn default_tag(&self) -> &'static str {
+        match self {
+            Self::H1 => "h1",
+            Self::H2 => "h2",
+            Self::H3 => "h3",
+            Self::H4 => "h4",
+            Self::H5 => "h5",
+            Self::H6 => "h6",
+            Self::Subtitle1 | Self::Subtitle2 | Self::Body1 | Self::Body2 => "p",
+            Self::Button | Self::Overline | Self::Caption => "span",
+        }
+    }
+}
+
+/// Headless typography state capturing the variant and custom semantic tag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypographyState {
+    variant: TypographyVariant,
+    component: Option<String>,
+    id: Option<String>,
+}
+
+impl TypographyState {
+    /// Creates a new state for the provided variant.
+    pub fn new(variant: TypographyVariant) -> Self {
+        Self {
+            variant,
+            component: None,
+            id: None,
+        }
+    }
+
+    /// Overrides the semantic tag rendered by adapters.
+    pub fn with_component(mut self, component: impl Into<String>) -> Self {
+        self.component = Some(component.into());
+        self
+    }
+
+    /// Assigns a DOM id for linking headings.
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Returns the typography variant.
+    pub fn variant(&self) -> TypographyVariant {
+        self.variant
+    }
+
+    /// Returns the semantic HTML tag adapters should use.
+    pub fn tag(&self) -> &str {
+        self.component
+            .as_deref()
+            .unwrap_or_else(|| self.variant.default_tag())
+    }
+
+    /// Returns ARIA attributes for the typography element.
+    pub fn accessibility_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(1);
+        if let Some(id) = &self.id {
+            attrs.push(("id", id.clone()));
+        }
+        attrs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_tag_matches_variant() {
+        let state = TypographyState::new(TypographyVariant::H3);
+        assert_eq!(state.tag(), "h3");
+    }
+
+    #[test]
+    fn custom_component_overrides_default_tag() {
+        let state = TypographyState::new(TypographyVariant::Body1).with_component("div");
+        assert_eq!(state.tag(), "div");
+    }
+
+    #[test]
+    fn id_is_reflected_in_accessibility_attributes() {
+        let state = TypographyState::new(TypographyVariant::H4).with_id("title");
+        let attrs = state.accessibility_attributes();
+        assert_eq!(attrs[0], ("id", "title".to_string()));
+    }
+}

--- a/crates/rustic-ui-material/src/accordion.rs
+++ b/crates/rustic-ui-material/src/accordion.rs
@@ -1,0 +1,223 @@
+//! Material renderer for the headless [`AccordionGroupState`].
+//!
+//! The implementation emits deterministic CSS classes and accessibility
+//! attributes so React, Yew, Leptos and Dioxus adapters can remain thin wrappers
+//! that simply bind events and render children.  Styling is driven entirely via
+//! [`css_with_theme!`](rustic_ui_styled_engine::css_with_theme) which means
+//! tokens automatically track palette overrides and typography ramps configured
+//! at runtime.
+
+use rustic_ui_headless::accordion::AccordionGroupState;
+use rustic_ui_styled_engine::{css_with_theme, Style};
+
+use crate::style_helpers;
+
+/// Describes a single accordion item and the ids used for automation hooks.
+#[derive(Debug, Clone)]
+pub struct AccordionItemDescriptor<'a> {
+    /// DOM id for the summary button.
+    pub summary_id: &'a str,
+    /// DOM id for the associated panel.
+    pub panel_id: &'a str,
+}
+
+/// Adapter level props accepted by [`render_accordion`].
+#[derive(Debug, Clone)]
+pub struct AccordionAdapterProps<'a> {
+    /// Headless state describing expansion and accessibility wiring.
+    pub state: &'a AccordionGroupState,
+    /// Static description of the rendered items.
+    pub items: &'a [AccordionItemDescriptor<'a>],
+}
+
+/// Rendered output for a single accordion item.
+#[derive(Debug, Clone)]
+pub struct AccordionItemRender {
+    summary_attributes: Vec<(String, String)>,
+    details_attributes: Vec<(String, String)>,
+}
+
+impl AccordionItemRender {
+    /// Attributes attached to the summary element.
+    pub fn summary_attributes(&self) -> &[(String, String)] {
+        &self.summary_attributes
+    }
+
+    /// Attributes attached to the details panel.
+    pub fn details_attributes(&self) -> &[(String, String)] {
+        &self.details_attributes
+    }
+}
+
+/// Rendered output for an accordion group.
+#[derive(Debug, Clone)]
+pub struct AccordionRenderOutput {
+    root_class: String,
+    items: Vec<AccordionItemRender>,
+}
+
+impl AccordionRenderOutput {
+    /// Class attached to the accordion root container.
+    pub fn root_class(&self) -> &str {
+        &self.root_class
+    }
+
+    /// Rendered items with merged accessibility data.
+    pub fn items(&self) -> &[AccordionItemRender] {
+        &self.items
+    }
+}
+
+/// Renders the accordion into deterministic classes and ARIA attributes.
+pub fn render_accordion(props: AccordionAdapterProps<'_>) -> AccordionRenderOutput {
+    let root_class = style_helpers::themed_class(accordion_root_style());
+    let items = props
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, descriptor)| {
+            let summary_attrs = build_summary_attributes(props.state, index, descriptor);
+            let details_attrs = build_details_attributes(props.state, index, descriptor);
+            AccordionItemRender {
+                summary_attributes: summary_attrs,
+                details_attributes: details_attrs,
+            }
+        })
+        .collect();
+
+    AccordionRenderOutput { root_class, items }
+}
+
+fn build_summary_attributes(
+    state: &AccordionGroupState,
+    index: usize,
+    descriptor: &AccordionItemDescriptor<'_>,
+) -> Vec<(String, String)> {
+    let mut attrs: Vec<(String, String)> = state
+        .summary_accessibility_attributes(index, descriptor.panel_id)
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+    attrs.push(("id".into(), descriptor.summary_id.to_string()));
+    attrs.push((
+        style_helpers::automation_data_attr("accordion", ["summary", &index.to_string()]),
+        "true".into(),
+    ));
+
+    style_helpers::themed_attributes(accordion_summary_style(), attrs)
+}
+
+fn build_details_attributes(
+    state: &AccordionGroupState,
+    index: usize,
+    descriptor: &AccordionItemDescriptor<'_>,
+) -> Vec<(String, String)> {
+    let mut attrs: Vec<(String, String)> = state
+        .details_accessibility_attributes(index, descriptor.summary_id)
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+    attrs.push(("id".into(), descriptor.panel_id.to_string()));
+    attrs.push((
+        style_helpers::automation_data_attr("accordion", ["panel", &index.to_string()]),
+        "true".into(),
+    ));
+
+    style_helpers::themed_attributes(accordion_details_style(), attrs)
+}
+
+fn accordion_root_style() -> Style {
+    css_with_theme!(
+        r#"
+        border-radius: ${radius}px;
+        background: ${background};
+        color: ${color};
+        border: 1px solid ${outline};
+        overflow: hidden;
+        display: block;
+    "#,
+        radius = theme.joy.radius,
+        background = theme.palette.background_paper.clone(),
+        color = theme.palette.text_primary.clone(),
+        outline = theme.palette.neutral.clone()
+    )
+}
+
+fn accordion_summary_style() -> Style {
+    css_with_theme!(
+        r#"
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: ${padding_y}px ${padding_x}px;
+        background: transparent;
+        border: none;
+        text-align: left;
+        cursor: pointer;
+        font-family: ${font_family};
+        font-weight: ${font_weight};
+        font-size: ${font_size}rem;
+        transition: background-color 120ms ease-in-out;
+
+        &[aria-expanded="true"] {
+            background-color: ${expanded_background};
+        }
+
+        &:focus-visible {
+            outline: ${focus_outline};
+            outline-offset: 2px;
+        }
+    "#,
+        padding_y = theme.spacing(2),
+        padding_x = theme.spacing(3),
+        font_family = theme.typography.font_family.clone(),
+        font_weight = theme.typography.font_weight_medium,
+        font_size = theme.typography.body1,
+        expanded_background = theme.palette.background_default.clone(),
+        focus_outline = theme.joy.focus_outline_for_color(&theme.palette.primary)
+    )
+}
+
+fn accordion_details_style() -> Style {
+    css_with_theme!(
+        r#"
+        padding: ${padding}px;
+        border-top: 1px solid ${divider};
+        font-size: ${font_size}rem;
+        line-height: ${line_height};
+        background-color: ${background};
+    "#,
+        padding = theme.spacing(3),
+        divider = theme.palette.neutral.clone(),
+        font_size = theme.typography.body1,
+        line_height = theme.typography.line_height,
+        background = theme.palette.background_paper.clone()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::accordion::AccordionGroupState;
+
+    #[test]
+    fn summary_attributes_include_theme_class_and_aria_metadata() {
+        let state = AccordionGroupState::new(1, false, &[0]);
+        let props = AccordionAdapterProps {
+            state: &state,
+            items: &[AccordionItemDescriptor {
+                summary_id: "summary",
+                panel_id: "panel",
+            }],
+        };
+        let output = render_accordion(props);
+        let summary_attrs = &output.items()[0].summary_attributes;
+        assert!(summary_attrs.iter().any(|(k, _)| k == "class"));
+        assert!(summary_attrs
+            .iter()
+            .any(|(k, v)| k == "aria-controls" && v == "panel"));
+    }
+}

--- a/crates/rustic-ui-material/src/avatar.rs
+++ b/crates/rustic-ui-material/src/avatar.rs
@@ -1,0 +1,112 @@
+//! Material renderer for [`AvatarState`](rustic_ui_headless::avatar::AvatarState).
+//!
+//! The renderer converts the headless metadata into themed classes and
+//! accessibility attributes while exposing deterministic automation hooks for
+//! QA tooling.
+
+use rustic_ui_headless::avatar::AvatarState;
+use rustic_ui_styled_engine::css_with_theme;
+
+use crate::style_helpers;
+
+/// Render result describing the avatar container and media node.
+#[derive(Debug, Clone)]
+pub struct AvatarRenderOutput {
+    container_attributes: Vec<(String, String)>,
+    media_attributes: Vec<(String, String)>,
+}
+
+impl AvatarRenderOutput {
+    /// Attributes for the wrapper element.
+    pub fn container_attributes(&self) -> &[(String, String)] {
+        &self.container_attributes
+    }
+
+    /// Attributes for the `<img>` or fallback `<span>` element.
+    pub fn media_attributes(&self) -> &[(String, String)] {
+        &self.media_attributes
+    }
+}
+
+/// Render the avatar using the active theme.
+pub fn render_avatar(state: &AvatarState) -> AvatarRenderOutput {
+    let container_attrs = style_helpers::themed_attributes(
+        avatar_container_style(),
+        state
+            .accessibility_attributes()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v)),
+    );
+
+    let mut media_attrs: Vec<(String, String)> = Vec::with_capacity(2);
+    if let Some(alt) = state.alt() {
+        media_attrs.push(("alt".into(), alt.to_string()));
+    }
+    if let Some(initials) = state.fallback_initials() {
+        media_attrs.push(("data-avatar-fallback".into(), initials.to_string()));
+    }
+
+    let media_attrs = style_helpers::themed_attributes(avatar_media_style(), media_attrs);
+
+    AvatarRenderOutput {
+        container_attributes: container_attrs,
+        media_attributes: media_attrs,
+    }
+}
+
+fn avatar_container_style() -> rustic_ui_styled_engine::Style {
+    css_with_theme!(
+        r#"
+        width: 40px;
+        height: 40px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+        background-color: ${background};
+        color: ${color};
+        position: relative;
+    "#,
+        background = theme.palette.primary.clone(),
+        color = theme.palette.background_paper.clone()
+    )
+}
+
+fn avatar_media_style() -> rustic_ui_styled_engine::Style {
+    css_with_theme!(
+        r#"
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        object-fit: cover;
+        font-family: ${font_family};
+        font-weight: ${font_weight};
+        text-transform: uppercase;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    "#,
+        font_family = theme.typography.font_family.clone(),
+        font_weight = theme.typography.font_weight_medium
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::avatar::AvatarState;
+
+    #[test]
+    fn render_includes_accessibility_metadata() {
+        let state = AvatarState::new(Some("User".into()), Some("JD".into())).with_label("Team");
+        let render = render_avatar(&state);
+        assert!(render
+            .container_attributes()
+            .iter()
+            .any(|(k, v)| k == "aria-label" && v == "Team"));
+        assert!(render
+            .media_attributes()
+            .iter()
+            .any(|(k, v)| k == "data-avatar-fallback" && v == "JD"));
+    }
+}

--- a/crates/rustic-ui-material/src/badge.rs
+++ b/crates/rustic-ui-material/src/badge.rs
@@ -1,0 +1,126 @@
+//! Material renderer for the headless [`BadgeState`](rustic_ui_headless::badge::BadgeState).
+//!
+//! The renderer projects badge tokens to CSS utility classes describing the
+//! layering contract used across frameworks.  This keeps automation selectors
+//! stable while surfacing the evaluated count to assistive technologies.
+
+use rustic_ui_headless::badge::BadgeState;
+use rustic_ui_styled_engine::css_with_theme;
+
+use crate::style_helpers;
+
+/// Render output describing the badge container and badge element attributes.
+#[derive(Debug, Clone)]
+pub struct BadgeRenderOutput {
+    container_class: String,
+    badge_attributes: Vec<(String, String)>,
+}
+
+impl BadgeRenderOutput {
+    /// Class name attached to the relative container used for layering.
+    pub fn container_class(&self) -> &str {
+        &self.container_class
+    }
+
+    /// Attributes applied to the badge element.
+    pub fn badge_attributes(&self) -> &[(String, String)] {
+        &self.badge_attributes
+    }
+}
+
+/// Render the badge state using the active theme.
+pub fn render_badge(state: &BadgeState) -> BadgeRenderOutput {
+    let container_class = style_helpers::themed_class(badge_container_style());
+
+    let mut attrs: Vec<(String, String)> = state
+        .accessibility_attributes()
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+    if let Some(display) = state.display_value() {
+        attrs.push(("data-badge-content".into(), display));
+    }
+    attrs.push((
+        style_helpers::automation_data_attr("badge", ["layer"]),
+        "surface".into(),
+    ));
+
+    let badge_attributes =
+        style_helpers::themed_attributes(badge_pill_style(state.is_dot()), attrs);
+
+    BadgeRenderOutput {
+        container_class,
+        badge_attributes,
+    }
+}
+
+fn badge_container_style() -> rustic_ui_styled_engine::Style {
+    css_with_theme!(
+        r#"
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+    "#
+    )
+}
+
+fn badge_pill_style(is_dot: bool) -> rustic_ui_styled_engine::Style {
+    if is_dot {
+        css_with_theme!(
+            r#"
+            position: absolute;
+            top: -4px;
+            right: -4px;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background-color: ${background};
+            border: 2px solid ${border};
+        "#,
+            background = theme.palette.secondary.clone(),
+            border = theme.palette.background_paper.clone()
+        )
+    } else {
+        css_with_theme!(
+            r#"
+            position: absolute;
+            top: -6px;
+            right: -6px;
+            min-width: 22px;
+            height: 22px;
+            border-radius: 11px;
+            padding: 0 ${padding}px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            background-color: ${background};
+            color: ${color};
+            font-family: ${font_family};
+            font-weight: ${font_weight};
+            font-size: 0.75rem;
+        "#,
+            padding = theme.spacing(1),
+            background = theme.palette.secondary.clone(),
+            color = theme.palette.background_paper.clone(),
+            font_family = theme.typography.font_family.clone(),
+            font_weight = theme.typography.font_weight_medium
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::badge::BadgeState;
+
+    #[test]
+    fn badge_attributes_surface_display_value() {
+        let state = BadgeState::new(Some(5));
+        let render = render_badge(&state);
+        assert!(render.badge_attributes().iter().any(|(k, _)| k == "class"));
+        assert!(render
+            .badge_attributes()
+            .iter()
+            .any(|(k, v)| k == "data-badge-content" && v == "5"));
+    }
+}

--- a/crates/rustic-ui-material/src/chip.rs
+++ b/crates/rustic-ui-material/src/chip.rs
@@ -202,7 +202,7 @@ fn root_attributes(
     ));
     attrs.push((
         "data-component".into(),
-        crate::style_helpers::automation_id("chip", None, crate::style_helpers::EMPTY_SEGMENTS),
+        crate::style_helpers::component_marker("chip"),
     ));
     attrs.push(("data-visible".into(), state.is_visible().to_string()));
     attrs.push((
@@ -244,20 +244,21 @@ fn delete_attributes(
     state: &ChipState,
     delete_id: &str,
 ) -> Vec<(String, String)> {
-    let mut builder =
+    let builder =
         ChipDeleteAttributes::new(state).label(props.delete_label.as_deref().unwrap_or("Remove"));
 
-    let mut attrs = Vec::new();
-    attrs.push(("id".into(), delete_id.to_string()));
-    attrs.push(("type".into(), "button".into()));
-    attrs.push(("data-chip-slot".into(), "delete".into()));
-    attrs.push(("data-visible".into(), state.controls_visible().to_string()));
-    attrs.push((
-        "data-deletion-pending".into(),
-        state.deletion_pending().to_string(),
-    ));
-    attrs.push(("data-disabled".into(), state.disabled().to_string()));
-    attrs.push(("role".into(), builder.role().into()));
+    let mut attrs = vec![
+        ("id".into(), delete_id.to_string()),
+        ("type".into(), "button".into()),
+        ("data-chip-slot".into(), "delete".into()),
+        ("data-visible".into(), state.controls_visible().to_string()),
+        (
+            "data-deletion-pending".into(),
+            state.deletion_pending().to_string(),
+        ),
+        ("data-disabled".into(), state.disabled().to_string()),
+        ("role".into(), builder.role().into()),
+    ];
     let (hidden_key, hidden_value) = builder.hidden();
     attrs.push((hidden_key.into(), hidden_value.into()));
     if let Some((key, value)) = builder.aria_label() {

--- a/crates/rustic-ui-material/src/lib.rs
+++ b/crates/rustic-ui-material/src/lib.rs
@@ -22,7 +22,10 @@
 //! }
 //! ```
 
+pub mod accordion;
 pub mod app_bar;
+pub mod avatar;
+pub mod badge;
 pub mod r#box;
 pub mod button;
 pub mod card;
@@ -38,6 +41,7 @@ pub mod image_list;
 pub mod list;
 pub mod macros;
 pub mod menu;
+pub mod paper;
 pub mod radio;
 mod render_helpers;
 pub mod select;
@@ -52,16 +56,24 @@ pub mod table;
 pub mod tabs;
 pub mod text_field;
 pub mod tooltip;
+pub mod typography;
 
 pub use rustic_ui_styled_engine::Theme;
 
 pub use crate::r#box::{render_box, BoxAdapterProps, BoxRenderOutput};
+pub use accordion::{
+    render_accordion, AccordionAdapterProps, AccordionItemDescriptor, AccordionRenderOutput,
+};
+pub use avatar::{render_avatar, AvatarRenderOutput};
+pub use badge::{render_badge, BadgeRenderOutput};
 pub use container::{render_container, ContainerAdapterProps, ContainerRenderOutput};
 pub use divider::{render_divider, DividerAdapterProps, DividerRenderOutput};
 pub use grid::{render_grid, GridAdapterProps, GridRenderOutput};
 pub use hidden::{render_hidden, HiddenAdapterProps, HiddenRenderOutput};
 pub use image_list::{render_image_list, ImageListAdapterProps, ImageListRenderOutput};
+pub use paper::{render_paper, PaperRenderOutput};
 pub use stack::{render_stack, StackAdapterProps, StackRenderOutput};
+pub use typography::{render_typography, TypographyRenderOutput};
 
 /// Confirms that the crate links to `rustic_ui_styled_engine` and compiles.
 pub fn placeholder() {

--- a/crates/rustic-ui-material/src/list.rs
+++ b/crates/rustic-ui-material/src/list.rs
@@ -287,8 +287,19 @@ fn root_attributes(props: &ListProps, state: &ListState) -> Vec<(String, String)
             if props.selection_mode == SelectionMode::Multiple {
                 attrs.push(("aria-multiselectable".into(), "true".into()));
             }
-            if let Some(highlight) = state.highlighted() {
-                attrs.push(("aria-activedescendant".into(), item_id(props, highlight)));
+            let current_highlight = state.highlighted();
+            let fallback_highlight = if current_highlight.is_none() && !props.items.is_empty() {
+                Some(0)
+            } else {
+                None
+            };
+            if let Some(highlight) = current_highlight.or(fallback_highlight) {
+                let descendant_id = props
+                    .automation_id
+                    .as_deref()
+                    .map(|id| format!("{id}-option-{highlight}"))
+                    .unwrap_or_else(|| item_id(props, highlight));
+                attrs.push(("aria-activedescendant".into(), descendant_id));
             }
         }
     }

--- a/crates/rustic-ui-material/src/menu.rs
+++ b/crates/rustic-ui-material/src/menu.rs
@@ -162,7 +162,7 @@ fn root_attributes(
     ));
     attrs.push((
         "data-component".into(),
-        crate::style_helpers::automation_id("menu", None, crate::style_helpers::EMPTY_SEGMENTS),
+        crate::style_helpers::component_marker("menu"),
     ));
     let (open_key, open_value) = surface_meta.data_open();
     attrs.push((open_key.into(), open_value.into()));

--- a/crates/rustic-ui-material/src/paper.rs
+++ b/crates/rustic-ui-material/src/paper.rs
@@ -1,0 +1,98 @@
+//! Material renderer for the headless [`PaperState`](rustic_ui_headless::paper::PaperState).
+//!
+//! Surfaces convert the abstract elevation/variant metadata into CSS classes
+//! derived from the active [`Theme`](rustic_ui_styled_engine::Theme).  Enterprise
+//! adapters use the returned attributes to keep SSR and client renders in sync.
+
+use rustic_ui_headless::paper::{PaperState, PaperVariant};
+use rustic_ui_styled_engine::css_with_theme;
+
+use crate::style_helpers;
+
+/// Rendered output for a Paper surface.
+#[derive(Debug, Clone)]
+pub struct PaperRenderOutput {
+    attributes: Vec<(String, String)>,
+}
+
+impl PaperRenderOutput {
+    /// Attributes merged into the surface container.
+    pub fn attributes(&self) -> &[(String, String)] {
+        &self.attributes
+    }
+}
+
+/// Render the provided [`PaperState`] into deterministic attributes.
+pub fn render_paper(state: &PaperState) -> PaperRenderOutput {
+    let mut attrs: Vec<(String, String)> = state
+        .accessibility_attributes()
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+    for (key, value) in state.tokens() {
+        attrs.push((format!("data-paper-{}", key), value));
+    }
+
+    let theme_attrs = style_helpers::themed_attributes(paper_style(state.variant()), attrs);
+
+    PaperRenderOutput {
+        attributes: theme_attrs,
+    }
+}
+
+fn paper_style(variant: PaperVariant) -> rustic_ui_styled_engine::Style {
+    match variant {
+        PaperVariant::Elevated => css_with_theme!(
+            r#"
+            background-color: ${background};
+            color: ${text};
+            border-radius: ${radius}px;
+            box-shadow: ${shadow};
+            transition: box-shadow 160ms ease-in-out;
+        "#,
+            background = theme.palette.background_paper.clone(),
+            text = theme.palette.text_primary.clone(),
+            radius = theme.joy.radius,
+            shadow = theme.joy.shadow.surface.clone()
+        ),
+        PaperVariant::Outlined => css_with_theme!(
+            r#"
+            background-color: ${background};
+            color: ${text};
+            border-radius: ${radius}px;
+            border: 1px solid ${outline};
+        "#,
+            background = theme.palette.background_paper.clone(),
+            text = theme.palette.text_primary.clone(),
+            radius = theme.joy.radius,
+            outline = theme.palette.neutral.clone()
+        ),
+        PaperVariant::Plain => css_with_theme!(
+            r#"
+            background-color: transparent;
+            color: ${text};
+            border-radius: ${radius}px;
+        "#,
+            text = theme.palette.text_primary.clone(),
+            radius = theme.joy.radius
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::paper::PaperState;
+
+    #[test]
+    fn attributes_include_data_tokens_and_class() {
+        let state = PaperState::new(PaperVariant::Elevated).with_elevation(6);
+        let render = render_paper(&state);
+        let attrs = render.attributes();
+        assert!(attrs.iter().any(|(k, _)| k == "class"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == "data-paper-elevation" && v == "6"));
+    }
+}

--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -62,7 +62,7 @@ fn render_html(props: &RadioGroupProps, state: &RadioGroupState) -> String {
     selection_control::render_radio_group(
         themed_radio_group_style(),
         group_attrs,
-        || themed_radio_option_style(),
+        themed_radio_option_style,
         &options,
     )
 }

--- a/crates/rustic-ui-material/src/select.rs
+++ b/crates/rustic-ui-material/src/select.rs
@@ -156,7 +156,7 @@ fn root_attributes(
     ));
     attrs.push((
         "data-component".into(),
-        crate::style_helpers::automation_id("select", None, crate::style_helpers::EMPTY_SEGMENTS),
+        crate::style_helpers::component_marker("select"),
     ));
     attrs.push(("data-open".into(), state.is_open().to_string()));
     attrs.push((

--- a/crates/rustic-ui-material/src/style_helpers.rs
+++ b/crates/rustic-ui-material/src/style_helpers.rs
@@ -18,6 +18,17 @@ use rustic_ui_utils::{attributes_to_html, collect_attributes};
 pub(crate) const COMPONENT_PREFIX: &str = "rustic";
 pub(crate) const EMPTY_SEGMENTS: [&str; 0] = [];
 
+/// Marker string used by `data-component` attributes across Material renderers.
+///
+/// Historical automation suites expect the underscore separated format (for
+/// example `rustic_ui_chip`).  Keeping the helper centralised ensures new
+/// components follow the same convention while the newer automation ids may
+/// adopt hyphenated formats.
+#[must_use]
+pub(crate) fn component_marker(component: &str) -> String {
+    format!("rustic_ui_{}", sanitise(component).replace('-', "_"))
+}
+
 /// Consumes a [`Style`] and returns the scoped class name produced by the
 /// styled engine.
 ///
@@ -195,5 +206,11 @@ mod tests {
     fn automation_data_attr_excludes_user_segment() {
         let attr = automation_data_attr("tooltip", ["surface"]);
         assert_eq!(attr, "data-rustic-tooltip-surface");
+    }
+
+    #[test]
+    fn component_marker_preserves_legacy_format() {
+        assert_eq!(component_marker("chip"), "rustic_ui_chip");
+        assert_eq!(component_marker("table-row"), "rustic_ui_table_row");
     }
 }

--- a/crates/rustic-ui-material/src/table.rs
+++ b/crates/rustic-ui-material/src/table.rs
@@ -184,7 +184,7 @@ fn render_html(props: &TableProps, state: &ListState) -> String {
         vec![
             (
                 String::from("data-component"),
-                crate::style_helpers::automation_id("table", None, ["header-row"]),
+                crate::style_helpers::component_marker("table-header_row"),
             ),
             (
                 crate::style_helpers::automation_data_attr("table", ["header-row"]),
@@ -244,11 +244,7 @@ fn column_id(props: &TableProps, index: usize) -> String {
 
 fn row_id(props: &TableProps, index: usize) -> String {
     let segment = format!("row-{index}");
-    crate::style_helpers::automation_id(
-        "table",
-        props.automation_id.as_deref(),
-        &[segment.as_str()],
-    )
+    crate::style_helpers::automation_id("table", props.automation_id.as_deref(), [segment.as_str()])
 }
 
 fn cell_automation_id(props: &TableProps, row: usize, col: usize, column: &TableColumn) -> String {
@@ -257,14 +253,14 @@ fn cell_automation_id(props: &TableProps, row: usize, col: usize, column: &Table
         crate::style_helpers::automation_id(
             "table",
             props.automation_id.as_deref(),
-            &[id.as_str(), row_segment.as_str()],
+            [id.as_str(), row_segment.as_str()],
         )
     } else {
         let segment = format!("cell-{row}-{col}");
         crate::style_helpers::automation_id(
             "table",
             props.automation_id.as_deref(),
-            &[segment.as_str()],
+            [segment.as_str()],
         )
     }
 }
@@ -273,11 +269,7 @@ fn table_attributes(props: &TableProps, state: &ListState) -> Vec<(String, Strin
     let mut attrs = vec![
         (
             "data-component".to_string(),
-            crate::style_helpers::automation_id(
-                "table",
-                None,
-                crate::style_helpers::EMPTY_SEGMENTS,
-            ),
+            crate::style_helpers::component_marker("table"),
         ),
         (
             "data-density".to_string(),
@@ -298,11 +290,19 @@ fn table_attributes(props: &TableProps, state: &ListState) -> Vec<(String, Strin
             if props.selection_mode == SelectionMode::Multiple {
                 attrs.push(("aria-multiselectable".to_string(), String::from("true")));
             }
-            if let Some(highlight) = state.highlighted() {
-                attrs.push((
-                    "aria-activedescendant".to_string(),
-                    row_id(props, highlight),
-                ));
+            let current_highlight = state.highlighted();
+            let fallback_highlight = if current_highlight.is_none() && !props.rows.is_empty() {
+                Some(0)
+            } else {
+                None
+            };
+            if let Some(highlight) = current_highlight.or(fallback_highlight) {
+                let descendant_id = props
+                    .automation_id
+                    .as_deref()
+                    .map(|id| format!("{id}-row-{highlight}"))
+                    .unwrap_or_else(|| row_id(props, highlight));
+                attrs.push(("aria-activedescendant".to_string(), descendant_id));
             }
         }
     }

--- a/crates/rustic-ui-material/src/tooltip.rs
+++ b/crates/rustic-ui-material/src/tooltip.rs
@@ -195,41 +195,50 @@ fn root_attributes(
     trigger_id: &str,
     surface_id: &str,
 ) -> Vec<(String, String)> {
-    let mut attrs = Vec::new();
-    attrs.push(("id".into(), base_id.to_string()));
-    attrs.push((
-        crate::style_helpers::automation_data_attr("tooltip", ["id"]),
-        base_id.to_string(),
-    ));
-    attrs.push((
-        crate::style_helpers::automation_data_attr("tooltip", ["root"]),
-        crate::style_helpers::automation_id("tooltip", props.automation_id.as_deref(), ["root"]),
-    ));
-    attrs.push((
-        "data-component".into(),
-        crate::style_helpers::automation_id("tooltip", None, crate::style_helpers::EMPTY_SEGMENTS),
-    ));
-    attrs.push(("data-visible".into(), state.visible().to_string()));
-    attrs.push((
-        "data-interactive".into(),
-        state.config().interactive.to_string(),
-    ));
-    attrs.push((
-        "data-dismissible".into(),
-        state.config().dismissible.to_string(),
-    ));
-    attrs.push((
-        "data-portal-layer".into(),
-        portal.layer().as_str().to_string(),
-    ));
-    attrs.push(("data-trigger-id".into(), trigger_id.to_string()));
-    attrs.push(("data-surface-id".into(), surface_id.to_string()));
-    attrs.push(("data-portal-anchor".into(), portal.anchor_id()));
-    attrs.push(("data-portal-root".into(), portal.container_id()));
-    attrs.push((
-        crate::style_helpers::automation_data_attr("tooltip", ["portal"]),
-        crate::style_helpers::automation_id("tooltip", props.automation_id.as_deref(), ["popover"]),
-    ));
+    let attrs = vec![
+        ("id".into(), base_id.to_string()),
+        (
+            crate::style_helpers::automation_data_attr("tooltip", ["id"]),
+            base_id.to_string(),
+        ),
+        (
+            crate::style_helpers::automation_data_attr("tooltip", ["root"]),
+            crate::style_helpers::automation_id(
+                "tooltip",
+                props.automation_id.as_deref(),
+                ["root"],
+            ),
+        ),
+        (
+            "data-component".into(),
+            crate::style_helpers::component_marker("tooltip"),
+        ),
+        ("data-visible".into(), state.visible().to_string()),
+        (
+            "data-interactive".into(),
+            state.config().interactive.to_string(),
+        ),
+        (
+            "data-dismissible".into(),
+            state.config().dismissible.to_string(),
+        ),
+        (
+            "data-portal-layer".into(),
+            portal.layer().as_str().to_string(),
+        ),
+        ("data-trigger-id".into(), trigger_id.to_string()),
+        ("data-surface-id".into(), surface_id.to_string()),
+        ("data-portal-anchor".into(), portal.anchor_id()),
+        ("data-portal-root".into(), portal.container_id()),
+        (
+            crate::style_helpers::automation_data_attr("tooltip", ["portal"]),
+            crate::style_helpers::automation_id(
+                "tooltip",
+                props.automation_id.as_deref(),
+                ["popover"],
+            ),
+        ),
+    ];
     attrs
 }
 
@@ -264,7 +273,7 @@ fn trigger_attributes(
     attrs.push(("type".into(), "button".into()));
     attrs.push((
         "data-component".into(),
-        crate::style_helpers::automation_id("tooltip", None, ["trigger"]),
+        crate::style_helpers::component_marker("tooltip-trigger"),
     ));
     attrs.push(("data-visible".into(), state.visible().to_string()));
     attrs.push(("data-portal-anchor".into(), portal.anchor_id()));
@@ -300,7 +309,7 @@ fn surface_attributes(
     attrs.push((hidden_key.into(), hidden_value.into()));
     attrs.push((
         "data-component".into(),
-        crate::style_helpers::automation_id("tooltip", None, ["surface"]),
+        crate::style_helpers::component_marker("tooltip-surface"),
     ));
     attrs.push(("data-visible".into(), state.visible().to_string()));
     attrs.push((

--- a/crates/rustic-ui-material/src/typography.rs
+++ b/crates/rustic-ui-material/src/typography.rs
@@ -1,0 +1,120 @@
+//! Material renderer for headless typography state.
+//!
+//! The renderer maps variants to theme driven font sizes and exposes the
+//! semantic tag computed by the headless machine so SSR and client renders stay
+//! aligned.
+
+use rustic_ui_headless::typography::{TypographyState, TypographyVariant};
+use rustic_ui_styled_engine::css_with_theme;
+
+use crate::style_helpers;
+
+/// Render output for a typography element.
+#[derive(Debug, Clone)]
+pub struct TypographyRenderOutput {
+    tag: String,
+    attributes: Vec<(String, String)>,
+}
+
+impl TypographyRenderOutput {
+    /// HTML tag representing the semantic element.
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    /// Attributes attached to the rendered element.
+    pub fn attributes(&self) -> &[(String, String)] {
+        &self.attributes
+    }
+}
+
+/// Render the provided typography state.
+pub fn render_typography(state: &TypographyState) -> TypographyRenderOutput {
+    let mut attrs: Vec<(String, String)> = state
+        .accessibility_attributes()
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+    attrs.push((
+        "data-typography-variant".into(),
+        state.variant().as_str().into(),
+    ));
+
+    let style = typography_style(state.variant());
+    let attrs = style_helpers::themed_attributes(style, attrs);
+
+    TypographyRenderOutput {
+        tag: state.tag().to_string(),
+        attributes: attrs,
+    }
+}
+
+fn typography_style(variant: TypographyVariant) -> rustic_ui_styled_engine::Style {
+    css_with_theme!(
+        r#"
+        font-family: ${font_family};
+        font-weight: ${font_weight};
+        font-size: ${font_size}rem;
+        line-height: ${line_height};
+        margin: 0;
+    "#,
+        font_family = theme.typography.font_family.clone(),
+        font_weight = match variant {
+            TypographyVariant::H1 | TypographyVariant::H2 | TypographyVariant::H3 => {
+                theme.typography.font_weight_light
+            }
+            TypographyVariant::H4 | TypographyVariant::H5 | TypographyVariant::H6 => {
+                theme.typography.font_weight_regular
+            }
+            TypographyVariant::Subtitle1
+            | TypographyVariant::Subtitle2
+            | TypographyVariant::Body1
+            | TypographyVariant::Body2 => theme.typography.font_weight_regular,
+            TypographyVariant::Button => theme.typography.font_weight_medium,
+            TypographyVariant::Caption | TypographyVariant::Overline => {
+                theme.typography.font_weight_medium
+            }
+        },
+        font_size = match variant {
+            TypographyVariant::H1 => theme.typography.h1,
+            TypographyVariant::H2 => theme.typography.h2,
+            TypographyVariant::H3 => theme.typography.h3,
+            TypographyVariant::H4 => theme.typography.h4,
+            TypographyVariant::H5 => theme.typography.h5,
+            TypographyVariant::H6 => theme.typography.h6,
+            TypographyVariant::Subtitle1 => theme.typography.subtitle1,
+            TypographyVariant::Subtitle2 => theme.typography.subtitle2,
+            TypographyVariant::Body1 => theme.typography.body1,
+            TypographyVariant::Body2 => theme.typography.body2,
+            TypographyVariant::Button => theme.typography.button,
+            TypographyVariant::Caption => theme.typography.caption,
+            TypographyVariant::Overline => theme.typography.overline,
+        },
+        line_height = match variant {
+            TypographyVariant::Overline | TypographyVariant::Caption => 1.66,
+            TypographyVariant::Button => 1.75,
+            _ => theme.typography.line_height,
+        }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::typography::{TypographyState, TypographyVariant};
+
+    #[test]
+    fn render_attaches_variant_attribute() {
+        let state = TypographyState::new(TypographyVariant::H5).with_id("heading");
+        let render = render_typography(&state);
+        assert_eq!(render.tag(), "h5");
+        assert!(render
+            .attributes()
+            .iter()
+            .any(|(k, v)| k == "data-typography-variant" && v == "h5"));
+        assert!(render
+            .attributes()
+            .iter()
+            .any(|(k, v)| k == "id" && v == "heading"));
+    }
+}


### PR DESCRIPTION
## Summary
- add headless state machines for Paper, Avatar, Badge, and Typography primitives with ARIA helpers
- implement Material renderers for Accordion plus new surface and data-display widgets that consume shared styling tokens
- update existing Material helpers to expose legacy automation markers and improved accessibility defaults

## Testing
- cargo fmt
- cargo clippy -p rustic-ui-headless --no-deps
- cargo clippy -p rustic-ui-material --no-deps
- cargo test -p rustic-ui-headless
- cargo test -p rustic-ui-material

------
https://chatgpt.com/codex/tasks/task_e_68da90fd4d58832ebaac8b9d85017487