### PR TITLE
Add telemetry hooks to click-away and collapsible adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,6 +3401,7 @@ dependencies = [
  "rustic-ui-utils",
  "serde_json",
  "stylist",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",

--- a/crates/rustic-ui-material/Cargo.toml
+++ b/crates/rustic-ui-material/Cargo.toml
@@ -23,6 +23,7 @@ wasm-bindgen = { workspace = true, optional = true }
 stylist = { version = "0.13", default-features = false, features = ["macros", "parser"] }
 rustic-ui-utils = { path = "../rustic-ui-utils", version = "0.1.0" }
 web-sys = { workspace = true, optional = true }
+tracing = "0.1"
 
 [dev-dependencies]
 wasm-bindgen-test.workspace = true

--- a/crates/rustic-ui-material/src/app_bar.rs
+++ b/crates/rustic-ui-material/src/app_bar.rs
@@ -175,7 +175,10 @@ pub mod dioxus {
         // stay aligned with the declarative front-end integrations.
         let attr_string = crate::style_helpers::themed_attributes_html(
             app_bar_style(&theme, props.color.clone(), props.size.clone()),
-            [("role", "banner"), ("aria-label", props.aria_label.clone())],
+            vec![
+                ("role".to_string(), "banner".to_string()),
+                ("aria-label".to_string(), props.aria_label.clone()),
+            ],
         );
         format!("<header {}>{}</header>", attr_string, props.title)
     }

--- a/crates/rustic-ui-material/src/click_away.rs
+++ b/crates/rustic-ui-material/src/click_away.rs
@@ -12,6 +12,7 @@
 //! exact same identifiers regardless of whether the consumer is
 //! running Yew, Leptos, Dioxus, Sycamore, or a server-side renderer.
 
+use crate::telemetry::{instrument_render, TelemetryContext, TelemetryHooks};
 use rustic_ui_headless::click_away::{ClickAwayRootAttributes, ClickAwayState};
 use rustic_ui_styled_engine::{css_with_theme, Style};
 
@@ -29,6 +30,29 @@ pub struct ClickAwayBoundaryOptions {
     pub analytics_id: Option<String>,
     /// Optional automation identifier surfaced via `data-automation-id`.
     pub automation_id: Option<String>,
+}
+
+fn merge_boundary_options(
+    options: &ClickAwayBoundaryOptions,
+    telemetry: &TelemetryHooks,
+) -> ClickAwayBoundaryOptions {
+    let mut merged = options.clone();
+    if merged.analytics_id.is_none() {
+        merged.analytics_id = telemetry.analytics_id.clone();
+    }
+    if merged.automation_id.is_none() {
+        merged.automation_id = telemetry.automation_id.clone();
+    }
+    merged
+}
+
+fn resolved_automation_id(options: &ClickAwayBoundaryOptions, fallback: &str) -> String {
+    options
+        .automation_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| fallback.to_string())
 }
 
 fn apply_boundary_options<'a>(
@@ -141,7 +165,7 @@ pub fn drawer_click_away_automation(props: &crate::drawer::DrawerProps<'_>) -> S
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "yew")]
-mod yew_impl {
+pub mod yew {
     use super::*;
     use std::rc::Rc;
     use yew::prelude::*;
@@ -164,6 +188,9 @@ mod yew_impl {
         /// Render subtree managed by the click-away detector.
         #[prop_or_default]
         pub children: Children,
+        /// Optional telemetry hooks executed around render.
+        #[prop_or_default]
+        pub telemetry: TelemetryHooks,
     }
 
     impl PartialEq for ClickAwayBoundaryProps {
@@ -172,40 +199,47 @@ mod yew_impl {
                 && self.options == other.options
                 && self.automation_fallback == other.automation_fallback
                 && self.children == other.children
+                && self.telemetry == other.telemetry
         }
     }
 
     #[function_component(ClickAwayBoundary)]
     pub fn click_away_boundary(props: &ClickAwayBoundaryProps) -> Html {
-        // The component simply renders attributes; all pointer subscriptions are
-        // owned by whichever orchestration layer toggles `ClickAwayState`.
-        let attrs = props.state.root_attributes();
-        let attrs = apply_boundary_options(attrs, &props.options);
-        let pairs =
-            click_away_root_attributes(attrs, props.automation_fallback.as_str(), &props.options);
-        let mut node = html! { <div>{ for props.children.iter() }</div> };
-        if let Html::VTag(ref mut tag) = node {
-            for (key, value) in pairs {
-                tag.add_attribute(key, value);
+        let options = merge_boundary_options(&props.options, &props.telemetry);
+        let automation = resolved_automation_id(&options, props.automation_fallback.as_str());
+        let context =
+            TelemetryContext::new("rustic_ui_material::click_away::yew::ClickAwayBoundary")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            let attrs = props.state.root_attributes();
+            let attrs = apply_boundary_options(attrs, &options);
+            let pairs =
+                click_away_root_attributes(attrs, props.automation_fallback.as_str(), &options);
+            let mut node = html! { <div>{ for props.children.iter() }</div> };
+            if let Html::VTag(ref mut tag) = node {
+                for (key, value) in pairs {
+                    tag.add_attribute(key, value);
+                }
+                tag.add_attribute(
+                    "class",
+                    crate::style_helpers::themed_class(boundary_style()),
+                );
             }
-            tag.add_attribute(
-                "class",
-                crate::style_helpers::themed_class(boundary_style()),
-            );
-        }
-        node
+            node
+        })
     }
 }
 
 #[cfg(feature = "yew")]
