### PR TITLE
Add cross-framework headless overlay renderers

### DIFF
--- a/crates/rustic-ui-material/src/click_away.rs
+++ b/crates/rustic-ui-material/src/click_away.rs
@@ -1,0 +1,348 @@
+#![deny(missing_docs)]
+//! Click-away renderer primitives that wrap [`ClickAwayState`]
+//! instances from `rustic_ui_headless` and expose framework
+//! adapters mirroring the ergonomics of [`dialog`](crate::dialog)
+//! and [`drawer`](crate::drawer).
+//!
+//! The goal of this module is to make it effortless to bolt the
+//! pointer/focus detection logic onto existing surfaces without
+//! duplicating orchestration code. Every helper funnels through
+//! automation-friendly attribute builders so analytics pipelines,
+//! QA harnesses, and distributed telemetry collectors observe the
+//! exact same identifiers regardless of whether the consumer is
+//! running Yew, Leptos, Dioxus, Sycamore, or a server-side renderer.
+
+use rustic_ui_headless::click_away::{ClickAwayRootAttributes, ClickAwayState};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+
+/// Declarative overrides for the root boundary exposed by [`ClickAwayState`].
+///
+/// The struct intentionally mirrors the ergonomics of
+/// [`DialogSurfaceOptions`](crate::dialog::DialogSurfaceOptions) so the same
+/// orchestration layers can be re-used for modals, drawers, menus and any other
+/// overlay that relies on click-away dismissal.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ClickAwayBoundaryOptions {
+    /// Optional DOM identifier applied to the boundary element.
+    pub id: Option<String>,
+    /// Optional analytics marker propagated to `data-rustic-analytics-id`.
+    pub analytics_id: Option<String>,
+    /// Optional automation identifier surfaced via `data-automation-id`.
+    pub automation_id: Option<String>,
+}
+
+fn apply_boundary_options<'a>(
+    mut attrs: ClickAwayRootAttributes<'a>,
+    options: &'a ClickAwayBoundaryOptions,
+) -> ClickAwayRootAttributes<'a> {
+    if let Some(id) = &options.id {
+        attrs = attrs.id(id);
+    }
+    if let Some(analytics) = &options.analytics_id {
+        attrs = attrs.analytics_id(analytics);
+    }
+    attrs
+}
+
+/// Convert the root attribute builder into automation-friendly key/value pairs.
+///
+/// * `automation_fallback` lets orchestration layers derive deterministic
+///   automation identifiers when none are supplied via [`ClickAwayBoundaryOptions`].
+/// * The helper preserves the canonical `data-rustic-click-away` tuple emitted by
+///   the headless state so centralised event listeners continue to function.
+#[must_use]
+pub fn click_away_root_attributes(
+    attrs: ClickAwayRootAttributes<'_>,
+    automation_fallback: &str,
+    options: &ClickAwayBoundaryOptions,
+) -> Vec<(String, String)> {
+    let mut pairs = Vec::with_capacity(4);
+    let (controller_key, controller_value) = attrs.controller_attribute();
+    pairs.push((controller_key.into(), controller_value.into()));
+    if let Some((key, value)) = attrs.id_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.analytics_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    let automation_id = options
+        .automation_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(automation_fallback);
+    pairs.push(("data-automation-id".into(), automation_id.to_string()));
+    pairs
+}
+
+/// Render the click-away boundary into HTML so SSR frameworks can reuse the
+/// exact same automation identifiers as their CSR counterparts.
+#[must_use]
+pub fn render_click_away_boundary_html(
+    state: &ClickAwayState,
+    options: &ClickAwayBoundaryOptions,
+    automation_fallback: &str,
+    children: &str,
+) -> String {
+    let attrs = state.root_attributes();
+    let attrs = apply_boundary_options(attrs, options);
+    let pairs = click_away_root_attributes(attrs, automation_fallback, options);
+    crate::render_helpers::render_element_html("div", boundary_style(), pairs, children)
+}
+
+fn boundary_style() -> Style {
+    css_with_theme!(
+        r#"
+        position: relative;
+        display: block;
+        isolation: isolate;
+        &[data-automation-id]{
+            /* Provide a stable hook for scripted telemetry collectors */
+            contain: layout paint;
+        }
+        "#
+    )
+}
+
+/// Derive a deterministic automation identifier for dialog overlays.
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore",
+    feature = "react",
+))]
+#[must_use]
+pub fn dialog_click_away_automation(surface: &crate::dialog::DialogSurfaceOptions) -> String {
+    surface
+        .analytics_id
+        .as_deref()
+        .map(|id| format!("dialog::{id}::click-away"))
+        .unwrap_or_else(|| "dialog::click-away".into())
+}
+
+/// Derive a deterministic automation identifier for drawer overlays.
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore",
+    feature = "react",
+))]
+#[must_use]
+pub fn drawer_click_away_automation(props: &crate::drawer::DrawerProps<'_>) -> String {
+    props
+        .on_toggle_event
+        .map(|event| format!("drawer::{event}::click-away"))
+        .unwrap_or_else(|| "drawer::click-away".into())
+}
+
+// ---------------------------------------------------------------------------
+// Yew adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use std::rc::Rc;
+    use yew::prelude::*;
+
+    /// Yew component that decorates the subtree with click-away telemetry
+    /// attributes while delegating actual event handling to the shared
+    /// orchestration layer.
+    #[derive(Properties, Clone)]
+    pub struct ClickAwayBoundaryProps {
+        /// Shared state machine driving the click-away lifecycle. The caller is
+        /// responsible for mutating the state in response to pointer/focus
+        /// events; this component only renders attributes and automation hooks.
+        pub state: Rc<ClickAwayState>,
+        /// Optional attribute overrides controlling id/analytics/automation ids.
+        #[prop_or_default]
+        pub options: ClickAwayBoundaryOptions,
+        /// Deterministic fallback automation identifier when `options` omit it.
+        #[prop_or_else(|| AttrValue::from("rustic-ui::click-away"))]
+        pub automation_fallback: AttrValue,
+        /// Render subtree managed by the click-away detector.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    impl PartialEq for ClickAwayBoundaryProps {
+        fn eq(&self, other: &Self) -> bool {
+            Rc::ptr_eq(&self.state, &other.state)
+                && self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.children == other.children
+        }
+    }
+
+    #[function_component(ClickAwayBoundary)]
+    pub fn click_away_boundary(props: &ClickAwayBoundaryProps) -> Html {
+        // The component simply renders attributes; all pointer subscriptions are
+        // owned by whichever orchestration layer toggles `ClickAwayState`.
+        let attrs = props.state.root_attributes();
+        let attrs = apply_boundary_options(attrs, &props.options);
+        let pairs =
+            click_away_root_attributes(attrs, props.automation_fallback.as_str(), &props.options);
+        let mut node = html! { <div>{ for props.children.iter() }</div> };
+        if let Html::VTag(ref mut tag) = node {
+            for (key, value) in pairs {
+                tag.add_attribute(key, value);
+            }
+            tag.add_attribute(
+                "class",
+                crate::style_helpers::themed_class(boundary_style()),
+            );
+        }
+        node
+    }
+}
+
+#[cfg(feature = "yew")]
+pub use yew_impl::{ClickAwayBoundary, ClickAwayBoundaryProps};
+
+// ---------------------------------------------------------------------------
+// Leptos adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::prelude::*;
+    use std::sync::Arc;
+
+    /// Leptos adapter exposing identical knobs as the Yew variant while
+    /// returning a fully composed `View` so SSR/CSR remain consistent.
+    #[derive(Clone)]
+    pub struct ClickAwayBoundaryProps {
+        /// Shared click-away state machine tracked by the hosting application.
+        pub state: Arc<ClickAwayState>,
+        /// Optional attribute overrides controlling ids and analytics markers.
+        pub options: ClickAwayBoundaryOptions,
+        /// Fallback automation identifier when none is supplied in `options`.
+        pub automation_fallback: String,
+        /// Child nodes rendered inside the boundary.
+        pub children: Box<dyn Fn() -> View + Send + Sync>,
+    }
+
+    impl Default for ClickAwayBoundaryProps {
+        fn default() -> Self {
+            Self {
+                state: Arc::new(ClickAwayState::new()),
+                options: ClickAwayBoundaryOptions::default(),
+                automation_fallback: "rustic-ui::click-away".into(),
+                children: Box::new(|| View::empty()),
+            }
+        }
+    }
+
+    impl PartialEq for ClickAwayBoundaryProps {
+        fn eq(&self, other: &Self) -> bool {
+            Arc::ptr_eq(&self.state, &other.state)
+                && self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+        }
+    }
+
+    #[component]
+    pub fn ClickAwayBoundary(props: ClickAwayBoundaryProps) -> impl IntoView {
+        let attrs = props.state.root_attributes();
+        let attrs = apply_boundary_options(attrs, &props.options);
+        let pairs = click_away_root_attributes(attrs, &props.automation_fallback, &props.options);
+        let mut element = leptos::html::div();
+        element = element.class(crate::style_helpers::themed_class(boundary_style()));
+        for (key, value) in pairs {
+            element = element.attr(key, value);
+        }
+        element.child((props.children)()).into_view()
+    }
+}
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::{ClickAwayBoundary, ClickAwayBoundaryProps};
+
+// ---------------------------------------------------------------------------
+// Dioxus adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Properties consumed by the Dioxus renderer.
+    #[derive(Clone, PartialEq)]
+    pub struct ClickAwayBoundaryProps {
+        /// Click-away state machine mirrored from the application layer.
+        pub state: ClickAwayState,
+        /// Declarative overrides for analytics/automation metadata.
+        pub options: ClickAwayBoundaryOptions,
+        /// Fallback automation identifier when the options omit one.
+        pub automation_fallback: String,
+        /// Serialized children rendered inside the boundary.
+        pub children: String,
+    }
+
+    impl Default for ClickAwayBoundaryProps {
+        fn default() -> Self {
+            Self {
+                state: ClickAwayState::new(),
+                options: ClickAwayBoundaryOptions::default(),
+                automation_fallback: "rustic-ui::click-away".into(),
+                children: String::new(),
+            }
+        }
+    }
+
+    /// Render the boundary into HTML so Dioxus SSR and client renderers stay in
+    /// lockstep with the Yew/Leptos adapters.
+    pub fn render(props: &ClickAwayBoundaryProps) -> String {
+        render_click_away_boundary_html(
+            &props.state,
+            &props.options,
+            &props.automation_fallback,
+            &props.children,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sycamore adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Sycamore renderer mirroring the Dioxus properties for API consistency.
+    #[derive(Clone, PartialEq)]
+    pub struct ClickAwayBoundaryProps {
+        /// Click-away state machine mirrored from the application layer.
+        pub state: ClickAwayState,
+        /// Declarative overrides for analytics/automation metadata.
+        pub options: ClickAwayBoundaryOptions,
+        /// Fallback automation identifier when the options omit one.
+        pub automation_fallback: String,
+        /// Serialized children rendered inside the boundary.
+        pub children: String,
+    }
+
+    impl Default for ClickAwayBoundaryProps {
+        fn default() -> Self {
+            Self {
+                state: ClickAwayState::new(),
+                options: ClickAwayBoundaryOptions::default(),
+                automation_fallback: "rustic-ui::click-away".into(),
+                children: String::new(),
+            }
+        }
+    }
+
+    /// Render the boundary into HTML string form.
+    pub fn render(props: &ClickAwayBoundaryProps) -> String {
+        render_click_away_boundary_html(
+            &props.state,
+            &props.options,
+            &props.automation_fallback,
+            &props.children,
+        )
+    }
+}

--- a/crates/rustic-ui-material/src/collapsible.rs
+++ b/crates/rustic-ui-material/src/collapsible.rs
@@ -1,0 +1,572 @@
+#![deny(missing_docs)]
+//! Collapsible region renderers that decorate [`CollapsibleRegionState`]
+//! with automation identifiers and multi-framework adapters. The helpers
+//! keep orchestration consistent with [`accordion`](crate::accordion)
+//! while exposing telemetry hooks identical to our dialog/drawer stacks.
+
+use rustic_ui_headless::collapsible_region::{
+    CollapsibleContentAttributes, CollapsibleRegionState, CollapsibleTriggerAttributes,
+};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+
+/// Declarative overrides for the trigger element controlling the region.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CollapsibleTriggerOptions {
+    /// Optional id referenced by analytics pipelines.
+    pub analytics_id: Option<String>,
+    /// Optional `aria-controls` identifier.
+    pub controls: Option<String>,
+    /// Optional automation identifier surfaced via `data-automation-id`.
+    pub automation_id: Option<String>,
+}
+
+/// Declarative overrides for the collapsible region itself.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CollapsibleRegionOptions {
+    /// Optional DOM identifier referenced by triggers and tests.
+    pub id: Option<String>,
+    /// Optional analytics identifier mirrored to `data-rustic-analytics-id`.
+    pub analytics_id: Option<String>,
+    /// Optional automation identifier surfaced via `data-automation-id`.
+    pub automation_id: Option<String>,
+}
+
+fn apply_trigger_options<'a>(
+    mut attrs: CollapsibleTriggerAttributes<'a>,
+    options: &'a CollapsibleTriggerOptions,
+) -> CollapsibleTriggerAttributes<'a> {
+    if let Some(controls) = &options.controls {
+        attrs = attrs.controls(controls);
+    }
+    if let Some(analytics) = &options.analytics_id {
+        attrs = attrs.analytics_id(analytics);
+    }
+    attrs
+}
+
+fn apply_region_options<'a>(
+    mut attrs: CollapsibleContentAttributes<'a>,
+    options: &'a CollapsibleRegionOptions,
+) -> CollapsibleContentAttributes<'a> {
+    if let Some(id) = &options.id {
+        attrs = attrs.id(id);
+    }
+    if let Some(analytics) = &options.analytics_id {
+        attrs = attrs.analytics_id(analytics);
+    }
+    attrs
+}
+
+/// Convert trigger attributes into automation-friendly key/value pairs.
+#[must_use]
+pub fn collapsible_trigger_attributes(
+    attrs: CollapsibleTriggerAttributes<'_>,
+    options: &CollapsibleTriggerOptions,
+    automation_fallback: &str,
+) -> Vec<(String, String)> {
+    let attrs = attrs.as_pairs();
+    let mut pairs = Vec::with_capacity(attrs.len() + 1);
+    for (key, value) in attrs {
+        pairs.push((key.into(), value));
+    }
+    let automation = options
+        .automation_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(automation_fallback);
+    pairs.push(("data-automation-id".into(), automation.to_string()));
+    pairs
+}
+
+/// Convert region attributes into automation-friendly key/value pairs.
+#[must_use]
+pub fn collapsible_region_attributes(
+    attrs: CollapsibleContentAttributes<'_>,
+    options: &CollapsibleRegionOptions,
+    automation_fallback: &str,
+) -> Vec<(String, String)> {
+    let attrs = attrs.as_pairs();
+    let mut pairs = Vec::with_capacity(attrs.len() + 1);
+    for (key, value) in attrs {
+        pairs.push((key.into(), value));
+    }
+    let automation = options
+        .automation_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(automation_fallback);
+    pairs.push(("data-automation-id".into(), automation.to_string()));
+    pairs
+}
+
+fn trigger_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        background: transparent;
+        border: none;
+        padding: ${padding};
+        cursor: pointer;
+        font: inherit;
+        color: inherit;
+        &[data-hidden="true"] { opacity: 0.6; }
+        "#,
+        padding = format!("{}px", theme.spacing(2)),
+    )
+}
+
+fn region_style() -> Style {
+    css_with_theme!(
+        r#"
+        overflow: hidden;
+        transition: height 200ms ease, opacity 200ms ease;
+        &[data-hidden="true"] {
+            height: 0;
+            opacity: 0;
+            visibility: hidden;
+        }
+        &:not([data-hidden="true"]) {
+            opacity: 1;
+            visibility: visible;
+        }
+        "#
+    )
+}
+
+/// Render the trigger as HTML for SSR pipelines.
+#[must_use]
+pub fn render_collapsible_trigger_html(
+    state: &CollapsibleRegionState,
+    options: &CollapsibleTriggerOptions,
+    automation_fallback: &str,
+    label: &str,
+) -> String {
+    let attrs = state.trigger_attributes();
+    let attrs = apply_trigger_options(attrs, options);
+    let pairs = collapsible_trigger_attributes(attrs, options, automation_fallback);
+    crate::render_helpers::render_element_html("button", trigger_style(), pairs, label)
+}
+
+/// Render the collapsible region as HTML for SSR pipelines.
+#[must_use]
+pub fn render_collapsible_region_html(
+    state: &CollapsibleRegionState,
+    options: &CollapsibleRegionOptions,
+    automation_fallback: &str,
+    children: &str,
+) -> String {
+    let attrs = state.region_attributes();
+    let attrs = apply_region_options(attrs, options);
+    let pairs = collapsible_region_attributes(attrs, options, automation_fallback);
+    crate::render_helpers::render_element_html("div", region_style(), pairs, children)
+}
+
+// ---------------------------------------------------------------------------
+// Yew adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use std::rc::Rc;
+    use yew::prelude::*;
+
+    /// Yew trigger component. Event listeners remain the responsibility of the
+    /// hosting accordion or disclosure widget; this wrapper simply mirrors
+    /// attributes and telemetry hooks so orchestration layers stay centralised.
+    #[derive(Properties, Clone)]
+    pub struct CollapsibleTriggerProps {
+        /// Shared region state machine.
+        pub state: Rc<CollapsibleRegionState>,
+        /// Optional attribute overrides.
+        #[prop_or_default]
+        pub options: CollapsibleTriggerOptions,
+        /// Fallback automation identifier when options omit one.
+        #[prop_or_else(|| AttrValue::from("rustic-ui::collapsible-trigger"))]
+        pub automation_fallback: AttrValue,
+        /// Optional custom class merged with the themed baseline.
+        #[prop_or_default]
+        pub class: Option<AttrValue>,
+        /// Trigger label children.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    impl PartialEq for CollapsibleTriggerProps {
+        fn eq(&self, other: &Self) -> bool {
+            Rc::ptr_eq(&self.state, &other.state)
+                && self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.class == other.class
+                && self.children == other.children
+        }
+    }
+
+    #[function_component(CollapsibleTrigger)]
+    pub fn collapsible_trigger(props: &CollapsibleTriggerProps) -> Html {
+        let attrs = props.state.trigger_attributes();
+        let attrs = apply_trigger_options(attrs, &props.options);
+        let pairs = collapsible_trigger_attributes(
+            attrs,
+            &props.options,
+            props.automation_fallback.as_str(),
+        );
+        let themed = crate::style_helpers::themed_class(trigger_style());
+        let class = match &props.class {
+            Some(custom) if !custom.is_empty() => format!("{themed} {custom}"),
+            _ => themed,
+        };
+        let mut node =
+            html! { <button type="button" class={class}>{ for props.children.iter() }</button> };
+        if let Html::VTag(ref mut tag) = node {
+            for (key, value) in pairs {
+                tag.add_attribute(key, value);
+            }
+        }
+        node
+    }
+
+    /// Yew region component mirroring the trigger API surface.
+    #[derive(Properties, Clone)]
+    pub struct CollapsibleRegionProps {
+        /// Shared region state machine.
+        pub state: Rc<CollapsibleRegionState>,
+        /// Optional attribute overrides.
+        #[prop_or_default]
+        pub options: CollapsibleRegionOptions,
+        /// Fallback automation identifier when options omit one.
+        #[prop_or_else(|| AttrValue::from("rustic-ui::collapsible-region"))]
+        pub automation_fallback: AttrValue,
+        /// Optional custom class merged with the themed baseline.
+        #[prop_or_default]
+        pub class: Option<AttrValue>,
+        /// Region contents.
+        #[prop_or_default]
+        pub children: Children,
+    }
+
+    impl PartialEq for CollapsibleRegionProps {
+        fn eq(&self, other: &Self) -> bool {
+            Rc::ptr_eq(&self.state, &other.state)
+                && self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.class == other.class
+                && self.children == other.children
+        }
+    }
+
+    #[function_component(CollapsibleRegion)]
+    pub fn collapsible_region(props: &CollapsibleRegionProps) -> Html {
+        let attrs = props.state.region_attributes();
+        let attrs = apply_region_options(attrs, &props.options);
+        let pairs = collapsible_region_attributes(
+            attrs,
+            &props.options,
+            props.automation_fallback.as_str(),
+        );
+        let themed = crate::style_helpers::themed_class(region_style());
+        let class = match &props.class {
+            Some(custom) if !custom.is_empty() => format!("{themed} {custom}"),
+            _ => themed,
+        };
+        let mut node = html! { <div class={class}>{ for props.children.iter() }</div> };
+        if let Html::VTag(ref mut tag) = node {
+            for (key, value) in pairs {
+                tag.add_attribute(key, value);
+            }
+        }
+        node
+    }
+}
+
+#[cfg(feature = "yew")]
+pub use yew_impl::{
+    CollapsibleRegion, CollapsibleRegionProps, CollapsibleTrigger, CollapsibleTriggerProps,
+};
+
+// ---------------------------------------------------------------------------
+// Leptos adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::prelude::*;
+    use std::sync::Arc;
+
+    /// Leptos variant of [`CollapsibleTrigger`].
+    #[derive(Clone)]
+    pub struct CollapsibleTriggerProps {
+        /// Shared region state machine.
+        pub state: Arc<CollapsibleRegionState>,
+        /// Attribute overrides.
+        pub options: CollapsibleTriggerOptions,
+        /// Fallback automation identifier.
+        pub automation_fallback: String,
+        /// Optional custom class appended to the themed baseline.
+        pub class: Option<String>,
+        /// Trigger children view factory.
+        pub children: Box<dyn Fn() -> View + Send + Sync>,
+    }
+
+    impl Default for CollapsibleTriggerProps {
+        fn default() -> Self {
+            Self {
+                state: Arc::new(CollapsibleRegionState::uncontrolled(false)),
+                options: CollapsibleTriggerOptions::default(),
+                automation_fallback: "rustic-ui::collapsible-trigger".into(),
+                class: None,
+                children: Box::new(|| View::empty()),
+            }
+        }
+    }
+
+    impl PartialEq for CollapsibleTriggerProps {
+        fn eq(&self, other: &Self) -> bool {
+            Arc::ptr_eq(&self.state, &other.state)
+                && self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.class == other.class
+        }
+    }
+
+    #[component]
+    pub fn CollapsibleTrigger(props: CollapsibleTriggerProps) -> impl IntoView {
+        let attrs = props.state.trigger_attributes();
+        let attrs = super::apply_trigger_options(attrs, &props.options);
+        let pairs = super::collapsible_trigger_attributes(
+            attrs,
+            &props.options,
+            &props.automation_fallback,
+        );
+        let themed = crate::style_helpers::themed_class(super::trigger_style());
+        let class = props
+            .class
+            .as_ref()
+            .map(|custom| format!("{themed} {custom}"))
+            .unwrap_or(themed);
+        let mut element = leptos::html::button().attr("type", "button");
+        element = element.class(class);
+        for (key, value) in pairs {
+            element = element.attr(key, value);
+        }
+        element.child((props.children)()).into_view()
+    }
+
+    /// Leptos variant of the collapsible region wrapper.
+    #[derive(Clone)]
+    pub struct CollapsibleRegionProps {
+        /// Shared region state machine.
+        pub state: Arc<CollapsibleRegionState>,
+        /// Attribute overrides.
+        pub options: CollapsibleRegionOptions,
+        /// Fallback automation identifier.
+        pub automation_fallback: String,
+        /// Optional custom class appended to the themed baseline.
+        pub class: Option<String>,
+        /// Region children view factory.
+        pub children: Box<dyn Fn() -> View + Send + Sync>,
+    }
+
+    impl Default for CollapsibleRegionProps {
+        fn default() -> Self {
+            Self {
+                state: Arc::new(CollapsibleRegionState::uncontrolled(false)),
+                options: CollapsibleRegionOptions::default(),
+                automation_fallback: "rustic-ui::collapsible-region".into(),
+                class: None,
+                children: Box::new(|| View::empty()),
+            }
+        }
+    }
+
+    impl PartialEq for CollapsibleRegionProps {
+        fn eq(&self, other: &Self) -> bool {
+            Arc::ptr_eq(&self.state, &other.state)
+                && self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.class == other.class
+        }
+    }
+
+    #[component]
+    pub fn CollapsibleRegion(props: CollapsibleRegionProps) -> impl IntoView {
+        let attrs = props.state.region_attributes();
+        let attrs = super::apply_region_options(attrs, &props.options);
+        let pairs =
+            super::collapsible_region_attributes(attrs, &props.options, &props.automation_fallback);
+        let themed = crate::style_helpers::themed_class(super::region_style());
+        let class = props
+            .class
+            .as_ref()
+            .map(|custom| format!("{themed} {custom}"))
+            .unwrap_or(themed);
+        let mut element = leptos::html::div().class(class);
+        for (key, value) in pairs {
+            element = element.attr(key, value);
+        }
+        element.child((props.children)()).into_view()
+    }
+}
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::{
+    CollapsibleRegion, CollapsibleRegionProps, CollapsibleTrigger, CollapsibleTriggerProps,
+};
+
+// ---------------------------------------------------------------------------
+// Dioxus adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Properties consumed by the Dioxus trigger renderer.
+    #[derive(Clone, PartialEq)]
+    pub struct CollapsibleTriggerProps {
+        /// Region state machine mirrored from the controller.
+        pub state: CollapsibleRegionState,
+        /// Attribute overrides.
+        pub options: CollapsibleTriggerOptions,
+        /// Fallback automation identifier.
+        pub automation_fallback: String,
+        /// Trigger children HTML.
+        pub children: String,
+    }
+
+    impl Default for CollapsibleTriggerProps {
+        fn default() -> Self {
+            Self {
+                state: CollapsibleRegionState::uncontrolled(false),
+                options: CollapsibleTriggerOptions::default(),
+                automation_fallback: "rustic-ui::collapsible-trigger".into(),
+                children: String::new(),
+            }
+        }
+    }
+
+    /// Render the trigger into HTML.
+    pub fn render_trigger(props: &CollapsibleTriggerProps) -> String {
+        super::render_collapsible_trigger_html(
+            &props.state,
+            &props.options,
+            &props.automation_fallback,
+            &props.children,
+        )
+    }
+
+    /// Properties consumed by the Dioxus region renderer.
+    #[derive(Clone, PartialEq)]
+    pub struct CollapsibleRegionProps {
+        /// Region state machine mirrored from the controller.
+        pub state: CollapsibleRegionState,
+        /// Attribute overrides.
+        pub options: CollapsibleRegionOptions,
+        /// Fallback automation identifier.
+        pub automation_fallback: String,
+        /// Region children HTML.
+        pub children: String,
+    }
+
+    impl Default for CollapsibleRegionProps {
+        fn default() -> Self {
+            Self {
+                state: CollapsibleRegionState::uncontrolled(false),
+                options: CollapsibleRegionOptions::default(),
+                automation_fallback: "rustic-ui::collapsible-region".into(),
+                children: String::new(),
+            }
+        }
+    }
+
+    /// Render the region into HTML.
+    pub fn render_region(props: &CollapsibleRegionProps) -> String {
+        super::render_collapsible_region_html(
+            &props.state,
+            &props.options,
+            &props.automation_fallback,
+            &props.children,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sycamore adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Sycamore trigger renderer properties.
+    #[derive(Clone, PartialEq)]
+    pub struct CollapsibleTriggerProps {
+        /// Region state machine mirrored from the controller.
+        pub state: CollapsibleRegionState,
+        /// Attribute overrides.
+        pub options: CollapsibleTriggerOptions,
+        /// Fallback automation identifier.
+        pub automation_fallback: String,
+        /// Trigger children HTML.
+        pub children: String,
+    }
+
+    impl Default for CollapsibleTriggerProps {
+        fn default() -> Self {
+            Self {
+                state: CollapsibleRegionState::uncontrolled(false),
+                options: CollapsibleTriggerOptions::default(),
+                automation_fallback: "rustic-ui::collapsible-trigger".into(),
+                children: String::new(),
+            }
+        }
+    }
+
+    /// Render the trigger into HTML.
+    pub fn render_trigger(props: &CollapsibleTriggerProps) -> String {
+        super::render_collapsible_trigger_html(
+            &props.state,
+            &props.options,
+            &props.automation_fallback,
+            &props.children,
+        )
+    }
+
+    /// Sycamore region renderer properties.
+    #[derive(Clone, PartialEq)]
+    pub struct CollapsibleRegionProps {
+        /// Region state machine mirrored from the controller.
+        pub state: CollapsibleRegionState,
+        /// Attribute overrides.
+        pub options: CollapsibleRegionOptions,
+        /// Fallback automation identifier.
+        pub automation_fallback: String,
+        /// Region children HTML.
+        pub children: String,
+    }
+
+    impl Default for CollapsibleRegionProps {
+        fn default() -> Self {
+            Self {
+                state: CollapsibleRegionState::uncontrolled(false),
+                options: CollapsibleRegionOptions::default(),
+                automation_fallback: "rustic-ui::collapsible-region".into(),
+                children: String::new(),
+            }
+        }
+    }
+
+    /// Render the region into HTML.
+    pub fn render_region(props: &CollapsibleRegionProps) -> String {
+        super::render_collapsible_region_html(
+            &props.state,
+            &props.options,
+            &props.automation_fallback,
+            &props.children,
+        )
+    }
+}

--- a/crates/rustic-ui-material/src/focus_trap.rs
+++ b/crates/rustic-ui-material/src/focus_trap.rs
@@ -1,0 +1,318 @@
+#![deny(missing_docs)]
+//! Focus trap renderers that decorate the headless [`FocusTrapState`]
+//! with automation identifiers and framework adapters. The helpers
+//! intentionally mirror the ergonomics of [`dialog`](crate::dialog)
+//! because most enterprise overlays compose a dialog surface with
+//! sentinels on either side to keep keyboard users within the modal
+//! while telemetry systems observe focus churn.
+
+use rustic_ui_headless::focus_trap::{FocusTrapSentinelAttributes, FocusTrapState};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+
+/// Enumerates the sentinel nodes that bookend a focus trap.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FocusTrapSentinelKind {
+    /// Sentinel rendered before the tabbable content.
+    Start,
+    /// Sentinel rendered after the tabbable content.
+    End,
+}
+
+impl FocusTrapSentinelKind {
+    fn automation_suffix(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::End => "end",
+        }
+    }
+}
+
+/// Optional overrides shared by both sentinels.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct FocusTrapSentinelOptions {
+    /// Optional automation prefix mirrored to `data-automation-id`.
+    pub automation_prefix: Option<String>,
+}
+
+/// Convert a sentinel attribute builder into automation-friendly pairs.
+#[must_use]
+pub fn focus_trap_sentinel_attributes(
+    attrs: FocusTrapSentinelAttributes<'_>,
+    kind: FocusTrapSentinelKind,
+    options: &FocusTrapSentinelOptions,
+    fallback_prefix: &str,
+) -> Vec<(String, String)> {
+    let mut pairs = Vec::with_capacity(3);
+    let (key, value) = attrs.controller_attribute();
+    pairs.push((key.into(), value));
+    if let Some((key, value)) = attrs.analytics_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    let prefix = options
+        .automation_prefix
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback_prefix);
+    pairs.push((
+        "data-automation-id".into(),
+        format!("{prefix}::focus-trap-{}", kind.automation_suffix()),
+    ));
+    pairs
+}
+
+fn sentinel_style() -> Style {
+    css_with_theme!(
+        r#"
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        border: 0;
+        clip: rect(0, 0, 0, 0);
+        overflow: hidden;
+        /* Sentinels should never steal layout real estate yet must remain */
+        /* discoverable for analytics, hence we isolate them visually. */
+        &[data-automation-id] { opacity: 0; }
+        "#
+    )
+}
+
+/// Render a sentinel as HTML so SSR retains the automation markers.
+#[must_use]
+pub fn render_focus_trap_sentinel_html(
+    state: &FocusTrapState,
+    kind: FocusTrapSentinelKind,
+    options: &FocusTrapSentinelOptions,
+    fallback_prefix: &str,
+) -> String {
+    let attrs = match kind {
+        FocusTrapSentinelKind::Start => state.start_sentinel_attributes(),
+        FocusTrapSentinelKind::End => state.end_sentinel_attributes(),
+    };
+    let pairs = focus_trap_sentinel_attributes(attrs, kind, options, fallback_prefix);
+    crate::render_helpers::render_element_html("span", sentinel_style(), pairs, "")
+}
+
+// ---------------------------------------------------------------------------
+// Yew adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "yew")]
+mod yew_impl {
+    use super::*;
+    use std::rc::Rc;
+    use yew::prelude::*;
+
+    /// Yew component rendering a focus trap sentinel.
+    #[derive(Properties, Clone)]
+    pub struct FocusTrapSentinelProps {
+        /// Shared focus trap state machine. The hosting overlay owns lifecycle
+        /// transitions (registering focus, rebuilding node lists, etc.) while
+        /// this adapter mirrors the analytics attributes.
+        pub state: Rc<FocusTrapState>,
+        /// Whether this sentinel sits before or after the tabbable content.
+        pub kind: FocusTrapSentinelKind,
+        /// Optional automation prefix. When omitted the component falls back to
+        /// the dialog automation prefix so telemetry streams remain stable.
+        #[prop_or_default]
+        pub options: FocusTrapSentinelOptions,
+        /// Fallback automation prefix used when `options.automation_prefix` is empty.
+        #[prop_or_else(|| AttrValue::from("dialog"))]
+        pub fallback_prefix: AttrValue,
+    }
+
+    impl PartialEq for FocusTrapSentinelProps {
+        fn eq(&self, other: &Self) -> bool {
+            Rc::ptr_eq(&self.state, &other.state)
+                && self.kind == other.kind
+                && self.options == other.options
+                && self.fallback_prefix == other.fallback_prefix
+        }
+    }
+
+    #[function_component(FocusTrapSentinel)]
+    pub fn focus_trap_sentinel(props: &FocusTrapSentinelProps) -> Html {
+        // Sentinels never subscribe to DOM events directly. Instead the overlay
+        // listens for focus/keyboard changes and mutates `FocusTrapState` which
+        // keeps teardown predictable during dialog unmounts.
+        let attrs = match props.kind {
+            FocusTrapSentinelKind::Start => props.state.start_sentinel_attributes(),
+            FocusTrapSentinelKind::End => props.state.end_sentinel_attributes(),
+        };
+        let pairs = focus_trap_sentinel_attributes(
+            attrs,
+            props.kind,
+            &props.options,
+            props.fallback_prefix.as_str(),
+        );
+        let mut node = html! { <span tabindex="0" aria-hidden="true"></span> };
+        if let Html::VTag(ref mut tag) = node {
+            tag.add_attribute(
+                "class",
+                crate::style_helpers::themed_class(sentinel_style()),
+            );
+            for (key, value) in pairs {
+                tag.add_attribute(key, value);
+            }
+        }
+        node
+    }
+}
+
+#[cfg(feature = "yew")]
+pub use yew_impl::{FocusTrapSentinel, FocusTrapSentinelProps};
+
+// ---------------------------------------------------------------------------
+// Leptos adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "leptos")]
+mod leptos_impl {
+    use super::*;
+    use leptos::prelude::*;
+    use std::sync::Arc;
+
+    /// Leptos sentinel component mirroring the Yew API surface.
+    #[derive(Clone)]
+    pub struct FocusTrapSentinelProps {
+        /// Shared focus trap state machine managed by the overlay controller.
+        pub state: Arc<FocusTrapState>,
+        /// Sentinel position relative to the tabbable content.
+        pub kind: FocusTrapSentinelKind,
+        /// Optional automation prefix overriding the fallback.
+        pub options: FocusTrapSentinelOptions,
+        /// Fallback automation prefix when the options omit one.
+        pub fallback_prefix: String,
+    }
+
+    impl Default for FocusTrapSentinelProps {
+        fn default() -> Self {
+            Self {
+                state: Arc::new(FocusTrapState::new(true)),
+                kind: FocusTrapSentinelKind::Start,
+                options: FocusTrapSentinelOptions::default(),
+                fallback_prefix: "dialog".into(),
+            }
+        }
+    }
+
+    impl PartialEq for FocusTrapSentinelProps {
+        fn eq(&self, other: &Self) -> bool {
+            Arc::ptr_eq(&self.state, &other.state)
+                && self.kind == other.kind
+                && self.options == other.options
+                && self.fallback_prefix == other.fallback_prefix
+        }
+    }
+
+    #[component]
+    pub fn FocusTrapSentinel(props: FocusTrapSentinelProps) -> impl IntoView {
+        let attrs = match props.kind {
+            FocusTrapSentinelKind::Start => props.state.start_sentinel_attributes(),
+            FocusTrapSentinelKind::End => props.state.end_sentinel_attributes(),
+        };
+        let pairs = focus_trap_sentinel_attributes(
+            attrs,
+            props.kind,
+            &props.options,
+            &props.fallback_prefix,
+        );
+        let mut element = leptos::html::span().attr("tabindex", "0");
+        element = element.attr("aria-hidden", "true");
+        element = element.class(crate::style_helpers::themed_class(sentinel_style()));
+        for (key, value) in pairs {
+            element = element.attr(key, value);
+        }
+        element.into_view()
+    }
+}
+
+#[cfg(feature = "leptos")]
+pub use leptos_impl::{FocusTrapSentinel, FocusTrapSentinelProps};
+
+// ---------------------------------------------------------------------------
+// Dioxus adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "dioxus")]
+pub mod dioxus {
+    use super::*;
+
+    /// Properties for the Dioxus sentinel renderer.
+    #[derive(Clone, PartialEq)]
+    pub struct FocusTrapSentinelProps {
+        /// Focus trap state machine mirrored from the controller.
+        pub state: FocusTrapState,
+        /// Sentinel position relative to the tabbable content.
+        pub kind: FocusTrapSentinelKind,
+        /// Optional automation prefix overriding the fallback.
+        pub options: FocusTrapSentinelOptions,
+        /// Fallback automation prefix when the options omit one.
+        pub fallback_prefix: String,
+    }
+
+    impl Default for FocusTrapSentinelProps {
+        fn default() -> Self {
+            Self {
+                state: FocusTrapState::new(true),
+                kind: FocusTrapSentinelKind::Start,
+                options: FocusTrapSentinelOptions::default(),
+                fallback_prefix: "dialog".into(),
+            }
+        }
+    }
+
+    /// Render the sentinel into HTML.
+    pub fn render(props: &FocusTrapSentinelProps) -> String {
+        render_focus_trap_sentinel_html(
+            &props.state,
+            props.kind,
+            &props.options,
+            &props.fallback_prefix,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sycamore adapter
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "sycamore")]
+pub mod sycamore {
+    use super::*;
+
+    /// Properties for the Sycamore sentinel renderer mirroring the Dioxus API.
+    #[derive(Clone, PartialEq)]
+    pub struct FocusTrapSentinelProps {
+        /// Focus trap state machine mirrored from the controller.
+        pub state: FocusTrapState,
+        /// Sentinel position relative to the tabbable content.
+        pub kind: FocusTrapSentinelKind,
+        /// Optional automation prefix overriding the fallback.
+        pub options: FocusTrapSentinelOptions,
+        /// Fallback automation prefix when the options omit one.
+        pub fallback_prefix: String,
+    }
+
+    impl Default for FocusTrapSentinelProps {
+        fn default() -> Self {
+            Self {
+                state: FocusTrapState::new(true),
+                kind: FocusTrapSentinelKind::Start,
+                options: FocusTrapSentinelOptions::default(),
+                fallback_prefix: "dialog".into(),
+            }
+        }
+    }
+
+    /// Render the sentinel into HTML.
+    pub fn render(props: &FocusTrapSentinelProps) -> String {
+        render_focus_trap_sentinel_html(
+            &props.state,
+            props.kind,
+            &props.options,
+            &props.fallback_prefix,
+        )
+    }
+}

--- a/crates/rustic-ui-material/src/lib.rs
+++ b/crates/rustic-ui-material/src/lib.rs
@@ -37,10 +37,13 @@ pub mod checkbox;
 pub mod chip;
 #[cfg(feature = "progress")]
 pub mod circular_progress;
+pub mod click_away;
+pub mod collapsible;
 pub mod container;
 pub mod dialog;
 pub mod divider;
 pub mod drawer;
+pub mod focus_trap;
 #[cfg(feature = "forms")]
 pub mod form_control;
 pub mod grid;
@@ -90,8 +93,19 @@ pub use badge::{render_badge, BadgeRenderOutput};
 pub use circular_progress::{
     render_circular_progress, CircularProgressAdapterProps, CircularProgressRenderOutput,
 };
+pub use click_away::{
+    click_away_root_attributes, render_click_away_boundary_html, ClickAwayBoundaryOptions,
+};
+pub use collapsible::{
+    collapsible_region_attributes, collapsible_trigger_attributes, render_collapsible_region_html,
+    render_collapsible_trigger_html, CollapsibleRegionOptions, CollapsibleTriggerOptions,
+};
 pub use container::{render_container, ContainerAdapterProps, ContainerRenderOutput};
 pub use divider::{render_divider, DividerAdapterProps, DividerRenderOutput};
+pub use focus_trap::{
+    focus_trap_sentinel_attributes, render_focus_trap_sentinel_html, FocusTrapSentinelKind,
+    FocusTrapSentinelOptions,
+};
 #[cfg(feature = "forms")]
 pub use form_control::{render_form_control, FormControlAdapterProps, FormControlRenderOutput};
 pub use grid::{render_grid, GridAdapterProps, GridRenderOutput};
@@ -112,6 +126,15 @@ pub use skeleton::{render_skeleton, SkeletonAdapterProps, SkeletonRenderOutput};
 pub use slider::{render_slider, SliderAdapterProps, SliderRenderOutput};
 pub use stack::{render_stack, StackAdapterProps, StackRenderOutput};
 pub use typography::{render_typography, TypographyRenderOutput};
+
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore",
+    feature = "react",
+))]
+pub use click_away::{dialog_click_away_automation, drawer_click_away_automation};
 
 /// Confirms that the crate links to `rustic_ui_styled_engine` and compiles.
 pub fn placeholder() {


### PR DESCRIPTION
## Summary
- add click-away renderers with automation-aware helpers and adapters for all supported UI frameworks
- expose focus-trap sentinel renderers that integrate with existing modal infrastructure
- provide collapsible trigger/region helpers plus framework components and re-export new modules from the crate root

## Testing
- cargo test -p rustic-ui-material

------
https://chatgpt.com/codex/tasks/task_e_68dac2f90324832e908b738b2c4576ae