-pub use yew_impl::{ClickAwayBoundary, ClickAwayBoundaryProps};
+pub use yew::{ClickAwayBoundary, ClickAwayBoundaryProps};
 
 // ---------------------------------------------------------------------------
 // Leptos adapter
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "leptos")]
-mod leptos_impl {
+pub mod leptos {
     use super::*;
     use leptos::prelude::*;
     use std::sync::Arc;
@@ -222,6 +256,8 @@ mod leptos_impl {
         pub automation_fallback: String,
         /// Child nodes rendered inside the boundary.
         pub children: Box<dyn Fn() -> View + Send + Sync>,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
     }
 
     impl Default for ClickAwayBoundaryProps {
@@ -231,6 +267,7 @@ mod leptos_impl {
                 options: ClickAwayBoundaryOptions::default(),
                 automation_fallback: "rustic-ui::click-away".into(),
                 children: Box::new(|| View::empty()),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
@@ -240,25 +277,35 @@ mod leptos_impl {
             Arc::ptr_eq(&self.state, &other.state)
                 && self.options == other.options
                 && self.automation_fallback == other.automation_fallback
+                && self.telemetry == other.telemetry
         }
     }
 
     #[component]
     pub fn ClickAwayBoundary(props: ClickAwayBoundaryProps) -> impl IntoView {
-        let attrs = props.state.root_attributes();
-        let attrs = apply_boundary_options(attrs, &props.options);
-        let pairs = click_away_root_attributes(attrs, &props.automation_fallback, &props.options);
-        let mut element = leptos::html::div();
-        element = element.class(crate::style_helpers::themed_class(boundary_style()));
-        for (key, value) in pairs {
-            element = element.attr(key, value);
-        }
-        element.child((props.children)()).into_view()
+        let options = merge_boundary_options(&props.options, &props.telemetry);
+        let automation = resolved_automation_id(&options, props.automation_fallback.as_str());
+        let context =
+            TelemetryContext::new("rustic_ui_material::click_away::leptos::ClickAwayBoundary")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            let attrs = props.state.root_attributes();
+            let attrs = apply_boundary_options(attrs, &options);
+            let pairs =
+                click_away_root_attributes(attrs, props.automation_fallback.as_str(), &options);
+            let mut element = leptos::html::div();
+            element = element.class(crate::style_helpers::themed_class(boundary_style()));
+            for (key, value) in pairs {
+                element = element.attr(key, value);
+            }
+            element.child((props.children)()).into_view()
+        })
     }
 }
 
 #[cfg(feature = "leptos")]
-pub use leptos_impl::{ClickAwayBoundary, ClickAwayBoundaryProps};
+pub use leptos::{ClickAwayBoundary, ClickAwayBoundaryProps};
 
 // ---------------------------------------------------------------------------
 // Dioxus adapter
@@ -269,7 +316,7 @@ pub mod dioxus {
     use super::*;
 
     /// Properties consumed by the Dioxus renderer.
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone)]
     pub struct ClickAwayBoundaryProps {
         /// Click-away state machine mirrored from the application layer.
         pub state: ClickAwayState,
@@ -279,6 +326,17 @@ pub mod dioxus {
         pub automation_fallback: String,
         /// Serialized children rendered inside the boundary.
         pub children: String,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
+    }
+
+    impl PartialEq for ClickAwayBoundaryProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.children == other.children
+                && self.telemetry == other.telemetry
+        }
     }
 
     impl Default for ClickAwayBoundaryProps {
@@ -288,6 +346,7 @@ pub mod dioxus {
                 options: ClickAwayBoundaryOptions::default(),
                 automation_fallback: "rustic-ui::click-away".into(),
                 children: String::new(),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
@@ -295,12 +354,20 @@ pub mod dioxus {
     /// Render the boundary into HTML so Dioxus SSR and client renderers stay in
     /// lockstep with the Yew/Leptos adapters.
     pub fn render(props: &ClickAwayBoundaryProps) -> String {
-        render_click_away_boundary_html(
-            &props.state,
-            &props.options,
-            &props.automation_fallback,
-            &props.children,
-        )
+        let options = merge_boundary_options(&props.options, &props.telemetry);
+        let automation = resolved_automation_id(&options, props.automation_fallback.as_str());
+        let context =
+            TelemetryContext::new("rustic_ui_material::click_away::dioxus::ClickAwayBoundary")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            render_click_away_boundary_html(
+                &props.state,
+                &options,
+                props.automation_fallback.as_str(),
+                &props.children,
+            )
+        })
     }
 }
 
@@ -313,7 +380,7 @@ pub mod sycamore {
     use super::*;
 
     /// Sycamore renderer mirroring the Dioxus properties for API consistency.
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone)]
     pub struct ClickAwayBoundaryProps {
         /// Click-away state machine mirrored from the application layer.
         pub state: ClickAwayState,
@@ -323,6 +390,17 @@ pub mod sycamore {
         pub automation_fallback: String,
         /// Serialized children rendered inside the boundary.
         pub children: String,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
+    }
+
+    impl PartialEq for ClickAwayBoundaryProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.children == other.children
+                && self.telemetry == other.telemetry
+        }
     }
 
     impl Default for ClickAwayBoundaryProps {
@@ -332,17 +410,26 @@ pub mod sycamore {
                 options: ClickAwayBoundaryOptions::default(),
                 automation_fallback: "rustic-ui::click-away".into(),
                 children: String::new(),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
 
     /// Render the boundary into HTML string form.
     pub fn render(props: &ClickAwayBoundaryProps) -> String {
-        render_click_away_boundary_html(
-            &props.state,
-            &props.options,
-            &props.automation_fallback,
-            &props.children,
-        )
+        let options = merge_boundary_options(&props.options, &props.telemetry);
+        let automation = resolved_automation_id(&options, props.automation_fallback.as_str());
+        let context =
+            TelemetryContext::new("rustic_ui_material::click_away::sycamore::ClickAwayBoundary")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            render_click_away_boundary_html(
+                &props.state,
+                &options,
+                props.automation_fallback.as_str(),
+                &props.children,
+            )
+        })
     }
 }

--- a/crates/rustic-ui-material/src/collapsible.rs
+++ b/crates/rustic-ui-material/src/collapsible.rs
@@ -4,6 +4,7 @@
 //! keep orchestration consistent with [`accordion`](crate::accordion)
 //! while exposing telemetry hooks identical to our dialog/drawer stacks.
 
+use crate::telemetry::{instrument_render, TelemetryContext, TelemetryHooks};
 use rustic_ui_headless::collapsible_region::{
     CollapsibleContentAttributes, CollapsibleRegionState, CollapsibleTriggerAttributes,
 };
@@ -29,6 +30,34 @@ pub struct CollapsibleRegionOptions {
     pub analytics_id: Option<String>,
     /// Optional automation identifier surfaced via `data-automation-id`.
     pub automation_id: Option<String>,
+}
+
+fn merge_trigger_options(
+    options: &CollapsibleTriggerOptions,
+    telemetry: &TelemetryHooks,
+) -> CollapsibleTriggerOptions {
+    let mut merged = options.clone();
+    if merged.analytics_id.is_none() {
+        merged.analytics_id = telemetry.analytics_id.clone();
+    }
+    if merged.automation_id.is_none() {
+        merged.automation_id = telemetry.automation_id.clone();
+    }
+    merged
+}
+
+fn merge_region_options(
+    options: &CollapsibleRegionOptions,
+    telemetry: &TelemetryHooks,
+) -> CollapsibleRegionOptions {
+    let mut merged = options.clone();
+    if merged.analytics_id.is_none() {
+        merged.analytics_id = telemetry.analytics_id.clone();
+    }
+    if merged.automation_id.is_none() {
+        merged.automation_id = telemetry.automation_id.clone();
+    }
+    merged
 }
 
 fn apply_trigger_options<'a>(
@@ -78,6 +107,15 @@ pub fn collapsible_trigger_attributes(
     pairs
 }
 
+fn resolved_trigger_automation(options: &CollapsibleTriggerOptions, fallback: &str) -> String {
+    options
+        .automation_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| fallback.to_string())
+}
+
 /// Convert region attributes into automation-friendly key/value pairs.
 #[must_use]
 pub fn collapsible_region_attributes(
@@ -97,6 +135,15 @@ pub fn collapsible_region_attributes(
         .unwrap_or(automation_fallback);
     pairs.push(("data-automation-id".into(), automation.to_string()));
     pairs
+}
+
+fn resolved_region_automation(options: &CollapsibleRegionOptions, fallback: &str) -> String {
+    options
+        .automation_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| fallback.to_string())
 }
 
 fn trigger_style() -> Style {
@@ -169,7 +216,7 @@ pub fn render_collapsible_region_html(
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "yew")]
-mod yew_impl {
+pub mod yew {
     use super::*;
     use std::rc::Rc;
     use yew::prelude::*;
@@ -193,6 +240,9 @@ mod yew_impl {
         /// Trigger label children.
         #[prop_or_default]
         pub children: Children,
+        /// Optional telemetry hooks executed around render.
+        #[prop_or_default]
+        pub telemetry: TelemetryHooks,
     }
 
     impl PartialEq for CollapsibleTriggerProps {
@@ -202,31 +252,36 @@ mod yew_impl {
                 && self.automation_fallback == other.automation_fallback
                 && self.class == other.class
                 && self.children == other.children
+                && self.telemetry == other.telemetry
         }
     }
 
     #[function_component(CollapsibleTrigger)]
     pub fn collapsible_trigger(props: &CollapsibleTriggerProps) -> Html {
-        let attrs = props.state.trigger_attributes();
-        let attrs = apply_trigger_options(attrs, &props.options);
-        let pairs = collapsible_trigger_attributes(
-            attrs,
-            &props.options,
-            props.automation_fallback.as_str(),
-        );
-        let themed = crate::style_helpers::themed_class(trigger_style());
-        let class = match &props.class {
-            Some(custom) if !custom.is_empty() => format!("{themed} {custom}"),
-            _ => themed,
-        };
-        let mut node =
-            html! { <button type="button" class={class}>{ for props.children.iter() }</button> };
-        if let Html::VTag(ref mut tag) = node {
-            for (key, value) in pairs {
-                tag.add_attribute(key, value);
+        let options = merge_trigger_options(&props.options, &props.telemetry);
+        let automation = resolved_trigger_automation(&options, props.automation_fallback.as_str());
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::yew::CollapsibleTrigger")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            let attrs = props.state.trigger_attributes();
+            let attrs = apply_trigger_options(attrs, &options);
+            let pairs =
+                collapsible_trigger_attributes(attrs, &options, props.automation_fallback.as_str());
+            let themed = crate::style_helpers::themed_class(trigger_style());
+            let class = match &props.class {
+                Some(custom) if !custom.is_empty() => format!("{themed} {custom}"),
+                _ => themed,
+            };
+            let mut node = html! { <button type="button" class={class}>{ for props.children.iter() }</button> };
+            if let Html::VTag(ref mut tag) = node {
+                for (key, value) in pairs {
+                    tag.add_attribute(key, value);
+                }
             }
-        }
-        node
+            node
+        })
     }
 
     /// Yew region component mirroring the trigger API surface.
@@ -246,6 +301,9 @@ mod yew_impl {
         /// Region contents.
         #[prop_or_default]
         pub children: Children,
+        /// Optional telemetry hooks executed around render.
+        #[prop_or_default]
+        pub telemetry: TelemetryHooks,
     }
 
     impl PartialEq for CollapsibleRegionProps {
@@ -255,35 +313,41 @@ mod yew_impl {
                 && self.automation_fallback == other.automation_fallback
                 && self.class == other.class
                 && self.children == other.children
+                && self.telemetry == other.telemetry
         }
     }
 
     #[function_component(CollapsibleRegion)]
     pub fn collapsible_region(props: &CollapsibleRegionProps) -> Html {
-        let attrs = props.state.region_attributes();
-        let attrs = apply_region_options(attrs, &props.options);
-        let pairs = collapsible_region_attributes(
-            attrs,
-            &props.options,
-            props.automation_fallback.as_str(),
-        );
-        let themed = crate::style_helpers::themed_class(region_style());
-        let class = match &props.class {
-            Some(custom) if !custom.is_empty() => format!("{themed} {custom}"),
-            _ => themed,
-        };
-        let mut node = html! { <div class={class}>{ for props.children.iter() }</div> };
-        if let Html::VTag(ref mut tag) = node {
-            for (key, value) in pairs {
-                tag.add_attribute(key, value);
+        let options = merge_region_options(&props.options, &props.telemetry);
+        let automation = resolved_region_automation(&options, props.automation_fallback.as_str());
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::yew::CollapsibleRegion")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            let attrs = props.state.region_attributes();
+            let attrs = apply_region_options(attrs, &options);
+            let pairs =
+                collapsible_region_attributes(attrs, &options, props.automation_fallback.as_str());
+            let themed = crate::style_helpers::themed_class(region_style());
+            let class = match &props.class {
+                Some(custom) if !custom.is_empty() => format!("{themed} {custom}"),
+                _ => themed,
+            };
+            let mut node = html! { <div class={class}>{ for props.children.iter() }</div> };
+            if let Html::VTag(ref mut tag) = node {
+                for (key, value) in pairs {
+                    tag.add_attribute(key, value);
+                }
             }
-        }
-        node
+            node
+        })
     }
 }
 
 #[cfg(feature = "yew")]
-pub use yew_impl::{
+pub use yew::{
     CollapsibleRegion, CollapsibleRegionProps, CollapsibleTrigger, CollapsibleTriggerProps,
 };
 
@@ -292,7 +356,7 @@ pub use yew_impl::{
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "leptos")]
-mod leptos_impl {
+pub mod leptos {
     use super::*;
     use leptos::prelude::*;
     use std::sync::Arc;
@@ -310,6 +374,8 @@ mod leptos_impl {
         pub class: Option<String>,
         /// Trigger children view factory.
         pub children: Box<dyn Fn() -> View + Send + Sync>,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
     }
 
     impl Default for CollapsibleTriggerProps {
@@ -320,6 +386,7 @@ mod leptos_impl {
                 automation_fallback: "rustic-ui::collapsible-trigger".into(),
                 class: None,
                 children: Box::new(|| View::empty()),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
@@ -330,30 +397,36 @@ mod leptos_impl {
                 && self.options == other.options
                 && self.automation_fallback == other.automation_fallback
                 && self.class == other.class
+                && self.telemetry == other.telemetry
         }
     }
 
     #[component]
     pub fn CollapsibleTrigger(props: CollapsibleTriggerProps) -> impl IntoView {
-        let attrs = props.state.trigger_attributes();
-        let attrs = super::apply_trigger_options(attrs, &props.options);
-        let pairs = super::collapsible_trigger_attributes(
-            attrs,
-            &props.options,
-            &props.automation_fallback,
-        );
-        let themed = crate::style_helpers::themed_class(super::trigger_style());
-        let class = props
-            .class
-            .as_ref()
-            .map(|custom| format!("{themed} {custom}"))
-            .unwrap_or(themed);
-        let mut element = leptos::html::button().attr("type", "button");
-        element = element.class(class);
-        for (key, value) in pairs {
-            element = element.attr(key, value);
-        }
-        element.child((props.children)()).into_view()
+        let options = merge_trigger_options(&props.options, &props.telemetry);
+        let automation = resolved_trigger_automation(&options, &props.automation_fallback);
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::leptos::CollapsibleTrigger")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            let attrs = props.state.trigger_attributes();
+            let attrs = super::apply_trigger_options(attrs, &options);
+            let pairs =
+                super::collapsible_trigger_attributes(attrs, &options, &props.automation_fallback);
+            let themed = crate::style_helpers::themed_class(super::trigger_style());
+            let class = props
+                .class
+                .as_ref()
+                .map(|custom| format!("{themed} {custom}"))
+                .unwrap_or(themed);
+            let mut element = leptos::html::button().attr("type", "button");
+            element = element.class(class);
+            for (key, value) in pairs {
+                element = element.attr(key, value);
+            }
+            element.child((props.children)()).into_view()
+        })
     }
 
     /// Leptos variant of the collapsible region wrapper.
@@ -369,6 +442,8 @@ mod leptos_impl {
         pub class: Option<String>,
         /// Region children view factory.
         pub children: Box<dyn Fn() -> View + Send + Sync>,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
     }
 
     impl Default for CollapsibleRegionProps {
@@ -379,6 +454,7 @@ mod leptos_impl {
                 automation_fallback: "rustic-ui::collapsible-region".into(),
                 class: None,
                 children: Box::new(|| View::empty()),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
@@ -389,31 +465,40 @@ mod leptos_impl {
                 && self.options == other.options
                 && self.automation_fallback == other.automation_fallback
                 && self.class == other.class
+                && self.telemetry == other.telemetry
         }
     }
 
     #[component]
     pub fn CollapsibleRegion(props: CollapsibleRegionProps) -> impl IntoView {
-        let attrs = props.state.region_attributes();
-        let attrs = super::apply_region_options(attrs, &props.options);
-        let pairs =
-            super::collapsible_region_attributes(attrs, &props.options, &props.automation_fallback);
-        let themed = crate::style_helpers::themed_class(super::region_style());
-        let class = props
-            .class
-            .as_ref()
-            .map(|custom| format!("{themed} {custom}"))
-            .unwrap_or(themed);
-        let mut element = leptos::html::div().class(class);
-        for (key, value) in pairs {
-            element = element.attr(key, value);
-        }
-        element.child((props.children)()).into_view()
+        let options = merge_region_options(&props.options, &props.telemetry);
+        let automation = resolved_region_automation(&options, &props.automation_fallback);
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::leptos::CollapsibleRegion")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            let attrs = props.state.region_attributes();
+            let attrs = super::apply_region_options(attrs, &options);
+            let pairs =
+                super::collapsible_region_attributes(attrs, &options, &props.automation_fallback);
+            let themed = crate::style_helpers::themed_class(super::region_style());
+            let class = props
+                .class
+                .as_ref()
+                .map(|custom| format!("{themed} {custom}"))
+                .unwrap_or(themed);
+            let mut element = leptos::html::div().class(class);
+            for (key, value) in pairs {
+                element = element.attr(key, value);
+            }
+            element.child((props.children)()).into_view()
+        })
     }
 }
 
 #[cfg(feature = "leptos")]
-pub use leptos_impl::{
+pub use leptos::{
     CollapsibleRegion, CollapsibleRegionProps, CollapsibleTrigger, CollapsibleTriggerProps,
 };
 
@@ -426,7 +511,7 @@ pub mod dioxus {
     use super::*;
 
     /// Properties consumed by the Dioxus trigger renderer.
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone)]
     pub struct CollapsibleTriggerProps {
         /// Region state machine mirrored from the controller.
         pub state: CollapsibleRegionState,
@@ -436,6 +521,17 @@ pub mod dioxus {
         pub automation_fallback: String,
         /// Trigger children HTML.
         pub children: String,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
+    }
+
+    impl PartialEq for CollapsibleTriggerProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.children == other.children
+                && self.telemetry == other.telemetry
+        }
     }
 
     impl Default for CollapsibleTriggerProps {
@@ -445,22 +541,31 @@ pub mod dioxus {
                 options: CollapsibleTriggerOptions::default(),
                 automation_fallback: "rustic-ui::collapsible-trigger".into(),
                 children: String::new(),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
 
     /// Render the trigger into HTML.
     pub fn render_trigger(props: &CollapsibleTriggerProps) -> String {
-        super::render_collapsible_trigger_html(
-            &props.state,
-            &props.options,
-            &props.automation_fallback,
-            &props.children,
-        )
+        let options = merge_trigger_options(&props.options, &props.telemetry);
+        let automation = resolved_trigger_automation(&options, &props.automation_fallback);
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::dioxus::CollapsibleTrigger")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            super::render_collapsible_trigger_html(
+                &props.state,
+                &options,
+                &props.automation_fallback,
+                &props.children,
+            )
+        })
     }
 
     /// Properties consumed by the Dioxus region renderer.
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone)]
     pub struct CollapsibleRegionProps {
         /// Region state machine mirrored from the controller.
         pub state: CollapsibleRegionState,
@@ -470,6 +575,17 @@ pub mod dioxus {
         pub automation_fallback: String,
         /// Region children HTML.
         pub children: String,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
+    }
+
+    impl PartialEq for CollapsibleRegionProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.children == other.children
+                && self.telemetry == other.telemetry
+        }
     }
 
     impl Default for CollapsibleRegionProps {
@@ -479,18 +595,27 @@ pub mod dioxus {
                 options: CollapsibleRegionOptions::default(),
                 automation_fallback: "rustic-ui::collapsible-region".into(),
                 children: String::new(),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
 
     /// Render the region into HTML.
     pub fn render_region(props: &CollapsibleRegionProps) -> String {
-        super::render_collapsible_region_html(
-            &props.state,
-            &props.options,
-            &props.automation_fallback,
-            &props.children,
-        )
+        let options = merge_region_options(&props.options, &props.telemetry);
+        let automation = resolved_region_automation(&options, &props.automation_fallback);
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::dioxus::CollapsibleRegion")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            super::render_collapsible_region_html(
+                &props.state,
+                &options,
+                &props.automation_fallback,
+                &props.children,
+            )
+        })
     }
 }
 
@@ -503,7 +628,7 @@ pub mod sycamore {
     use super::*;
 
     /// Sycamore trigger renderer properties.
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone)]
     pub struct CollapsibleTriggerProps {
         /// Region state machine mirrored from the controller.
         pub state: CollapsibleRegionState,
@@ -513,6 +638,17 @@ pub mod sycamore {
         pub automation_fallback: String,
         /// Trigger children HTML.
         pub children: String,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
+    }
+
+    impl PartialEq for CollapsibleTriggerProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.children == other.children
+                && self.telemetry == other.telemetry
+        }
     }
 
     impl Default for CollapsibleTriggerProps {
@@ -522,22 +658,31 @@ pub mod sycamore {
                 options: CollapsibleTriggerOptions::default(),
                 automation_fallback: "rustic-ui::collapsible-trigger".into(),
                 children: String::new(),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
 
     /// Render the trigger into HTML.
     pub fn render_trigger(props: &CollapsibleTriggerProps) -> String {
-        super::render_collapsible_trigger_html(
-            &props.state,
-            &props.options,
-            &props.automation_fallback,
-            &props.children,
-        )
+        let options = merge_trigger_options(&props.options, &props.telemetry);
+        let automation = resolved_trigger_automation(&options, &props.automation_fallback);
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::sycamore::CollapsibleTrigger")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            super::render_collapsible_trigger_html(
+                &props.state,
+                &options,
+                &props.automation_fallback,
+                &props.children,
+            )
+        })
     }
 
     /// Sycamore region renderer properties.
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone)]
     pub struct CollapsibleRegionProps {
         /// Region state machine mirrored from the controller.
         pub state: CollapsibleRegionState,
@@ -547,6 +692,17 @@ pub mod sycamore {
         pub automation_fallback: String,
         /// Region children HTML.
         pub children: String,
+        /// Optional telemetry hooks executed around render.
+        pub telemetry: TelemetryHooks,
+    }
+
+    impl PartialEq for CollapsibleRegionProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.options == other.options
+                && self.automation_fallback == other.automation_fallback
+                && self.children == other.children
+                && self.telemetry == other.telemetry
+        }
     }
 
     impl Default for CollapsibleRegionProps {
@@ -556,17 +712,26 @@ pub mod sycamore {
                 options: CollapsibleRegionOptions::default(),
                 automation_fallback: "rustic-ui::collapsible-region".into(),
                 children: String::new(),
+                telemetry: TelemetryHooks::default(),
             }
         }
     }
 
     /// Render the region into HTML.
     pub fn render_region(props: &CollapsibleRegionProps) -> String {
-        super::render_collapsible_region_html(
-            &props.state,
-            &props.options,
-            &props.automation_fallback,
-            &props.children,
-        )
+        let options = merge_region_options(&props.options, &props.telemetry);
+        let automation = resolved_region_automation(&options, &props.automation_fallback);
+        let context =
+            TelemetryContext::new("rustic_ui_material::collapsible::sycamore::CollapsibleRegion")
+                .with_analytics(options.analytics_id.clone())
+                .with_automation(Some(automation));
+        instrument_render(&props.telemetry, context, || {
+            super::render_collapsible_region_html(
+                &props.state,
+                &options,
+                &props.automation_fallback,
+                &props.children,
+            )
+        })
     }
 }

--- a/crates/rustic-ui-material/src/dialog.rs
+++ b/crates/rustic-ui-material/src/dialog.rs
@@ -245,7 +245,7 @@ pub mod react {
 
     /// Properties accepted by the React oriented renderer. The struct mirrors
     /// the SSR adapters to keep orchestration consistent across frameworks.
-    #[derive(Clone, Debug, Default, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub struct DialogProps {
         /// Dialog state machine controlling visibility and analytics hooks.
         pub state: DialogState,
@@ -255,6 +255,17 @@ pub mod react {
         pub children: String,
         /// Optional accessible label announced by assistive technologies.
         pub aria_label: Option<String>,
+    }
+
+    impl Default for DialogProps {
+        fn default() -> Self {
+            Self {
+                state: DialogState::uncontrolled(false),
+                surface: DialogSurfaceOptions::default(),
+                children: String::new(),
+                aria_label: None,
+            }
+        }
     }
 
     /// Render the dialog surface using the shared SSR helper so React output

--- a/crates/rustic-ui-material/src/focus_trap.rs
+++ b/crates/rustic-ui-material/src/focus_trap.rs
@@ -240,7 +240,7 @@ pub mod dioxus {
     use super::*;
 
     /// Properties for the Dioxus sentinel renderer.
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone)]
     pub struct FocusTrapSentinelProps {
         /// Focus trap state machine mirrored from the controller.
         pub state: FocusTrapState,
@@ -250,6 +250,14 @@ pub mod dioxus {
         pub options: FocusTrapSentinelOptions,
         /// Fallback automation prefix when the options omit one.
         pub fallback_prefix: String,
+    }
+
+    impl PartialEq for FocusTrapSentinelProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.kind == other.kind
+                && self.options == other.options
+                && self.fallback_prefix == other.fallback_prefix
+        }
     }
 
     impl Default for FocusTrapSentinelProps {

--- a/crates/rustic-ui-material/src/lib.rs
+++ b/crates/rustic-ui-material/src/lib.rs
@@ -73,6 +73,7 @@ pub mod tab;
 pub mod tab_panel;
 pub mod table;
 pub mod tabs;
+mod telemetry;
 pub mod text_field;
 pub mod tooltip;
 pub mod typography;
@@ -125,6 +126,7 @@ pub use skeleton::{render_skeleton, SkeletonAdapterProps, SkeletonRenderOutput};
 #[cfg(feature = "forms")]
 pub use slider::{render_slider, SliderAdapterProps, SliderRenderOutput};
 pub use stack::{render_stack, StackAdapterProps, StackRenderOutput};
+pub use telemetry::{TelemetryContext, TelemetryError, TelemetryHooks};
 pub use typography::{render_typography, TypographyRenderOutput};
 
 #[cfg(any(

--- a/crates/rustic-ui-material/src/telemetry.rs
+++ b/crates/rustic-ui-material/src/telemetry.rs
@@ -1,0 +1,179 @@
+#![allow(dead_code)]
+//! Shared telemetry helpers used across adapter modules.
+//!
+//! The utilities in this module keep instrumentation consistent across
+//! frameworks. Adapters feed their render closures through
+//! [`instrument_render`] which automatically enters the provided
+//! [`tracing::Span`], executes success callbacks, and reports panics to
+//! opt-in error hooks. The indirection eliminates repetitive plumbing in
+//! each framework integration while giving enterprise applications a single
+//! struct they can configure to bolt analytics, tracing, and error
+//! collection into RusticUI widgets.
+
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::Arc;
+
+use tracing::{field, span, Level, Span};
+
+/// Context describing the component instance currently being rendered.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TelemetryContext {
+    /// Fully-qualified component identifier (e.g. module path).
+    pub component: &'static str,
+    /// Optional analytics identifier reported alongside telemetry events.
+    pub analytics_id: Option<String>,
+    /// Optional automation identifier associated with the rendered element.
+    pub automation_id: Option<String>,
+}
+
+impl TelemetryContext {
+    /// Construct a new telemetry context for the supplied component.
+    #[must_use]
+    pub const fn new(component: &'static str) -> Self {
+        Self {
+            component,
+            analytics_id: None,
+            automation_id: None,
+        }
+    }
+
+    /// Attach an analytics identifier to the context.
+    #[must_use]
+    pub fn with_analytics(mut self, analytics_id: Option<String>) -> Self {
+        self.analytics_id = analytics_id;
+        self
+    }
+
+    /// Attach an automation identifier to the context.
+    #[must_use]
+    pub fn with_automation(mut self, automation_id: Option<String>) -> Self {
+        self.automation_id = automation_id;
+        self
+    }
+}
+
+/// Error payload reported to telemetry hooks when rendering panics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TelemetryError {
+    /// Human readable description of the failure.
+    pub message: String,
+}
+
+impl TelemetryError {
+    /// Construct a telemetry error with the provided message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+fn span_id(span: &Span) -> Option<tracing::Id> {
+    span.id()
+}
+
+fn span_option_eq(lhs: &Option<Span>, rhs: &Option<Span>) -> bool {
+    match (lhs, rhs) {
+        (Some(a), Some(b)) => span_id(a) == span_id(b),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn callback_eq<T: ?Sized>(lhs: &Option<Arc<T>>, rhs: &Option<Arc<T>>) -> bool {
+    match (lhs, rhs) {
+        (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+/// Configurable hooks invoked around adapter renders.
+#[derive(Clone, Default)]
+pub struct TelemetryHooks {
+    /// Optional analytics identifier automatically applied when the adapter
+    /// options do not specify one.
+    pub analytics_id: Option<String>,
+    /// Optional automation identifier automatically applied when adapter
+    /// options do not specify one.
+    pub automation_id: Option<String>,
+    /// Optional tracing span entered for the duration of the render.
+    pub span: Option<Span>,
+    /// Callback executed when rendering succeeds.
+    pub on_render: Option<Arc<dyn Fn(TelemetryContext) + Send + Sync + 'static>>,
+    /// Callback executed when rendering panics.
+    pub on_error: Option<Arc<dyn Fn(TelemetryContext, TelemetryError) + Send + Sync + 'static>>,
+}
+
+impl PartialEq for TelemetryHooks {
+    fn eq(&self, other: &Self) -> bool {
+        self.analytics_id == other.analytics_id
+            && self.automation_id == other.automation_id
+            && span_option_eq(&self.span, &other.span)
+            && callback_eq(&self.on_render, &other.on_render)
+            && callback_eq(&self.on_error, &other.on_error)
+    }
+}
+
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else {
+        String::from("render panic")
+    }
+}
+
+/// Execute the provided closure within the configured tracing span and
+/// telemetry hooks.
+#[must_use]
+pub fn instrument_render<F, T>(hooks: &TelemetryHooks, context: TelemetryContext, render: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let analytics = context
+        .analytics_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("n/a");
+    let automation = context
+        .automation_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("n/a");
+    let span = hooks.span.clone().unwrap_or_else(|| {
+        span!(
+            Level::INFO,
+            "rustic_ui_component",
+            component = context.component,
+            analytics_id = field::display(analytics),
+            automation_id = field::display(automation)
+        )
+    });
+    let _guard = span.enter();
+    match panic::catch_unwind(AssertUnwindSafe(render)) {
+        Ok(output) => {
+            if let Some(on_render) = &hooks.on_render {
+                on_render(context.clone());
+            }
+            output
+        }
+        Err(payload) => {
+            let message = panic_message(&*payload);
+            let error = TelemetryError::new(message.clone());
+            tracing::error!(
+                component = context.component,
+                analytics_id = analytics,
+                automation_id = automation,
+                message = %message,
+                "adapter render panic"
+            );
+            if let Some(on_error) = &hooks.on_error {
+                on_error(context.clone(), error);
+            }
+            panic::resume_unwind(payload);
+        }
+    }
+}

--- a/crates/rustic-ui-material/src/text_field.rs
+++ b/crates/rustic-ui-material/src/text_field.rs
@@ -50,7 +50,8 @@
     feature = "sycamore"
 ))]
 use rustic_ui_headless::text_field::{
-    TextFieldChangeEvent, TextFieldCommitEvent, TextFieldResetEvent, TextFieldState,
+    TextFieldAttributes, TextFieldChangeEvent, TextFieldCommitEvent, TextFieldResetEvent,
+    TextFieldState,
 };
 #[cfg(any(
     feature = "yew",

--- a/crates/rustic-ui-material/tests/utility_telemetry.rs
+++ b/crates/rustic-ui-material/tests/utility_telemetry.rs
@@ -1,0 +1,118 @@
+#![cfg(feature = "dioxus")]
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+
+use rustic_ui_headless::{click_away::ClickAwayState, collapsible_region::CollapsibleRegionState};
+use rustic_ui_material::{
+    click_away, collapsible, dialog::DialogSurfaceOptions, TelemetryContext, TelemetryHooks,
+};
+
+fn record_contexts(
+    target: Arc<Mutex<Vec<TelemetryContext>>>,
+) -> Arc<dyn Fn(TelemetryContext) + Send + Sync> {
+    Arc::new(move |ctx: TelemetryContext| {
+        target.lock().unwrap().push(ctx);
+    })
+}
+
+#[test]
+fn click_away_dioxus_adapter_emits_dialog_telemetry() {
+    let mut surface = DialogSurfaceOptions::default();
+    surface.analytics_id = Some("checkout-flow".into());
+    let fallback = click_away::dialog_click_away_automation(&surface);
+
+    let contexts = Arc::new(Mutex::new(Vec::new()));
+    let errors = Arc::new(AtomicUsize::new(0));
+    let mut telemetry = TelemetryHooks::default();
+    telemetry.analytics_id = Some("override-analytics".into());
+    telemetry.on_render = Some(record_contexts(Arc::clone(&contexts)));
+    telemetry.on_error = Some(Arc::new({
+        let errors = Arc::clone(&errors);
+        move |_, _| {
+            errors.fetch_add(1, Ordering::Relaxed);
+        }
+    }));
+
+    let html = click_away::dioxus::render(&click_away::dioxus::ClickAwayBoundaryProps {
+        state: ClickAwayState::new(),
+        options: click_away::ClickAwayBoundaryOptions::default(),
+        automation_fallback: fallback.clone(),
+        children: "<section></section>".into(),
+        telemetry,
+    });
+
+    assert!(html.contains("data-rustic-click-away=\"root\""));
+    assert!(html.contains("data-automation-id"));
+    assert!(html.contains(&fallback));
+    let stored = contexts.lock().unwrap();
+    assert_eq!(stored.len(), 1);
+    let ctx = &stored[0];
+    assert_eq!(
+        ctx.component,
+        "rustic_ui_material::click_away::dioxus::ClickAwayBoundary"
+    );
+    assert_eq!(ctx.analytics_id.as_deref(), Some("override-analytics"));
+    assert_eq!(ctx.automation_id.as_deref(), Some(fallback.as_str()));
+    assert_eq!(errors.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn collapsible_dioxus_adapters_emit_menu_telemetry() {
+    let trigger_contexts = Arc::new(Mutex::new(Vec::new()));
+    let region_contexts = Arc::new(Mutex::new(Vec::new()));
+
+    let mut trigger_hooks = TelemetryHooks::default();
+    trigger_hooks.analytics_id = Some("menu-analytics".into());
+    trigger_hooks.on_render = Some(record_contexts(Arc::clone(&trigger_contexts)));
+
+    let mut region_hooks = TelemetryHooks::default();
+    region_hooks.analytics_id = Some("menu-analytics".into());
+    region_hooks.on_render = Some(record_contexts(Arc::clone(&region_contexts)));
+
+    let trigger_html =
+        collapsible::dioxus::render_trigger(&collapsible::dioxus::CollapsibleTriggerProps {
+            state: CollapsibleRegionState::uncontrolled(false),
+            options: collapsible::CollapsibleTriggerOptions::default(),
+            automation_fallback: "menu::trigger::primary".into(),
+            children: "<span>Trigger</span>".into(),
+            telemetry: trigger_hooks,
+        });
+    assert!(trigger_html.contains("data-automation-id=\"menu::trigger::primary\""));
+    assert!(trigger_html.contains("data-rustic-analytics-id=\"menu-analytics\""));
+
+    let region_html =
+        collapsible::dioxus::render_region(&collapsible::dioxus::CollapsibleRegionProps {
+            state: CollapsibleRegionState::uncontrolled(false),
+            options: collapsible::CollapsibleRegionOptions::default(),
+            automation_fallback: "menu::region::primary".into(),
+            children: "<div>Region</div>".into(),
+            telemetry: region_hooks,
+        });
+    assert!(region_html.contains("data-automation-id=\"menu::region::primary\""));
+    assert!(region_html.contains("data-rustic-analytics-id=\"menu-analytics\""));
+
+    let trigger_events = trigger_contexts.lock().unwrap();
+    assert_eq!(trigger_events.len(), 1);
+    assert_eq!(
+        trigger_events[0].component,
+        "rustic_ui_material::collapsible::dioxus::CollapsibleTrigger"
+    );
+    assert_eq!(
+        trigger_events[0].automation_id.as_deref(),
+        Some("menu::trigger::primary")
+    );
+
+    let region_events = region_contexts.lock().unwrap();
+    assert_eq!(region_events.len(), 1);
+    assert_eq!(
+        region_events[0].component,
+        "rustic_ui_material::collapsible::dioxus::CollapsibleRegion"
+    );
+    assert_eq!(
+        region_events[0].automation_id.as_deref(),
+        Some("menu::region::primary")
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared telemetry module that instruments adapter renders with spans, analytics identifiers, and failure hooks
- update the click-away and collapsible adapters to merge telemetry metadata and expose framework-specific modules under `click_away::yew`, `collapsible::leptos`, etc.
- add dioxus-focused integration tests that exercise the new telemetry callbacks when composing click-away boundaries and collapsible regions

## Testing
- `cargo check -p rustic-ui-material`
- `cargo test -p rustic-ui-material --features dioxus` *(fails: existing css_with_theme! macro expansion issues when compiling dioxus-only adapters)*

------
https://chatgpt.com/codex/tasks/task_e_68dac8bf4000832eabf92314bbe9dc61