### PR TITLE
Align navigation renderers with public tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 RusticUI documents every step of the transition from Material UI for Rust to the Apotheon.ai–stewarded RusticUI platform. The
 archived Material UI change history now lives in [`docs/archives/material-ui-changelog.md`](docs/archives/material-ui-changelog.md).
 
+## 2025-06-10 – Navigation primitives and analytics alignment
+
+### Highlights
+
+- Added headless state machines for bottom navigation, breadcrumbs, link,
+  pagination, and speed dial widgets with controlled/uncontrolled flows,
+  deterministic keyboard handling, and structured analytics payloads.
+- Implemented Material renderers plus React, Yew, Leptos, Sycamore, and Dioxus
+  adapters for each primitive, emitting automation-focused data attributes and
+  SSR-safe inline styles that reuse the shared helper modules.
+- Expanded the Rust integration test suite with navigation-focused coverage so
+  telemetry hooks and accessibility contracts stay locked across frameworks and
+  server-side rendering pipelines.
+
+### Verification
+
+- `cargo fmt`
+- `cargo test -p rustic-ui-headless --test navigation_primitives`
+- `cargo test -p rustic-ui-material --lib`
+
 ## 2025-06-02 – Headless utility expansion and observability rails
 
 ### Highlights

--- a/crates/rustic-ui-headless/src/aria.rs
+++ b/crates/rustic-ui-headless/src/aria.rs
@@ -52,6 +52,36 @@ pub const fn role_button() -> &'static str {
     "button"
 }
 
+/// Returns the ARIA role for anchor style links.
+#[inline]
+pub const fn role_link() -> &'static str {
+    "link"
+}
+
+/// Returns the ARIA role for navigation landmarks.
+#[inline]
+pub const fn role_navigation() -> &'static str {
+    "navigation"
+}
+
+/// Returns the ARIA role for generic list containers.
+#[inline]
+pub const fn role_list() -> &'static str {
+    "list"
+}
+
+/// Returns the ARIA role for list items.
+#[inline]
+pub const fn role_listitem() -> &'static str {
+    "listitem"
+}
+
+/// Returns the ARIA role for separator glyphs.
+#[inline]
+pub const fn role_separator() -> &'static str {
+    "separator"
+}
+
 /// Returns the ARIA role for the listbox container element.
 #[inline]
 pub const fn role_listbox() -> &'static str {
@@ -207,6 +237,12 @@ pub fn aria_controls(id: &str) -> (&'static str, &str) {
 #[inline]
 pub fn aria_labelledby(id: &str) -> (&'static str, &str) {
     ("aria-labelledby", id)
+}
+
+/// Compute the `aria-current` attribute describing the current page or step.
+#[inline]
+pub fn aria_current(value: &str) -> (&'static str, &str) {
+    ("aria-current", value)
 }
 
 /// Compute the `aria-describedby` attribute linking to additional context.

--- a/crates/rustic-ui-headless/src/bottom_navigation.rs
+++ b/crates/rustic-ui-headless/src/bottom_navigation.rs
@@ -1,0 +1,491 @@
+#![deny(missing_docs)]
+//! Headless state machine powering Material flavored bottom navigation bars.
+//!
+//! The implementation keeps ARIA wiring, keyboard orchestration, and analytics
+//! hooks centralized so framework adapters can remain declarative.  Integrations
+//! only need to forward DOM events and configure identifiers; the state machine
+//! handles controlled/uncontrolled flows, roving focus, disabled item semantics,
+//! and event payload generation for telemetry pipelines.  The goal is to let
+//! enterprise teams stamp out consistent navigation shells without bespoke
+//! boilerplate in every codebase.
+
+use crate::{
+    aria,
+    interaction::ControlKey,
+    selection::{clamp_index, wrap_index, ControlStrategy},
+};
+
+/// Describes how keyboard interaction updates the selected destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BottomNavigationActivationMode {
+    /// Selection changes immediately as focus moves.  This mirrors the default
+    /// Material behaviour where navigating with the keyboard activates the
+    /// highlighted destination.
+    Automatic,
+    /// Selection is committed explicitly via <Enter> or <Space>.  Enterprise
+    /// surfaces frequently adopt this mode so content panes do not re-render
+    /// until the user confirms their intent.
+    Manual,
+}
+
+impl BottomNavigationActivationMode {
+    #[inline]
+    fn is_automatic(self) -> bool {
+        matches!(self, Self::Automatic)
+    }
+}
+
+/// Outcome produced after processing a keyboard event.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BottomNavigationKeyboardOutcome {
+    /// Destination that should receive focus after the key press.
+    pub focused: Option<usize>,
+    /// Destination that should be considered selected.
+    pub selected: Option<usize>,
+    /// Analytics payload describing the selection transition.
+    pub analytics: Option<BottomNavigationAnalyticsEvent>,
+}
+
+/// Analytics payload emitted when a destination is activated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BottomNavigationAnalyticsEvent {
+    /// Logical channel that downstream telemetry should attribute the event to.
+    pub channel: String,
+    /// Zero-based index of the activated destination.
+    pub index: usize,
+    /// Optional identifier supplied by the adapter for the activated item.
+    pub item_tag: Option<String>,
+}
+
+/// Builder describing the root navigation element.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationAttributes<'a> {
+    state: &'a BottomNavigationState,
+    id: Option<&'a str>,
+    labelled_by: Option<&'a str>,
+}
+
+impl<'a> BottomNavigationAttributes<'a> {
+    /// Create a new builder instance bound to the provided state.
+    pub fn new(state: &'a BottomNavigationState) -> Self {
+        Self {
+            state,
+            id: None,
+            labelled_by: None,
+        }
+    }
+
+    /// Assign a DOM id to the navigation region.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Link the navigation region to an external label.
+    pub fn labelled_by(mut self, value: &'a str) -> Self {
+        self.labelled_by = Some(value);
+        self
+    }
+
+    /// Returns the ARIA role describing the container.
+    pub fn role(&self) -> &'static str {
+        aria::role_tablist()
+    }
+
+    /// Optional id attribute tuple.
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Optional `aria-labelledby` attribute tuple.
+    pub fn labelledby(&self) -> Option<(&'static str, &str)> {
+        self.labelled_by.map(aria::aria_labelledby)
+    }
+
+    /// Optional analytics attribute applied to the root wrapper.
+    pub fn analytics_attribute(&self) -> Option<(&'static str, &str)> {
+        self.state
+            .analytics_channel
+            .as_deref()
+            .map(|value| ("data-rustic-analytics-channel", value))
+    }
+}
+
+/// Builder describing a single navigation destination.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationItemAttributes<'a> {
+    state: &'a BottomNavigationState,
+    index: usize,
+    id: Option<&'a str>,
+    controls: Option<&'a str>,
+    analytics_tag: Option<&'a str>,
+}
+
+impl<'a> BottomNavigationItemAttributes<'a> {
+    /// Internal helper for constructing a builder instance.
+    fn new(state: &'a BottomNavigationState, index: usize) -> Self {
+        Self {
+            state,
+            index,
+            id: None,
+            controls: None,
+            analytics_tag: None,
+        }
+    }
+
+    /// Assign the DOM id for the interactive element.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Declare the `aria-controls` relationship linking to the associated panel.
+    pub fn controls(mut self, value: &'a str) -> Self {
+        self.controls = Some(value);
+        self
+    }
+
+    /// Associate a stable analytics tag for the destination.
+    pub fn analytics_tag(mut self, value: &'a str) -> Self {
+        self.analytics_tag = Some(value);
+        self
+    }
+
+    /// Collect the ARIA and data attributes describing the destination.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::with_capacity(6);
+        pairs.push(("role", aria::role_tab().to_string()));
+        let selected = self.state.selected == Some(self.index);
+        let focused = self.state.focused == Some(self.index);
+        pairs.push((
+            aria::aria_selected(selected).0,
+            aria::aria_selected(selected).1.to_string(),
+        ));
+        let tabindex = if focused { 0 } else { -1 };
+        pairs.push(("tabindex", tabindex.to_string()));
+        if let Some(id) = self.id {
+            pairs.push(("id", id.to_string()));
+        }
+        if let Some(controls) = self.controls {
+            pairs.push(("aria-controls", controls.to_string()));
+        }
+        if let Some(tag) = self.analytics_tag {
+            pairs.push(("data-rustic-analytics-id", tag.to_string()));
+        }
+        pairs.push((
+            "data-rustic-bottom-navigation-index",
+            self.index.to_string(),
+        ));
+        if let Some(disabled) = self.state.disabled.get(self.index) {
+            if *disabled {
+                pairs.push(("aria-disabled", "true".into()));
+                pairs.push(("data-disabled", "true".into()));
+            }
+        }
+        pairs
+    }
+}
+
+/// Headless controller managing bottom navigation state.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationState {
+    item_count: usize,
+    selected: Option<usize>,
+    focused: Option<usize>,
+    activation: BottomNavigationActivationMode,
+    selection_mode: ControlStrategy,
+    focus_mode: ControlStrategy,
+    analytics_channel: Option<String>,
+    analytics_tags: Vec<Option<String>>,
+    disabled: Vec<bool>,
+}
+
+impl BottomNavigationState {
+    /// Construct a new state machine instance.
+    pub fn new(
+        item_count: usize,
+        default_selected: Option<usize>,
+        activation: BottomNavigationActivationMode,
+        selection_mode: ControlStrategy,
+        focus_mode: ControlStrategy,
+    ) -> Self {
+        let selected = clamp_index(default_selected, item_count);
+        let focused = selected.or(if item_count > 0 { Some(0) } else { None });
+        Self {
+            item_count,
+            selected,
+            focused,
+            activation,
+            selection_mode,
+            focus_mode,
+            analytics_channel: None,
+            analytics_tags: vec![None; item_count],
+            disabled: vec![false; item_count],
+        }
+    }
+
+    /// Returns the builder for the container attributes.
+    pub fn root_attributes(&self) -> BottomNavigationAttributes<'_> {
+        BottomNavigationAttributes::new(self)
+    }
+
+    /// Returns the builder for an item at the specified index.
+    pub fn item_attributes(&self, index: usize) -> BottomNavigationItemAttributes<'_> {
+        BottomNavigationItemAttributes::new(self, index)
+    }
+
+    /// Configure an analytics channel surfaced via `data-rustic-analytics-channel`.
+    pub fn set_analytics_channel(&mut self, channel: Option<impl Into<String>>) {
+        self.analytics_channel = channel.map(Into::into);
+    }
+
+    /// Assign an analytics tag used when emitting selection events for an item.
+    pub fn set_item_analytics_tag(&mut self, index: usize, tag: Option<impl Into<String>>) {
+        if index >= self.item_count {
+            return;
+        }
+        if let Some(slot) = self.analytics_tags.get_mut(index) {
+            *slot = tag.map(Into::into);
+        }
+    }
+
+    /// Update the disabled flag for a destination.
+    pub fn set_item_disabled(&mut self, index: usize, disabled: bool) {
+        if index >= self.item_count {
+            return;
+        }
+        if let Some(slot) = self.disabled.get_mut(index) {
+            *slot = disabled;
+        }
+        if self.focused == Some(index) && disabled {
+            self.focused = self.next_enabled(index as isize + 1);
+        }
+        if self.selected == Some(index) && disabled {
+            self.selected = self.next_enabled(index as isize + 1);
+        }
+    }
+
+    /// Returns whether the destination is disabled.
+    pub fn is_disabled(&self, index: usize) -> bool {
+        self.disabled.get(index).copied().unwrap_or(true)
+    }
+
+    /// Synchronize the selected destination for controlled adapters.
+    pub fn sync_selected(&mut self, index: Option<usize>) {
+        self.selected = clamp_index(index, self.item_count);
+    }
+
+    /// Synchronize the focused destination when the adapter owns roving tabindex.
+    pub fn sync_focused(&mut self, index: Option<usize>) {
+        self.focused = clamp_index(index, self.item_count);
+    }
+
+    /// Returns the currently selected destination.
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Returns the currently focused destination.
+    pub fn focused(&self) -> Option<usize> {
+        self.focused
+    }
+
+    /// Process a keyboard interaction and return the resulting focus/selection.
+    pub fn on_key<F: FnMut(BottomNavigationSelection)>(
+        &mut self,
+        key: ControlKey,
+        mut on_select: F,
+    ) -> BottomNavigationKeyboardOutcome {
+        let mut outcome = BottomNavigationKeyboardOutcome::default();
+        match key {
+            ControlKey::Enter | ControlKey::Space => {
+                if let Some(index) = self.focused {
+                    if !self.is_disabled(index) {
+                        outcome.selected = Some(index);
+                        outcome.focused = Some(index);
+                        outcome.analytics = self.apply_selection(index, &mut on_select);
+                    }
+                }
+            }
+            ControlKey::Home => {
+                let next = self.first_enabled();
+                outcome.focused = self.apply_focus(next);
+                if self.activation.is_automatic() {
+                    if let Some(index) = outcome.focused {
+                        outcome.selected = Some(index);
+                        outcome.analytics = self.apply_selection(index, &mut on_select);
+                    }
+                }
+            }
+            ControlKey::End => {
+                let next = self.last_enabled();
+                outcome.focused = self.apply_focus(next);
+                if self.activation.is_automatic() {
+                    if let Some(index) = outcome.focused {
+                        outcome.selected = Some(index);
+                        outcome.analytics = self.apply_selection(index, &mut on_select);
+                    }
+                }
+            }
+            _ if key.is_forward() => {
+                let next = self.advance(1);
+                outcome.focused = self.apply_focus(next);
+                if self.activation.is_automatic() {
+                    if let Some(index) = outcome.focused {
+                        outcome.selected = Some(index);
+                        outcome.analytics = self.apply_selection(index, &mut on_select);
+                    }
+                }
+            }
+            _ if key.is_backward() => {
+                let next = self.advance(-1);
+                outcome.focused = self.apply_focus(next);
+                if self.activation.is_automatic() {
+                    if let Some(index) = outcome.focused {
+                        outcome.selected = Some(index);
+                        outcome.analytics = self.apply_selection(index, &mut on_select);
+                    }
+                }
+            }
+            _ => {}
+        }
+        outcome
+    }
+
+    /// Activate the currently focused destination.
+    pub fn select_focused<F: FnMut(BottomNavigationSelection)>(
+        &mut self,
+        mut on_select: F,
+    ) -> Option<BottomNavigationAnalyticsEvent> {
+        if let Some(index) = self.focused {
+            if !self.is_disabled(index) {
+                return self.apply_selection(index, &mut on_select);
+            }
+        }
+        None
+    }
+
+    /// Activate a specific destination by index.
+    pub fn select_index<F: FnMut(BottomNavigationSelection)>(
+        &mut self,
+        index: usize,
+        mut on_select: F,
+    ) -> Option<BottomNavigationAnalyticsEvent> {
+        if index >= self.item_count || self.is_disabled(index) {
+            return None;
+        }
+        self.apply_focus(Some(index));
+        self.apply_selection(index, &mut on_select)
+    }
+
+    /// Resize the navigation when the number of destinations changes.
+    pub fn set_item_count(&mut self, count: usize) {
+        self.item_count = count;
+        self.analytics_tags.resize(count, None);
+        self.disabled.resize(count, false);
+        self.focused = clamp_index(self.focused, count);
+        self.selected = clamp_index(self.selected, count);
+    }
+
+    fn apply_focus(&mut self, next: Option<usize>) -> Option<usize> {
+        let normalized = clamp_index(next, self.item_count);
+        if !self.focus_mode.is_controlled() {
+            self.focused = normalized;
+        }
+        normalized
+    }
+
+    fn apply_selection<F: FnMut(BottomNavigationSelection)>(
+        &mut self,
+        index: usize,
+        on_select: &mut F,
+    ) -> Option<BottomNavigationAnalyticsEvent> {
+        if !self.focus_mode.is_controlled() {
+            self.focused = Some(index);
+        }
+        if !self.selection_mode.is_controlled() {
+            self.selected = Some(index);
+        }
+        let analytics = self.analytics_payload(index);
+        on_select(BottomNavigationSelection {
+            index,
+            analytics: analytics.clone(),
+        });
+        analytics
+    }
+
+    fn analytics_payload(&self, index: usize) -> Option<BottomNavigationAnalyticsEvent> {
+        let channel = self.analytics_channel.as_ref()?;
+        let tag = self
+            .analytics_tags
+            .get(index)
+            .and_then(|value| value.as_ref().map(|value| value.to_string()));
+        Some(BottomNavigationAnalyticsEvent {
+            channel: channel.clone(),
+            index,
+            item_tag: tag,
+        })
+    }
+
+    fn first_enabled(&self) -> Option<usize> {
+        (0..self.item_count).find(|&index| !self.is_disabled(index))
+    }
+
+    fn last_enabled(&self) -> Option<usize> {
+        (0..self.item_count)
+            .rev()
+            .find(|&index| !self.is_disabled(index))
+    }
+
+    fn next_enabled(&self, start: isize) -> Option<usize> {
+        if self.item_count == 0 {
+            return None;
+        }
+        let mut current = ((start % self.item_count as isize) + self.item_count as isize)
+            % self.item_count as isize;
+        for _ in 0..self.item_count {
+            let index = current as usize;
+            if !self.is_disabled(index) {
+                return Some(index);
+            }
+            current = (current + 1) % self.item_count as isize;
+        }
+        None
+    }
+
+    fn advance(&self, delta: isize) -> Option<usize> {
+        if self.item_count == 0 {
+            return None;
+        }
+        if self.focused.is_none() {
+            return if delta.is_positive() {
+                self.first_enabled()
+            } else {
+                self.last_enabled()
+            };
+        }
+        let mut candidate = wrap_index(self.focused, delta, self.item_count);
+        let mut attempts = 0;
+        while let Some(index) = candidate {
+            if !self.is_disabled(index) {
+                return Some(index);
+            }
+            attempts += 1;
+            if attempts >= self.item_count {
+                break;
+            }
+            candidate = wrap_index(Some(index), delta, self.item_count);
+        }
+        None
+    }
+}
+
+/// Selection notification emitted by [`BottomNavigationState`] when a destination
+/// changes.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationSelection {
+    /// Selected index.
+    pub index: usize,
+    /// Optional analytics payload.
+    pub analytics: Option<BottomNavigationAnalyticsEvent>,
+}

--- a/crates/rustic-ui-headless/src/breadcrumbs.rs
+++ b/crates/rustic-ui-headless/src/breadcrumbs.rs
@@ -1,0 +1,459 @@
+#![deny(missing_docs)]
+//! Headless breadcrumb controller that centralises ARIA, keyboard behaviour,
+//! and analytics hooks.
+//!
+//! The state machine is intentionally declarative: adapters describe the number
+//! of crumbs, mark the active page, and optionally supply automation/analytics
+//! identifiers.  Keyboard navigation mirrors WAI-ARIA authoring practices for
+//! breadcrumb trails by supporting horizontal traversal with <Left>/<Right>,
+//! quick jumps via <Home>/<End>, and activation through <Enter>/<Space>.  The
+//! resulting telemetry payload keeps audit logs consistent across frameworks
+//! without leaking implementation details into application code.
+
+use crate::{
+    aria,
+    interaction::ControlKey,
+    selection::{clamp_index, wrap_index, ControlStrategy},
+};
+
+/// Analytics payload describing user interaction with the breadcrumb trail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BreadcrumbsAnalyticsEvent {
+    /// Logical telemetry channel surfaced via `data-rustic-analytics-channel`.
+    pub channel: String,
+    /// Zero-based index of the activated crumb.
+    pub index: usize,
+    /// Optional crumb specific tag configured by the adapter.
+    pub crumb_tag: Option<String>,
+}
+
+/// Outcome produced after processing a keyboard event.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BreadcrumbsKeyboardOutcome {
+    /// Index that should receive focus.
+    pub focused: Option<usize>,
+    /// Index that should be activated (navigated to).
+    pub activated: Option<usize>,
+    /// Analytics payload describing the activation.
+    pub analytics: Option<BreadcrumbsAnalyticsEvent>,
+}
+
+/// Builder describing the `<nav>` wrapper attributes.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbsRootAttributes<'a> {
+    state: &'a BreadcrumbsState,
+    id: Option<&'a str>,
+    aria_label: Option<&'a str>,
+}
+
+impl<'a> BreadcrumbsRootAttributes<'a> {
+    /// Construct a new builder bound to the provided state.
+    pub fn new(state: &'a BreadcrumbsState) -> Self {
+        Self {
+            state,
+            id: None,
+            aria_label: Some("Breadcrumb"),
+        }
+    }
+
+    /// Assign a DOM id to the navigation region.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Override the accessible label announced by assistive technology.
+    pub fn aria_label(mut self, value: &'a str) -> Self {
+        self.aria_label = Some(value);
+        self
+    }
+
+    /// Returns the `role` tuple.
+    pub fn role(&self) -> &'static str {
+        aria::role_navigation()
+    }
+
+    /// Optional `id` attribute tuple.
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Optional `aria-label` tuple.
+    pub fn aria_label_attr(&self) -> Option<(&'static str, &str)> {
+        self.aria_label.map(|value| ("aria-label", value))
+    }
+
+    /// Optional analytics hook attribute.
+    pub fn analytics_attribute(&self) -> Option<(&'static str, &str)> {
+        self.state
+            .analytics_channel
+            .as_deref()
+            .map(|value| ("data-rustic-analytics-channel", value))
+    }
+}
+
+/// Builder describing the ordered list wrapper attributes.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbsListAttributes<'a> {
+    state: &'a BreadcrumbsState,
+    id: Option<&'a str>,
+}
+
+impl<'a> BreadcrumbsListAttributes<'a> {
+    /// Create a new builder for the list container.
+    pub fn new(state: &'a BreadcrumbsState) -> Self {
+        Self { state, id: None }
+    }
+
+    /// Assign a DOM id to the list element.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Returns the `role` tuple.
+    pub fn role(&self) -> &'static str {
+        aria::role_list()
+    }
+
+    /// Optional `id` attribute tuple.
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Optional analytics attribute mirrored from the root.
+    pub fn analytics_attribute(&self) -> Option<(&'static str, &str)> {
+        self.state
+            .analytics_channel
+            .as_deref()
+            .map(|value| ("data-rustic-analytics-channel", value))
+    }
+}
+
+/// Builder describing the interactive crumb element.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbItemAttributes<'a> {
+    state: &'a BreadcrumbsState,
+    index: usize,
+    id: Option<&'a str>,
+    href: Option<&'a str>,
+    analytics_tag: Option<&'a str>,
+}
+
+impl<'a> BreadcrumbItemAttributes<'a> {
+    fn new(state: &'a BreadcrumbsState, index: usize) -> Self {
+        Self {
+            state,
+            index,
+            id: None,
+            href: None,
+            analytics_tag: None,
+        }
+    }
+
+    /// Assign a DOM id to the anchor.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Configure the `href` destination.
+    pub fn href(mut self, value: &'a str) -> Self {
+        self.href = Some(value);
+        self
+    }
+
+    /// Associate an analytics identifier for the crumb.
+    pub fn analytics_tag(mut self, value: &'a str) -> Self {
+        self.analytics_tag = Some(value);
+        self
+    }
+
+    /// Collect the configured attributes into reusable pairs.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::with_capacity(8);
+        pairs.push(("role", aria::role_link().to_string()));
+        let focused = self.state.focused == Some(self.index);
+        pairs.push(("tabindex", if focused { "0" } else { "-1" }.to_string()));
+        if let Some(id) = self.id {
+            pairs.push(("id", id.to_string()));
+        }
+        if let Some(href) = self.href {
+            pairs.push(("href", href.to_string()));
+        }
+        if self.state.current == Some(self.index) {
+            let (key, value) = aria::aria_current("page");
+            pairs.push((key, value.to_string()));
+        }
+        if let Some(tag) = self.analytics_tag {
+            pairs.push(("data-rustic-analytics-id", tag.to_string()));
+        }
+        pairs.push(("data-rustic-breadcrumb-index", self.index.to_string()));
+        if self.state.is_disabled(self.index) {
+            pairs.push(("aria-disabled", "true".into()));
+            pairs.push(("data-disabled", "true".into()));
+        }
+        pairs
+    }
+}
+
+/// Builder describing the separator glyph between crumbs.
+#[derive(Debug, Clone, Default)]
+pub struct BreadcrumbSeparatorAttributes {
+    id: Option<String>,
+}
+
+impl BreadcrumbSeparatorAttributes {
+    /// Assign a DOM id to the separator for analytics tooling.
+    pub fn id(mut self, value: impl Into<String>) -> Self {
+        self.id = Some(value.into());
+        self
+    }
+
+    /// Returns the attributes describing the separator element.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = vec![("role", aria::role_separator().to_string())];
+        if let Some(id) = &self.id {
+            pairs.push(("id", id.clone()));
+        }
+        pairs
+    }
+}
+
+/// Headless breadcrumb state machine.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbsState {
+    item_count: usize,
+    focused: Option<usize>,
+    current: Option<usize>,
+    focus_mode: ControlStrategy,
+    selection_mode: ControlStrategy,
+    analytics_channel: Option<String>,
+    analytics_tags: Vec<Option<String>>,
+    disabled: Vec<bool>,
+}
+
+impl BreadcrumbsState {
+    /// Construct a new breadcrumb controller.
+    pub fn new(
+        item_count: usize,
+        current: Option<usize>,
+        focus_mode: ControlStrategy,
+        selection_mode: ControlStrategy,
+    ) -> Self {
+        let current = clamp_index(current, item_count);
+        let focused = current.or(if item_count > 0 { Some(0) } else { None });
+        Self {
+            item_count,
+            focused,
+            current,
+            focus_mode,
+            selection_mode,
+            analytics_channel: None,
+            analytics_tags: vec![None; item_count],
+            disabled: vec![false; item_count],
+        }
+    }
+
+    /// Returns the root attribute builder.
+    pub fn root_attributes(&self) -> BreadcrumbsRootAttributes<'_> {
+        BreadcrumbsRootAttributes::new(self)
+    }
+
+    /// Returns the ordered list attribute builder.
+    pub fn list_attributes(&self) -> BreadcrumbsListAttributes<'_> {
+        BreadcrumbsListAttributes::new(self)
+    }
+
+    /// Returns the item attribute builder for the provided index.
+    pub fn item_attributes(&self, index: usize) -> BreadcrumbItemAttributes<'_> {
+        BreadcrumbItemAttributes::new(self, index)
+    }
+
+    /// Returns a separator attribute builder.
+    pub fn separator_attributes(&self) -> BreadcrumbSeparatorAttributes {
+        BreadcrumbSeparatorAttributes::default()
+    }
+
+    /// Update the number of crumbs.
+    pub fn set_item_count(&mut self, count: usize) {
+        self.item_count = count;
+        self.analytics_tags.resize(count, None);
+        self.disabled.resize(count, false);
+        self.focused = clamp_index(self.focused, count);
+        self.current = clamp_index(self.current, count);
+    }
+
+    /// Configure the analytics channel.
+    pub fn set_analytics_channel(&mut self, channel: Option<impl Into<String>>) {
+        self.analytics_channel = channel.map(Into::into);
+    }
+
+    /// Configure an analytics tag for the crumb at `index`.
+    pub fn set_item_analytics_tag(&mut self, index: usize, tag: Option<impl Into<String>>) {
+        if index >= self.item_count {
+            return;
+        }
+        if let Some(slot) = self.analytics_tags.get_mut(index) {
+            *slot = tag.map(Into::into);
+        }
+    }
+
+    /// Mark a crumb as disabled (non-navigable).
+    pub fn set_item_disabled(&mut self, index: usize, disabled: bool) {
+        if index >= self.item_count {
+            return;
+        }
+        if let Some(slot) = self.disabled.get_mut(index) {
+            *slot = disabled;
+        }
+        if disabled {
+            if self.focused == Some(index) {
+                self.focused = self.advance(1);
+            }
+            if self.current == Some(index) {
+                self.current = None;
+            }
+        }
+    }
+
+    /// Returns whether the crumb is disabled.
+    pub fn is_disabled(&self, index: usize) -> bool {
+        self.disabled.get(index).copied().unwrap_or(true)
+    }
+
+    /// Synchronise the currently active crumb (controlled mode).
+    pub fn sync_current(&mut self, index: Option<usize>) {
+        if self.selection_mode.is_controlled() {
+            self.current = clamp_index(index, self.item_count);
+        }
+    }
+
+    /// Synchronise the focused crumb (controlled focus mode).
+    pub fn sync_focused(&mut self, index: Option<usize>) {
+        if self.focus_mode.is_controlled() {
+            self.focused = clamp_index(index, self.item_count);
+        }
+    }
+
+    /// Handle keyboard interactions and return the resulting intent.
+    pub fn on_key<F: FnMut(BreadcrumbsActivation)>(
+        &mut self,
+        key: ControlKey,
+        mut on_activate: F,
+    ) -> BreadcrumbsKeyboardOutcome {
+        let mut outcome = BreadcrumbsKeyboardOutcome::default();
+        match key {
+            ControlKey::Enter | ControlKey::Space => {
+                if let Some(index) = self.focused {
+                    if !self.is_disabled(index) {
+                        outcome.activated = Some(index);
+                        outcome.analytics = self.apply_activation(index, &mut on_activate);
+                    }
+                }
+            }
+            ControlKey::Home => {
+                outcome.focused = self.apply_focus(self.first_enabled());
+            }
+            ControlKey::End => {
+                outcome.focused = self.apply_focus(self.last_enabled());
+            }
+            _ if key.is_forward() => {
+                outcome.focused = self.apply_focus(self.advance(1));
+            }
+            _ if key.is_backward() => {
+                outcome.focused = self.apply_focus(self.advance(-1));
+            }
+            _ => {}
+        }
+        outcome
+    }
+
+    /// Imperatively activate a crumb.
+    pub fn activate<F: FnMut(BreadcrumbsActivation)>(
+        &mut self,
+        index: usize,
+        mut on_activate: F,
+    ) -> Option<BreadcrumbsAnalyticsEvent> {
+        if index >= self.item_count || self.is_disabled(index) {
+            return None;
+        }
+        self.apply_focus(Some(index));
+        self.apply_activation(index, &mut on_activate)
+    }
+
+    fn apply_focus(&mut self, next: Option<usize>) -> Option<usize> {
+        let normalized = clamp_index(next, self.item_count);
+        if !self.focus_mode.is_controlled() {
+            self.focused = normalized;
+        }
+        normalized
+    }
+
+    fn apply_activation<F: FnMut(BreadcrumbsActivation)>(
+        &mut self,
+        index: usize,
+        on_activate: &mut F,
+    ) -> Option<BreadcrumbsAnalyticsEvent> {
+        if !self.selection_mode.is_controlled() {
+            self.current = Some(index);
+        }
+        let analytics = self.analytics_payload(index);
+        on_activate(BreadcrumbsActivation {
+            index,
+            analytics: analytics.clone(),
+        });
+        analytics
+    }
+
+    fn analytics_payload(&self, index: usize) -> Option<BreadcrumbsAnalyticsEvent> {
+        let channel = self.analytics_channel.as_ref()?;
+        let tag = self
+            .analytics_tags
+            .get(index)
+            .and_then(|value| value.as_ref().map(|value| value.to_string()));
+        Some(BreadcrumbsAnalyticsEvent {
+            channel: channel.clone(),
+            index,
+            crumb_tag: tag,
+        })
+    }
+
+    fn first_enabled(&self) -> Option<usize> {
+        (0..self.item_count).find(|&index| !self.is_disabled(index))
+    }
+
+    fn last_enabled(&self) -> Option<usize> {
+        (0..self.item_count)
+            .rev()
+            .find(|&index| !self.is_disabled(index))
+    }
+
+    fn advance(&self, delta: isize) -> Option<usize> {
+        if self.item_count == 0 {
+            return None;
+        }
+        let mut candidate = wrap_index(self.focused, delta, self.item_count);
+        let mut attempts = 0;
+        while let Some(index) = candidate {
+            if !self.is_disabled(index) {
+                return Some(index);
+            }
+            attempts += 1;
+            if attempts >= self.item_count {
+                break;
+            }
+            candidate = wrap_index(Some(index), delta, self.item_count);
+        }
+        None
+    }
+}
+
+/// Activation payload emitted when a crumb is triggered.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbsActivation {
+    /// Activated crumb index.
+    pub index: usize,
+    /// Optional analytics payload describing the activation.
+    pub analytics: Option<BreadcrumbsAnalyticsEvent>,
+}

--- a/crates/rustic-ui-headless/src/lib.rs
+++ b/crates/rustic-ui-headless/src/lib.rs
@@ -34,7 +34,9 @@ pub mod avatar;
 #[cfg(feature = "feedback")]
 pub mod backdrop;
 pub mod badge;
+pub mod bottom_navigation;
 pub mod r#box;
+pub mod breadcrumbs;
 pub mod button;
 pub mod checkbox;
 pub mod chip;
@@ -58,8 +60,10 @@ pub mod interaction;
 pub mod layout;
 #[cfg(feature = "progress")]
 pub mod linear_progress;
+pub mod link;
 pub mod list;
 pub mod menu;
+pub mod pagination;
 pub mod paper;
 pub mod popover;
 pub mod radio;
@@ -68,6 +72,7 @@ pub mod select;
 pub mod skeleton;
 pub mod slider;
 pub mod snackbar;
+pub mod speed_dial;
 pub mod stack;
 pub mod stepper;
 pub mod switch;
@@ -82,6 +87,8 @@ pub mod typography;
 
 mod selection;
 mod toggle;
+
+pub use selection::ControlStrategy;
 
 #[cfg(feature = "compat-mui")]
 #[doc = "Deprecated compatibility shim exposing the crate under the legacy `mui_headless` name.\n\

--- a/crates/rustic-ui-headless/src/link.rs
+++ b/crates/rustic-ui-headless/src/link.rs
@@ -1,0 +1,176 @@
+#![deny(missing_docs)]
+//! Headless helpers for instrumentation friendly links.
+//!
+//! The state keeps analytics identifiers, accessibility metadata, and keyboard
+//! semantics consistent across frameworks.  Renderers simply merge the returned
+//! attribute pairs into their markup, guaranteeing that SSR, hydration, and
+//! automation tooling observe the same contracts regardless of runtime.
+
+use crate::{aria, interaction::ControlKey};
+
+/// Analytics payload emitted when the link is activated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkAnalyticsEvent {
+    /// Logical analytics channel surfaced on the rendered element.
+    pub channel: String,
+    /// Optional analytics tag supplied by the adapter for granular reporting.
+    pub link_tag: Option<String>,
+}
+
+/// Describes the outcome of handling a keyboard event.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LinkKeyboardOutcome {
+    /// Whether the event should trigger navigation.
+    pub activate: bool,
+    /// Analytics payload associated with the activation.
+    pub analytics: Option<LinkAnalyticsEvent>,
+}
+
+/// Headless state backing instrumentation aware links.
+#[derive(Debug, Clone, Default)]
+pub struct LinkState {
+    disabled: bool,
+    activate_on_space: bool,
+    analytics_channel: Option<String>,
+    analytics_tag: Option<String>,
+}
+
+impl LinkState {
+    /// Construct a new link controller.
+    pub fn new(activate_on_space: bool) -> Self {
+        Self {
+            disabled: false,
+            activate_on_space,
+            analytics_channel: None,
+            analytics_tag: None,
+        }
+    }
+
+    /// Returns whether the link is currently disabled.
+    pub fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
+    /// Mark the link as disabled which removes it from the tab order.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.disabled = disabled;
+    }
+
+    /// Configure the analytics channel surfaced on the rendered element.
+    pub fn set_analytics_channel(&mut self, channel: Option<impl Into<String>>) {
+        self.analytics_channel = channel.map(Into::into);
+    }
+
+    /// Configure the analytics tag used when emitting activation events.
+    pub fn set_analytics_tag(&mut self, tag: Option<impl Into<String>>) {
+        self.analytics_tag = tag.map(Into::into);
+    }
+
+    /// Returns the attribute builder describing the anchor element.
+    pub fn attributes(&self) -> LinkAttributes<'_> {
+        LinkAttributes {
+            state: self,
+            href: None,
+            id: None,
+            rel: None,
+            target: None,
+        }
+    }
+
+    /// Handle keyboard events returning whether the link should activate.
+    pub fn on_key(&self, key: ControlKey) -> LinkKeyboardOutcome {
+        if self.disabled {
+            return LinkKeyboardOutcome::default();
+        }
+        match key {
+            ControlKey::Enter => LinkKeyboardOutcome {
+                activate: true,
+                analytics: self.analytics_payload(),
+            },
+            ControlKey::Space if self.activate_on_space => LinkKeyboardOutcome {
+                activate: true,
+                analytics: self.analytics_payload(),
+            },
+            _ => LinkKeyboardOutcome::default(),
+        }
+    }
+
+    /// Build the analytics payload when the link activates.
+    pub fn analytics_payload(&self) -> Option<LinkAnalyticsEvent> {
+        self.analytics_channel
+            .as_ref()
+            .map(|channel| LinkAnalyticsEvent {
+                channel: channel.clone(),
+                link_tag: self.analytics_tag.clone(),
+            })
+    }
+}
+
+/// Builder describing the anchor attributes.
+#[derive(Debug, Clone)]
+pub struct LinkAttributes<'a> {
+    state: &'a LinkState,
+    href: Option<&'a str>,
+    id: Option<&'a str>,
+    rel: Option<&'a str>,
+    target: Option<&'a str>,
+}
+
+impl<'a> LinkAttributes<'a> {
+    /// Assign the `href` destination.
+    pub fn href(mut self, value: &'a str) -> Self {
+        self.href = Some(value);
+        self
+    }
+
+    /// Assign the `id` attribute.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Assign the `rel` attribute.
+    pub fn rel(mut self, value: &'a str) -> Self {
+        self.rel = Some(value);
+        self
+    }
+
+    /// Assign the `target` attribute.
+    pub fn target(mut self, value: &'a str) -> Self {
+        self.target = Some(value);
+        self
+    }
+
+    /// Collect the configured attributes into reusable pairs.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::with_capacity(8);
+        pairs.push(("role", aria::role_link().to_string()));
+        pairs.push((
+            "tabindex",
+            if self.state.disabled { "-1" } else { "0" }.to_string(),
+        ));
+        if let Some(href) = self.href {
+            pairs.push(("href", href.to_string()));
+        }
+        if let Some(id) = self.id {
+            pairs.push(("id", id.to_string()));
+        }
+        if let Some(rel) = self.rel {
+            pairs.push(("rel", rel.to_string()));
+        }
+        if let Some(target) = self.target {
+            pairs.push(("target", target.to_string()));
+        }
+        if self.state.disabled {
+            pairs.push(("aria-disabled", "true".into()));
+            pairs.push(("data-disabled", "true".into()));
+        }
+        if let Some(channel) = self.state.analytics_channel.as_ref() {
+            pairs.push(("data-rustic-analytics-channel", channel.clone()));
+        }
+        if let Some(tag) = self.state.analytics_tag.as_ref() {
+            pairs.push(("data-rustic-analytics-id", tag.clone()));
+        }
+        pairs
+    }
+}

--- a/crates/rustic-ui-headless/src/pagination.rs
+++ b/crates/rustic-ui-headless/src/pagination.rs
@@ -1,0 +1,557 @@
+#![deny(missing_docs)]
+//! Headless pagination controller shared across framework adapters.
+//!
+//! The state machine centralises keyboard handling, ARIA wiring, and analytics
+//! payload generation so renderers can remain deterministic.  Consumers describe
+//! the number of pages, optionally expose first/last controls, and wire the
+//! resulting attribute builders into their templates.
+
+use crate::{
+    aria,
+    interaction::ControlKey,
+    selection::{clamp_index, ControlStrategy},
+};
+
+/// Analytics payload emitted when the current page changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaginationAnalyticsEvent {
+    /// Logical analytics channel surfaced on the rendered container.
+    pub channel: String,
+    /// Selected zero-based page index.
+    pub page_index: usize,
+    /// Optional page specific analytics tag.
+    pub page_tag: Option<String>,
+}
+
+/// Outcome produced when handling keyboard input.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PaginationKeyboardOutcome {
+    /// Item that should receive focus after the key press.
+    pub focused: Option<PaginationItemKind>,
+    /// Page that should be selected.
+    pub selected_page: Option<usize>,
+    /// Analytics payload describing the selection.
+    pub analytics: Option<PaginationAnalyticsEvent>,
+}
+
+/// Enumerates the interactive elements rendered by the pagination component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PaginationItemKind {
+    /// Represents a numbered page button.
+    Page(usize),
+    /// Represents the "previous" control.
+    Previous,
+    /// Represents the "next" control.
+    Next,
+    /// Represents the "first" control.
+    First,
+    /// Represents the "last" control.
+    Last,
+}
+
+impl PaginationItemKind {
+    /// Returns a machine readable identifier used by automation hooks.
+    pub fn as_data_value(self) -> &'static str {
+        match self {
+            Self::Page(_) => "page",
+            Self::Previous => "previous",
+            Self::Next => "next",
+            Self::First => "first",
+            Self::Last => "last",
+        }
+    }
+}
+
+/// Builder describing the `<nav>` wrapper attributes.
+#[derive(Debug, Clone)]
+pub struct PaginationRootAttributes<'a> {
+    state: &'a PaginationState,
+    id: Option<&'a str>,
+    aria_label: Option<&'a str>,
+}
+
+impl<'a> PaginationRootAttributes<'a> {
+    /// Construct a new builder bound to the provided state.
+    pub fn new(state: &'a PaginationState) -> Self {
+        Self {
+            state,
+            id: None,
+            aria_label: Some("Pagination"),
+        }
+    }
+
+    /// Assign a DOM id to the navigation region.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Override the default `aria-label`.
+    pub fn aria_label(mut self, value: &'a str) -> Self {
+        self.aria_label = Some(value);
+        self
+    }
+
+    /// Returns the landmark role for the wrapper.
+    pub fn role(&self) -> &'static str {
+        aria::role_navigation()
+    }
+
+    /// Optional `id` attribute tuple.
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Optional `aria-label` tuple.
+    pub fn aria_label_attr(&self) -> Option<(&'static str, &str)> {
+        self.aria_label.map(|value| ("aria-label", value))
+    }
+
+    /// Optional analytics attribute.
+    pub fn analytics_attribute(&self) -> Option<(&'static str, &str)> {
+        self.state
+            .analytics_channel
+            .as_deref()
+            .map(|value| ("data-rustic-analytics-channel", value))
+    }
+}
+
+/// Builder describing the list wrapper attributes.
+#[derive(Debug, Clone)]
+pub struct PaginationListAttributes<'a> {
+    state: &'a PaginationState,
+    id: Option<&'a str>,
+}
+
+impl<'a> PaginationListAttributes<'a> {
+    /// Construct a new builder for the list container.
+    pub fn new(state: &'a PaginationState) -> Self {
+        Self { state, id: None }
+    }
+
+    /// Assign a DOM id to the list element.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Returns the ARIA role for the list container.
+    pub fn role(&self) -> &'static str {
+        aria::role_list()
+    }
+
+    /// Optional `id` tuple.
+    pub fn id_attr(&self) -> Option<(&'static str, &str)> {
+        self.id.map(|value| ("id", value))
+    }
+
+    /// Optional analytics attribute mirrored from the root.
+    pub fn analytics_attribute(&self) -> Option<(&'static str, &str)> {
+        self.state
+            .analytics_channel
+            .as_deref()
+            .map(|value| ("data-rustic-analytics-channel", value))
+    }
+}
+
+/// Builder describing an interactive pagination control.
+#[derive(Debug, Clone)]
+pub struct PaginationItemAttributes<'a> {
+    state: &'a PaginationState,
+    kind: PaginationItemKind,
+    id: Option<&'a str>,
+    aria_label: Option<&'a str>,
+}
+
+impl<'a> PaginationItemAttributes<'a> {
+    fn new(state: &'a PaginationState, kind: PaginationItemKind) -> Self {
+        Self {
+            state,
+            kind,
+            id: None,
+            aria_label: None,
+        }
+    }
+
+    /// Assign a DOM id to the interactive element.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Override the accessible label for non-page controls.
+    pub fn aria_label(mut self, value: &'a str) -> Self {
+        self.aria_label = Some(value);
+        self
+    }
+
+    /// Collect ARIA/data attributes describing the element.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::with_capacity(10);
+        pairs.push(("role", aria::role_button().to_string()));
+        let focused = self.state.focused == Some(self.kind);
+        pairs.push(("tabindex", if focused { "0" } else { "-1" }.to_string()));
+        if let Some(id) = self.id {
+            pairs.push(("id", id.to_string()));
+        }
+        let disabled = self.state.is_disabled(self.kind);
+        if disabled {
+            pairs.push(("aria-disabled", "true".into()));
+            pairs.push(("data-disabled", "true".into()));
+        }
+        let label = self
+            .aria_label
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| match self.kind {
+                PaginationItemKind::Previous => "Go to previous page".to_string(),
+                PaginationItemKind::Next => "Go to next page".to_string(),
+                PaginationItemKind::First => "Go to first page".to_string(),
+                PaginationItemKind::Last => "Go to last page".to_string(),
+                PaginationItemKind::Page(index) => {
+                    if self.state.page_count == 0 {
+                        "Page".to_string()
+                    } else {
+                        format!("Go to page {}", index + 1)
+                    }
+                }
+            });
+        pairs.push(("aria-label", label));
+        pairs.push((
+            "data-rustic-pagination-kind",
+            self.kind.as_data_value().to_string(),
+        ));
+        if let PaginationItemKind::Page(index) = self.kind {
+            pairs.push(("data-rustic-pagination-page", index.to_string()));
+            if self.state.current == Some(index) {
+                let (key, value) = aria::aria_current("page");
+                pairs.push((key, value.to_string()));
+            }
+        }
+        pairs
+    }
+}
+
+/// Headless state machine managing pagination interactions.
+#[derive(Debug, Clone)]
+pub struct PaginationState {
+    page_count: usize,
+    current: Option<usize>,
+    focused: Option<PaginationItemKind>,
+    selection_mode: ControlStrategy,
+    focus_mode: ControlStrategy,
+    include_edge_controls: bool,
+    analytics_channel: Option<String>,
+    page_tags: Vec<Option<String>>,
+}
+
+impl PaginationState {
+    /// Construct a new pagination controller.
+    pub fn new(
+        page_count: usize,
+        current: Option<usize>,
+        selection_mode: ControlStrategy,
+        focus_mode: ControlStrategy,
+    ) -> Self {
+        let current = clamp_index(current, page_count);
+        let focused = current.map(PaginationItemKind::Page).or_else(|| {
+            if page_count > 0 {
+                Some(PaginationItemKind::Page(0))
+            } else {
+                None
+            }
+        });
+        Self {
+            page_count,
+            current,
+            focused,
+            selection_mode,
+            focus_mode,
+            include_edge_controls: true,
+            analytics_channel: None,
+            page_tags: vec![None; page_count],
+        }
+    }
+
+    /// Returns the root attribute builder.
+    pub fn root_attributes(&self) -> PaginationRootAttributes<'_> {
+        PaginationRootAttributes::new(self)
+    }
+
+    /// Returns the list attribute builder.
+    pub fn list_attributes(&self) -> PaginationListAttributes<'_> {
+        PaginationListAttributes::new(self)
+    }
+
+    /// Returns the item attribute builder for a specific kind.
+    pub fn item_attributes(&self, kind: PaginationItemKind) -> PaginationItemAttributes<'_> {
+        PaginationItemAttributes::new(self, kind)
+    }
+
+    /// Toggle whether "first"/"last" controls are rendered.
+    pub fn set_include_edge_controls(&mut self, include: bool) {
+        self.include_edge_controls = include;
+    }
+
+    /// Configure the analytics channel for telemetry pipelines.
+    pub fn set_analytics_channel(&mut self, channel: Option<impl Into<String>>) {
+        self.analytics_channel = channel.map(Into::into);
+    }
+
+    /// Configure the analytics tag for a specific page button.
+    pub fn set_page_analytics_tag(&mut self, index: usize, tag: Option<impl Into<String>>) {
+        if index >= self.page_count {
+            return;
+        }
+        if let Some(slot) = self.page_tags.get_mut(index) {
+            *slot = tag.map(Into::into);
+        }
+    }
+
+    /// Update the number of available pages.
+    pub fn set_page_count(&mut self, count: usize) {
+        self.page_count = count;
+        self.page_tags.resize(count, None);
+        self.current = clamp_index(self.current, count);
+        if let Some(PaginationItemKind::Page(index)) = self.focused {
+            self.focused = clamp_index(Some(index), count).map(PaginationItemKind::Page);
+        }
+    }
+
+    /// Synchronise the current page when controlled externally.
+    pub fn sync_current(&mut self, index: Option<usize>) {
+        if self.selection_mode.is_controlled() {
+            self.current = clamp_index(index, self.page_count);
+        }
+    }
+
+    /// Synchronise the focused item when roving tabindex is controlled.
+    pub fn sync_focused(&mut self, kind: Option<PaginationItemKind>) {
+        if self.focus_mode.is_controlled() {
+            self.focused = kind;
+        }
+    }
+
+    /// Returns whether the provided control is disabled.
+    pub fn is_disabled(&self, kind: PaginationItemKind) -> bool {
+        match kind {
+            PaginationItemKind::Page(index) => index >= self.page_count,
+            PaginationItemKind::Previous | PaginationItemKind::First => {
+                self.page_count == 0 || self.current.unwrap_or(0) == 0
+            }
+            PaginationItemKind::Next | PaginationItemKind::Last => {
+                if self.page_count == 0 {
+                    true
+                } else {
+                    self.current.unwrap_or(0) >= self.page_count.saturating_sub(1)
+                }
+            }
+        }
+    }
+
+    /// Process a keyboard event returning the resulting intent.
+    pub fn on_key<F: FnMut(PaginationSelection)>(
+        &mut self,
+        key: ControlKey,
+        mut on_select: F,
+    ) -> PaginationKeyboardOutcome {
+        let mut outcome = PaginationKeyboardOutcome::default();
+        match key {
+            ControlKey::Enter | ControlKey::Space => {
+                if let Some(kind) = self.focused {
+                    let result = self.activate(kind, &mut on_select);
+                    outcome.selected_page = result.selected_page;
+                    outcome.analytics = result.analytics;
+                }
+            }
+            ControlKey::Home => {
+                outcome.focused = self.apply_focus(self.first_focusable());
+            }
+            ControlKey::End => {
+                outcome.focused = self.apply_focus(self.last_focusable());
+            }
+            _ if key.is_forward() => {
+                outcome.focused = self.apply_focus(self.advance_focus(1));
+            }
+            _ if key.is_backward() => {
+                outcome.focused = self.apply_focus(self.advance_focus(-1));
+            }
+            _ => {}
+        }
+        outcome
+    }
+
+    /// Imperatively activate a pagination control.
+    pub fn activate<F: FnMut(PaginationSelection)>(
+        &mut self,
+        kind: PaginationItemKind,
+        mut on_select: F,
+    ) -> PaginationSelectionOutcome {
+        self.activate_internal(kind, &mut on_select)
+    }
+
+    fn activate_internal<F: FnMut(PaginationSelection)>(
+        &mut self,
+        kind: PaginationItemKind,
+        on_select: &mut F,
+    ) -> PaginationSelectionOutcome {
+        if self.is_disabled(kind) {
+            return PaginationSelectionOutcome::default();
+        }
+        match kind {
+            PaginationItemKind::Page(index) => self.apply_selection(index, on_select),
+            PaginationItemKind::Previous => {
+                let current = self.current.unwrap_or(0);
+                if current > 0 {
+                    self.apply_selection(current - 1, on_select)
+                } else {
+                    PaginationSelectionOutcome::default()
+                }
+            }
+            PaginationItemKind::Next => {
+                if let Some(current) = self.current {
+                    if current + 1 < self.page_count {
+                        self.apply_selection(current + 1, on_select)
+                    } else {
+                        PaginationSelectionOutcome::default()
+                    }
+                } else if self.page_count > 0 {
+                    self.apply_selection(0, on_select)
+                } else {
+                    PaginationSelectionOutcome::default()
+                }
+            }
+            PaginationItemKind::First => {
+                if self.page_count > 0 {
+                    self.apply_selection(0, on_select)
+                } else {
+                    PaginationSelectionOutcome::default()
+                }
+            }
+            PaginationItemKind::Last => {
+                if self.page_count > 0 {
+                    self.apply_selection(self.page_count - 1, on_select)
+                } else {
+                    PaginationSelectionOutcome::default()
+                }
+            }
+        }
+    }
+
+    fn apply_selection<F: FnMut(PaginationSelection)>(
+        &mut self,
+        index: usize,
+        on_select: &mut F,
+    ) -> PaginationSelectionOutcome {
+        if index >= self.page_count {
+            return PaginationSelectionOutcome::default();
+        }
+        if !self.selection_mode.is_controlled() {
+            self.current = Some(index);
+        }
+        let analytics = self.analytics_payload(index);
+        let selection = PaginationSelection {
+            page_index: index,
+            analytics: analytics.clone(),
+        };
+        on_select(selection);
+        PaginationSelectionOutcome {
+            selected_page: Some(index),
+            analytics,
+        }
+    }
+
+    fn analytics_payload(&self, index: usize) -> Option<PaginationAnalyticsEvent> {
+        let channel = self.analytics_channel.as_ref()?;
+        let tag = self
+            .page_tags
+            .get(index)
+            .and_then(|value| value.as_ref().map(|value| value.to_string()));
+        Some(PaginationAnalyticsEvent {
+            channel: channel.clone(),
+            page_index: index,
+            page_tag: tag,
+        })
+    }
+
+    fn apply_focus(&mut self, next: Option<PaginationItemKind>) -> Option<PaginationItemKind> {
+        if !self.focus_mode.is_controlled() {
+            self.focused = next;
+        }
+        next
+    }
+
+    fn first_focusable(&self) -> Option<PaginationItemKind> {
+        self.focus_sequence()
+            .into_iter()
+            .find(|kind| !self.is_disabled(*kind))
+    }
+
+    fn last_focusable(&self) -> Option<PaginationItemKind> {
+        self.focus_sequence()
+            .into_iter()
+            .rev()
+            .find(|kind| !self.is_disabled(*kind))
+    }
+
+    fn advance_focus(&self, delta: isize) -> Option<PaginationItemKind> {
+        let sequence = self.focus_sequence();
+        if sequence.is_empty() {
+            return None;
+        }
+        let current_index = self
+            .focused
+            .and_then(|focused| sequence.iter().position(|kind| *kind == focused))
+            .unwrap_or(0);
+        let mut next_index = current_index as isize + delta;
+        let len = sequence.len() as isize;
+        if next_index < 0 {
+            next_index = len - 1;
+        }
+        next_index %= len;
+        let mut attempts = 0;
+        let mut candidate = next_index;
+        while attempts < sequence.len() {
+            let kind = sequence[candidate as usize];
+            if !self.is_disabled(kind) {
+                return Some(kind);
+            }
+            candidate = (candidate + delta).rem_euclid(len);
+            attempts += 1;
+        }
+        None
+    }
+
+    fn focus_sequence(&self) -> Vec<PaginationItemKind> {
+        let mut sequence = Vec::with_capacity(self.page_count + 4);
+        if self.include_edge_controls {
+            sequence.push(PaginationItemKind::First);
+        }
+        sequence.push(PaginationItemKind::Previous);
+        for index in 0..self.page_count {
+            sequence.push(PaginationItemKind::Page(index));
+        }
+        sequence.push(PaginationItemKind::Next);
+        if self.include_edge_controls {
+            sequence.push(PaginationItemKind::Last);
+        }
+        sequence
+    }
+}
+
+/// Selection payload emitted when the current page changes.
+#[derive(Debug, Clone)]
+pub struct PaginationSelection {
+    /// Selected zero-based page index.
+    pub page_index: usize,
+    /// Optional analytics payload describing the transition.
+    pub analytics: Option<PaginationAnalyticsEvent>,
+}
+
+/// Result returned by [`PaginationState::activate`] and [`PaginationState::on_key`].
+#[derive(Debug, Clone, Default)]
+pub struct PaginationSelectionOutcome {
+    /// The selected page index if a change occurred.
+    pub selected_page: Option<usize>,
+    /// Analytics payload describing the selection.
+    pub analytics: Option<PaginationAnalyticsEvent>,
+}

--- a/crates/rustic-ui-headless/src/speed_dial.rs
+++ b/crates/rustic-ui-headless/src/speed_dial.rs
@@ -1,0 +1,508 @@
+#![deny(missing_docs)]
+//! Headless state machine powering Material speed dial components.
+//!
+//! The state exposes deterministic keyboard handling, ARIA wiring, and
+//! analytics hooks so framework adapters only need to forward events and merge
+//! attribute pairs.  Controlling teams can decide whether the open/highlight
+//! state is managed internally or externally by toggling the `ControlStrategy`
+//! flags.
+
+use crate::{
+    aria,
+    interaction::ControlKey,
+    selection::{clamp_index, wrap_index, ControlStrategy},
+};
+
+/// Analytics signal emitted when the speed dial mutates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpeedDialAnalyticsEvent {
+    /// Logical telemetry channel surfaced on the root element.
+    pub channel: String,
+    /// Describes the action that triggered the event.
+    pub kind: SpeedDialAnalyticsKind,
+}
+
+/// Enumerates the analytics events emitted by the speed dial.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpeedDialAnalyticsKind {
+    /// The floating action button opened the speed dial.
+    Opened,
+    /// The speed dial closed, typically because focus left the menu or the user
+    /// invoked the trigger again.
+    Closed,
+    /// An action button inside the speed dial was activated.
+    Action {
+        /// Zero-based action index that triggered the event.
+        index: usize,
+        /// Optional analytics tag associated with the activated action.
+        tag: Option<String>,
+    },
+}
+
+/// Outcome returned after processing a keyboard event.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SpeedDialKeyboardOutcome {
+    /// Which action should receive focus.
+    pub highlighted: Option<usize>,
+    /// Which action should be invoked.
+    pub activated: Option<usize>,
+    /// Analytics payload describing the change.
+    pub analytics: Option<SpeedDialAnalyticsEvent>,
+}
+
+/// Builder describing the floating action button attributes.
+#[derive(Debug, Clone)]
+pub struct SpeedDialTriggerAttributes<'a> {
+    state: &'a SpeedDialState,
+    id: Option<&'a str>,
+    analytics_tag: Option<&'a str>,
+}
+
+impl<'a> SpeedDialTriggerAttributes<'a> {
+    fn new(state: &'a SpeedDialState) -> Self {
+        Self {
+            state,
+            id: None,
+            analytics_tag: None,
+        }
+    }
+
+    /// Assign a DOM id to the trigger button.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Associate an analytics identifier with the trigger.
+    pub fn analytics_tag(mut self, value: &'a str) -> Self {
+        self.analytics_tag = Some(value);
+        self
+    }
+
+    /// Collect ARIA/data attributes describing the trigger.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::with_capacity(8);
+        pairs.push(("role", aria::role_button().to_string()));
+        pairs.push((
+            "aria-expanded",
+            if self.state.open { "true" } else { "false" }.to_string(),
+        ));
+        let (popup_key, popup_value) = aria::aria_haspopup("menu");
+        pairs.push((popup_key, popup_value.to_string()));
+        if let Some(id) = self.id {
+            pairs.push(("id", id.to_string()));
+        }
+        if let Some(channel) = self.state.analytics_channel.as_ref() {
+            pairs.push(("data-rustic-analytics-channel", channel.clone()));
+        }
+        if let Some(tag) = self.analytics_tag {
+            pairs.push(("data-rustic-analytics-id", tag.to_string()));
+        }
+        pairs.push((
+            "data-rustic-speed-dial-state",
+            if self.state.open { "open" } else { "closed" }.to_string(),
+        ));
+        pairs
+    }
+}
+
+/// Builder describing the action list container.
+#[derive(Debug, Clone)]
+pub struct SpeedDialListAttributes<'a> {
+    state: &'a SpeedDialState,
+    id: Option<&'a str>,
+}
+
+impl<'a> SpeedDialListAttributes<'a> {
+    fn new(state: &'a SpeedDialState) -> Self {
+        Self { state, id: None }
+    }
+
+    /// Assign a DOM id to the list element.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Collect attributes describing the action list.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::with_capacity(6);
+        pairs.push(("role", aria::role_menu().to_string()));
+        if let Some(id) = self.id {
+            pairs.push(("id", id.to_string()));
+        }
+        pairs.push(("data-rustic-speed-dial", "actions".to_string()));
+        if let Some(channel) = self.state.analytics_channel.as_ref() {
+            pairs.push(("data-rustic-analytics-channel", channel.clone()));
+        }
+        pairs
+    }
+}
+
+/// Builder describing an individual action button.
+#[derive(Debug, Clone)]
+pub struct SpeedDialActionAttributes<'a> {
+    state: &'a SpeedDialState,
+    index: usize,
+    id: Option<&'a str>,
+    analytics_tag: Option<&'a str>,
+    aria_label: Option<&'a str>,
+}
+
+impl<'a> SpeedDialActionAttributes<'a> {
+    fn new(state: &'a SpeedDialState, index: usize) -> Self {
+        Self {
+            state,
+            index,
+            id: None,
+            analytics_tag: None,
+            aria_label: None,
+        }
+    }
+
+    /// Assign a DOM id to the action button.
+    pub fn id(mut self, value: &'a str) -> Self {
+        self.id = Some(value);
+        self
+    }
+
+    /// Associate an analytics identifier with the action.
+    pub fn analytics_tag(mut self, value: &'a str) -> Self {
+        self.analytics_tag = Some(value);
+        self
+    }
+
+    /// Override the accessible label for the action.
+    pub fn aria_label(mut self, value: &'a str) -> Self {
+        self.aria_label = Some(value);
+        self
+    }
+
+    /// Collect the configured attributes into reusable pairs.
+    pub fn as_pairs(&self) -> Vec<(&'static str, String)> {
+        let mut pairs = Vec::with_capacity(10);
+        pairs.push(("role", aria::role_menuitem().to_string()));
+        let highlighted = self.state.highlighted == Some(self.index);
+        pairs.push(("tabindex", if highlighted { "0" } else { "-1" }.to_string()));
+        if let Some(id) = self.id {
+            pairs.push(("id", id.to_string()));
+        }
+        let disabled = self.state.is_action_disabled(self.index);
+        if disabled {
+            pairs.push(("aria-disabled", "true".into()));
+            pairs.push(("data-disabled", "true".into()));
+        }
+        if let Some(tag) = self.analytics_tag.or_else(|| {
+            self.state
+                .action_tags
+                .get(self.index)
+                .and_then(|value| value.as_deref())
+        }) {
+            pairs.push(("data-rustic-analytics-id", tag.to_string()));
+        }
+        if let Some(channel) = self.state.analytics_channel.as_ref() {
+            pairs.push(("data-rustic-analytics-channel", channel.clone()));
+        }
+        let label = self
+            .aria_label
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| format!("Speed dial action {}", self.index + 1));
+        pairs.push(("aria-label", label));
+        pairs.push(("data-rustic-speed-dial-index", self.index.to_string()));
+        pairs
+    }
+}
+
+/// Headless controller for Material speed dial menus.
+#[derive(Debug, Clone)]
+pub struct SpeedDialState {
+    action_count: usize,
+    open: bool,
+    highlighted: Option<usize>,
+    open_mode: ControlStrategy,
+    highlight_mode: ControlStrategy,
+    analytics_channel: Option<String>,
+    action_tags: Vec<Option<String>>,
+    disabled: Vec<bool>,
+}
+
+impl SpeedDialState {
+    /// Construct a new speed dial controller.
+    pub fn new(
+        action_count: usize,
+        default_open: bool,
+        open_mode: ControlStrategy,
+        highlight_mode: ControlStrategy,
+    ) -> Self {
+        let open = if open_mode.is_controlled() {
+            false
+        } else {
+            default_open
+        };
+        let highlighted = if action_count > 0 { Some(0) } else { None };
+        Self {
+            action_count,
+            open,
+            highlighted,
+            open_mode,
+            highlight_mode,
+            analytics_channel: None,
+            action_tags: vec![None; action_count],
+            disabled: vec![false; action_count],
+        }
+    }
+
+    /// Returns whether the speed dial menu is expanded.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Returns the currently highlighted action index.
+    pub fn highlighted(&self) -> Option<usize> {
+        self.highlighted
+    }
+
+    /// Builder for the floating action button.
+    pub fn trigger_attributes(&self) -> SpeedDialTriggerAttributes<'_> {
+        SpeedDialTriggerAttributes::new(self)
+    }
+
+    /// Builder for the action list container.
+    pub fn list_attributes(&self) -> SpeedDialListAttributes<'_> {
+        SpeedDialListAttributes::new(self)
+    }
+
+    /// Builder for an individual action button.
+    pub fn action_attributes(&self, index: usize) -> SpeedDialActionAttributes<'_> {
+        SpeedDialActionAttributes::new(self, index)
+    }
+
+    /// Configure the analytics channel surfaced on all rendered elements.
+    pub fn set_analytics_channel(&mut self, channel: Option<impl Into<String>>) {
+        self.analytics_channel = channel.map(Into::into);
+    }
+
+    /// Configure the analytics tag for a specific action index.
+    pub fn set_action_analytics_tag(&mut self, index: usize, tag: Option<impl Into<String>>) {
+        if index >= self.action_count {
+            return;
+        }
+        if let Some(slot) = self.action_tags.get_mut(index) {
+            *slot = tag.map(Into::into);
+        }
+    }
+
+    /// Mark an action as disabled.
+    pub fn set_action_disabled(&mut self, index: usize, disabled: bool) {
+        if index >= self.action_count {
+            return;
+        }
+        if let Some(slot) = self.disabled.get_mut(index) {
+            *slot = disabled;
+        }
+        if disabled && self.highlighted == Some(index) {
+            self.highlighted = self.advance(1);
+        }
+    }
+
+    /// Returns whether the action at `index` is disabled.
+    pub fn is_action_disabled(&self, index: usize) -> bool {
+        self.disabled.get(index).copied().unwrap_or(true)
+    }
+
+    /// Update the number of rendered actions.
+    pub fn set_action_count(&mut self, count: usize) {
+        self.action_count = count;
+        self.action_tags.resize(count, None);
+        self.disabled.resize(count, false);
+        self.highlighted = clamp_index(self.highlighted, count);
+    }
+
+    /// Synchronise the open state when controlled externally.
+    pub fn sync_open(&mut self, open: bool) {
+        if self.open_mode.is_controlled() {
+            self.open = open;
+        }
+    }
+
+    /// Synchronise the highlighted index when controlled externally.
+    pub fn sync_highlighted(&mut self, index: Option<usize>) {
+        if self.highlight_mode.is_controlled() {
+            self.highlighted = clamp_index(index, self.action_count);
+        }
+    }
+
+    /// Open the speed dial.
+    pub fn open<F: FnOnce(bool)>(&mut self, notify: F) -> Option<SpeedDialAnalyticsEvent> {
+        self.set_open(true, notify)
+    }
+
+    /// Close the speed dial.
+    pub fn close<F: FnOnce(bool)>(&mut self, notify: F) -> Option<SpeedDialAnalyticsEvent> {
+        self.set_open(false, notify)
+    }
+
+    /// Toggle the speed dial.
+    pub fn toggle<F: FnOnce(bool)>(&mut self, notify: F) -> Option<SpeedDialAnalyticsEvent> {
+        self.set_open(!self.open, notify)
+    }
+
+    /// Handle keyboard interaction returning the resulting intent.
+    pub fn on_key<F: FnMut(SpeedDialSelection)>(
+        &mut self,
+        key: ControlKey,
+        mut on_select: F,
+    ) -> SpeedDialKeyboardOutcome {
+        let mut outcome = SpeedDialKeyboardOutcome::default();
+        match key {
+            ControlKey::Enter | ControlKey::Space => {
+                if !self.open {
+                    outcome.analytics = self.open(|_| {});
+                    outcome.highlighted = self.highlighted;
+                } else if let Some(index) = self.highlighted {
+                    if !self.is_action_disabled(index) {
+                        let result = self.activate(index, &mut on_select);
+                        outcome.activated = result.activated;
+                        outcome.analytics = result.analytics;
+                    }
+                }
+            }
+            ControlKey::Home => {
+                outcome.highlighted = self.apply_highlight(self.first_enabled());
+            }
+            ControlKey::End => {
+                outcome.highlighted = self.apply_highlight(self.last_enabled());
+            }
+            _ if key.is_forward() => {
+                outcome.highlighted = self.apply_highlight(self.advance(1));
+            }
+            _ if key.is_backward() => {
+                outcome.highlighted = self.apply_highlight(self.advance(-1));
+            }
+            _ => {}
+        }
+        outcome
+    }
+
+    /// Activate a specific action.
+    pub fn activate<F: FnMut(SpeedDialSelection)>(
+        &mut self,
+        index: usize,
+        mut on_select: F,
+    ) -> SpeedDialSelectionOutcome {
+        if index >= self.action_count || self.is_action_disabled(index) {
+            return SpeedDialSelectionOutcome::default();
+        }
+        if !self.highlight_mode.is_controlled() {
+            self.highlighted = Some(index);
+        }
+        let analytics = self.analytics_payload(SpeedDialAnalyticsKind::Action {
+            index,
+            tag: self
+                .action_tags
+                .get(index)
+                .and_then(|value| value.as_ref().map(|value| value.to_string())),
+        });
+        let selection = SpeedDialSelection {
+            index,
+            analytics: analytics.clone(),
+        };
+        on_select(selection);
+        SpeedDialSelectionOutcome {
+            activated: Some(index),
+            analytics,
+        }
+    }
+
+    fn set_open<F: FnOnce(bool)>(
+        &mut self,
+        next: bool,
+        notify: F,
+    ) -> Option<SpeedDialAnalyticsEvent> {
+        if self.open == next {
+            notify(next);
+            return None;
+        }
+        if !self.open_mode.is_controlled() {
+            self.open = next;
+        }
+        notify(next);
+        if next {
+            self.highlighted = self.first_enabled();
+            self.analytics_payload(SpeedDialAnalyticsKind::Opened)
+        } else {
+            self.analytics_payload(SpeedDialAnalyticsKind::Closed)
+        }
+    }
+
+    fn analytics_payload(&self, kind: SpeedDialAnalyticsKind) -> Option<SpeedDialAnalyticsEvent> {
+        self.analytics_channel
+            .as_ref()
+            .map(|channel| SpeedDialAnalyticsEvent {
+                channel: channel.clone(),
+                kind,
+            })
+    }
+
+    fn apply_highlight(&mut self, next: Option<usize>) -> Option<usize> {
+        let normalized = clamp_index(next, self.action_count);
+        if !self.highlight_mode.is_controlled() {
+            self.highlighted = normalized;
+        }
+        normalized
+    }
+
+    fn first_enabled(&self) -> Option<usize> {
+        (0..self.action_count).find(|&index| !self.is_action_disabled(index))
+    }
+
+    fn last_enabled(&self) -> Option<usize> {
+        (0..self.action_count)
+            .rev()
+            .find(|&index| !self.is_action_disabled(index))
+    }
+
+    fn advance(&self, delta: isize) -> Option<usize> {
+        if self.action_count == 0 {
+            return None;
+        }
+        if self.highlighted.is_none() {
+            return if delta.is_positive() {
+                self.first_enabled()
+            } else {
+                self.last_enabled()
+            };
+        }
+        let mut candidate = wrap_index(self.highlighted, delta, self.action_count);
+        let mut attempts = 0;
+        while let Some(index) = candidate {
+            if !self.is_action_disabled(index) {
+                return Some(index);
+            }
+            attempts += 1;
+            if attempts >= self.action_count {
+                break;
+            }
+            candidate = wrap_index(Some(index), delta, self.action_count);
+        }
+        None
+    }
+}
+
+/// Selection payload emitted when an action is activated.
+#[derive(Debug, Clone)]
+pub struct SpeedDialSelection {
+    /// Activated action index.
+    pub index: usize,
+    /// Optional analytics payload describing the activation.
+    pub analytics: Option<SpeedDialAnalyticsEvent>,
+}
+
+/// Result returned by [`SpeedDialState::activate`] and [`SpeedDialState::on_key`].
+#[derive(Debug, Clone, Default)]
+pub struct SpeedDialSelectionOutcome {
+    /// Activated action index when a selection occurs.
+    pub activated: Option<usize>,
+    /// Analytics payload emitted alongside the activation.
+    pub analytics: Option<SpeedDialAnalyticsEvent>,
+}

--- a/crates/rustic-ui-headless/tests/navigation_primitives.rs
+++ b/crates/rustic-ui-headless/tests/navigation_primitives.rs
@@ -1,0 +1,134 @@
+use rustic_ui_headless::bottom_navigation::{
+    BottomNavigationActivationMode, BottomNavigationState,
+};
+use rustic_ui_headless::breadcrumbs::BreadcrumbsState;
+use rustic_ui_headless::interaction::ControlKey;
+use rustic_ui_headless::link::LinkState;
+use rustic_ui_headless::pagination::{PaginationItemKind, PaginationState};
+use rustic_ui_headless::speed_dial::SpeedDialState;
+use rustic_ui_headless::ControlStrategy;
+
+#[test]
+fn bottom_navigation_emits_selection_analytics() {
+    let mut state = BottomNavigationState::new(
+        3,
+        Some(0),
+        BottomNavigationActivationMode::Automatic,
+        ControlStrategy::Uncontrolled,
+        ControlStrategy::Uncontrolled,
+    );
+    state.set_analytics_channel(Some("nav"));
+    state.set_item_analytics_tag(1, Some("files"));
+
+    let mut seen = Vec::new();
+    let outcome = state.on_key(ControlKey::ArrowRight, |selection| {
+        seen.push(selection.index)
+    });
+
+    assert_eq!(outcome.selected, Some(1));
+    assert_eq!(seen, vec![1]);
+    assert_eq!(
+        outcome
+            .analytics
+            .as_ref()
+            .and_then(|event| event.item_tag.as_deref()),
+        Some("files")
+    );
+}
+
+#[test]
+fn breadcrumbs_activation_reports_analytics() {
+    let mut state = BreadcrumbsState::new(
+        3,
+        Some(0),
+        ControlStrategy::Uncontrolled,
+        ControlStrategy::Uncontrolled,
+    );
+    state.set_analytics_channel(Some("breadcrumbs"));
+    state.set_item_analytics_tag(2, Some("current"));
+
+    let mut activated = None;
+    let outcome = state.on_key(ControlKey::End, |activation| {
+        activated = Some(activation.index)
+    });
+    assert_eq!(outcome.focused, Some(2));
+    assert_eq!(activated, None);
+
+    let mut analytics_index = None;
+    state.activate(2, |activation| {
+        analytics_index = activation.analytics.as_ref().map(|event| event.index);
+    });
+    assert_eq!(analytics_index, Some(2));
+}
+
+#[test]
+fn link_state_handles_keyboard_activation() {
+    let mut state = LinkState::new(true);
+    state.set_analytics_channel(Some("links"));
+    state.set_analytics_tag(Some("primary"));
+
+    let outcome = state.on_key(ControlKey::Space);
+    assert!(outcome.activate);
+    assert_eq!(
+        outcome
+            .analytics
+            .as_ref()
+            .and_then(|event| event.link_tag.as_deref()),
+        Some("primary")
+    );
+}
+
+#[test]
+fn pagination_activation_tracks_selected_page() {
+    let mut state = PaginationState::new(
+        5,
+        Some(1),
+        ControlStrategy::Uncontrolled,
+        ControlStrategy::Uncontrolled,
+    );
+    state.set_analytics_channel(Some("pagination"));
+    state.set_page_analytics_tag(3, Some("reports"));
+
+    let mut selected = None;
+    let result = state.activate(PaginationItemKind::Page(3), |selection| {
+        selected = Some(selection.page_index);
+    });
+
+    assert_eq!(selected, Some(3));
+    assert_eq!(result.selected_page, Some(3));
+    assert_eq!(
+        result
+            .analytics
+            .as_ref()
+            .and_then(|event| event.page_tag.as_deref()),
+        Some("reports")
+    );
+}
+
+#[test]
+fn speed_dial_toggle_and_activate_emit_events() {
+    let mut state = SpeedDialState::new(
+        2,
+        false,
+        ControlStrategy::Uncontrolled,
+        ControlStrategy::Uncontrolled,
+    );
+    state.set_analytics_channel(Some("speed-dial"));
+    state.set_action_analytics_tag(0, Some("new"));
+
+    let opened = state.toggle(|open| assert!(open));
+    assert!(opened.is_some());
+
+    let mut activated = None;
+    let outcome = state.activate(0, |selection| activated = selection.analytics.clone());
+    assert_eq!(outcome.activated, Some(0));
+    assert_eq!(
+        activated.as_ref().map(|event| match &event.kind {
+            rustic_ui_headless::speed_dial::SpeedDialAnalyticsKind::Action { tag, .. } => {
+                tag.clone()
+            }
+            _ => None,
+        }),
+        Some(Some("new".into()))
+    );
+}

--- a/crates/rustic-ui-material/src/bottom_navigation.rs
+++ b/crates/rustic-ui-material/src/bottom_navigation.rs
@@ -1,0 +1,361 @@
+//! Material renderer for [`BottomNavigationState`](rustic_ui_headless::bottom_navigation::BottomNavigationState).
+//!
+//! The module converts the headless state machine into deterministic attribute
+//! maps and SSR friendly HTML helpers.  Every rendered element exposes
+//! automation-first `data-rustic-*` markers so QA pipelines and analytics hooks
+//! can bind without resorting to brittle CSS selectors.
+
+use rustic_ui_headless::bottom_navigation::{BottomNavigationAttributes, BottomNavigationState};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+
+use crate::style_helpers;
+use rustic_ui_utils::attributes_to_html;
+
+/// Describes an individual navigation destination.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationItemDescriptor<'a> {
+    /// Optional DOM id applied to the rendered button.
+    pub id: Option<&'a str>,
+    /// Optional identifier of the panel controlled by this destination.
+    pub controls: Option<&'a str>,
+    /// Pre-rendered inner HTML representing the destination content.
+    pub content: &'a str,
+}
+
+/// Adapter props shared across React/Yew/Leptos/Dioxus/Sycamore integrations.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationAdapterProps<'a> {
+    /// Headless state describing selection and focus semantics.
+    pub state: &'a BottomNavigationState,
+    /// Attribute builder returned from the headless state for the root element.
+    pub attributes: BottomNavigationAttributes<'a>,
+    /// Logical destinations rendered within the navigation bar.
+    pub items: &'a [BottomNavigationItemDescriptor<'a>],
+    /// Optional event channel surfaced via `data-on-select` for analytics.
+    pub on_select_event: Option<&'a str>,
+}
+
+/// Rendered attributes for a single destination.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationItemRender {
+    attributes: Vec<(String, String)>,
+    content: String,
+}
+
+impl BottomNavigationItemRender {
+    /// Returns the attribute pairs describing the destination button.
+    pub fn attributes(&self) -> &[(String, String)] {
+        &self.attributes
+    }
+
+    /// Returns the serialized inner HTML for the destination.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+}
+
+/// Rendered attributes for the navigation container.
+#[derive(Debug, Clone)]
+pub struct BottomNavigationRenderOutput {
+    root_attributes: Vec<(String, String)>,
+    items: Vec<BottomNavigationItemRender>,
+}
+
+impl BottomNavigationRenderOutput {
+    /// Attribute pairs attached to the `<nav>` wrapper.
+    pub fn root_attributes(&self) -> &[(String, String)] {
+        &self.root_attributes
+    }
+
+    /// Rendered destinations.
+    pub fn items(&self) -> &[BottomNavigationItemRender] {
+        &self.items
+    }
+}
+
+/// Render the bottom navigation into attribute maps.
+#[must_use]
+pub fn render_bottom_navigation(
+    props: BottomNavigationAdapterProps<'_>,
+) -> BottomNavigationRenderOutput {
+    let root_attributes =
+        build_root_attributes(props.state, props.attributes, props.on_select_event);
+    let items = props
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, descriptor)| BottomNavigationItemRender {
+            attributes: build_item_attributes(props.state, index, descriptor),
+            content: descriptor.content.to_string(),
+        })
+        .collect();
+
+    BottomNavigationRenderOutput {
+        root_attributes,
+        items,
+    }
+}
+
+/// Render the bottom navigation into serialized HTML markup.
+#[must_use]
+pub fn render_bottom_navigation_html(props: BottomNavigationAdapterProps<'_>) -> String {
+    let rendered = render_bottom_navigation(props);
+    let items_html = rendered
+        .items()
+        .iter()
+        .map(|item| {
+            format!(
+                "<button {attrs}>{content}</button>",
+                attrs = attributes_to_html(item.attributes()),
+                content = item.content()
+            )
+        })
+        .collect::<String>();
+
+    format!(
+        "<nav {attrs}>{items}</nav>",
+        attrs = attributes_to_html(rendered.root_attributes()),
+        items = items_html
+    )
+}
+
+fn build_root_attributes(
+    state: &BottomNavigationState,
+    attrs: BottomNavigationAttributes<'_>,
+    on_select_event: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::with_capacity(8);
+    pairs.push(("role".into(), attrs.role().into()));
+    if let Some((key, value)) = attrs.id_attr() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.labelledby() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.analytics_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("bottom-navigation"),
+    ));
+    pairs.push((
+        style_helpers::automation_data_attr("bottom-navigation", ["root"]),
+        "true".into(),
+    ));
+    pairs.push((
+        "data-selected-index".into(),
+        state
+            .selected()
+            .map(|index| index.to_string())
+            .unwrap_or_else(|| "".into()),
+    ));
+    if let Some(event) = on_select_event {
+        pairs.push(("data-on-select".into(), event.into()));
+    }
+    style_helpers::themed_attributes(bottom_navigation_root_style(), pairs)
+}
+
+fn build_item_attributes(
+    state: &BottomNavigationState,
+    index: usize,
+    descriptor: &BottomNavigationItemDescriptor<'_>,
+) -> Vec<(String, String)> {
+    let mut builder = state.item_attributes(index);
+    if let Some(id) = descriptor.id {
+        builder = builder.id(id);
+    }
+    if let Some(controls) = descriptor.controls {
+        builder = builder.controls(controls);
+    }
+    let mut pairs: Vec<(String, String)> = builder
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    pairs.push((
+        style_helpers::automation_data_attr("bottom-navigation", ["item", &index.to_string()]),
+        "true".into(),
+    ));
+    pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("bottom-navigation-item"),
+    ));
+    style_helpers::themed_attributes(bottom_navigation_item_style(), pairs)
+}
+
+fn bottom_navigation_root_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+        gap: ${gap};
+        padding: ${padding_y}px ${padding_x}px;
+        background: ${background};
+        border-radius: ${radius};
+        box-shadow: ${shadow};
+        min-height: ${min_height}px;
+    "#,
+        gap = theme.spacing(2),
+        padding_y = theme.spacing(1),
+        padding_x = theme.spacing(2),
+        background = theme.palette.background_paper.clone(),
+        radius = format!("{}px", theme.joy.radius),
+        shadow = theme.joy.shadow.surface.clone(),
+        min_height = theme.spacing(8)
+    )
+}
+
+fn bottom_navigation_item_style() -> Style {
+    css_with_theme!(
+        r#"
+        appearance: none;
+        background: transparent;
+        border: none;
+        padding: ${padding_y}px ${padding_x}px;
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        color: ${color};
+        font-family: ${font_family};
+        font-size: ${font_size};
+        line-height: 1.2;
+        cursor: pointer;
+        position: relative;
+        transition: color 120ms ease;
+        &[aria-selected="true"] {
+            color: ${active_color};
+        }
+        &[data-disabled="true"] {
+            opacity: 0.38;
+            cursor: default;
+        }
+    "#,
+        padding_y = theme.spacing(1),
+        padding_x = theme.spacing(2),
+        color = theme.palette.text_secondary.clone(),
+        active_color = theme.palette.primary.clone(),
+        font_family = theme.typography.font_family.clone(),
+        font_size = format!("{:.3}rem", theme.typography.button)
+    )
+}
+
+/// React adapter that renders the bottom navigation into HTML.
+pub mod react {
+    use super::*;
+
+    /// Render the bottom navigation for React SSR pipelines.
+    pub fn render_bottom_navigation(props: BottomNavigationAdapterProps<'_>) -> String {
+        super::render_bottom_navigation_html(props)
+    }
+}
+
+/// Yew adapter mirroring the React implementation.
+pub mod yew {
+    use super::*;
+
+    /// Render the bottom navigation for snapshot testing.
+    pub fn render_bottom_navigation(props: BottomNavigationAdapterProps<'_>) -> String {
+        super::render_bottom_navigation_html(props)
+    }
+}
+
+/// Leptos adapter keeping parity with React/Yew output.
+pub mod leptos {
+    use super::*;
+
+    /// Render the bottom navigation into deterministic HTML.
+    pub fn render_bottom_navigation(props: BottomNavigationAdapterProps<'_>) -> String {
+        super::render_bottom_navigation_html(props)
+    }
+}
+
+/// Sycamore adapter delegating to the shared renderer.
+pub mod sycamore {
+    use super::*;
+
+    /// Render the bottom navigation for Sycamore SSR flows.
+    pub fn render_bottom_navigation(props: BottomNavigationAdapterProps<'_>) -> String {
+        super::render_bottom_navigation_html(props)
+    }
+}
+
+/// Dioxus adapter mirroring every other integration.
+pub mod dioxus {
+    use super::*;
+
+    /// Render the bottom navigation into HTML markup.
+    pub fn render_bottom_navigation(props: BottomNavigationAdapterProps<'_>) -> String {
+        super::render_bottom_navigation_html(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::bottom_navigation::{
+        BottomNavigationActivationMode, BottomNavigationState,
+    };
+    use rustic_ui_headless::ControlStrategy;
+
+    fn build_state() -> BottomNavigationState {
+        BottomNavigationState::new(
+            3,
+            Some(1),
+            BottomNavigationActivationMode::Automatic,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        )
+    }
+
+    fn build_props<'a>(state: &'a BottomNavigationState) -> BottomNavigationAdapterProps<'a> {
+        BottomNavigationAdapterProps {
+            state,
+            attributes: state.root_attributes().id("nav"),
+            items: &[
+                BottomNavigationItemDescriptor {
+                    id: Some("home"),
+                    controls: None,
+                    content: "<span>Home</span>",
+                },
+                BottomNavigationItemDescriptor {
+                    id: Some("files"),
+                    controls: None,
+                    content: "<span>Files</span>",
+                },
+                BottomNavigationItemDescriptor {
+                    id: Some("settings"),
+                    controls: None,
+                    content: "<span>Settings</span>",
+                },
+            ],
+            on_select_event: Some("nav-select"),
+        }
+    }
+
+    #[test]
+    fn root_attributes_include_automation_hooks() {
+        let state = build_state();
+        let rendered = render_bottom_navigation(build_props(&state));
+        assert!(rendered
+            .root_attributes()
+            .iter()
+            .any(|(k, v)| k == "data-component"
+                && *v == style_helpers::component_marker("bottom-navigation")));
+        assert!(rendered
+            .root_attributes()
+            .iter()
+            .any(|(k, v)| k == "data-on-select" && v == "nav-select"));
+    }
+
+    #[test]
+    fn html_renderer_emits_buttons_for_each_item() {
+        let state = build_state();
+        let html = render_bottom_navigation_html(build_props(&state));
+        assert!(html.contains("<nav"));
+        assert!(html.contains("role=\"tablist\""));
+        assert!(html.matches("<button").count() >= 3);
+    }
+}

--- a/crates/rustic-ui-material/src/breadcrumbs.rs
+++ b/crates/rustic-ui-material/src/breadcrumbs.rs
@@ -1,0 +1,487 @@
+//! Material renderer for [`BreadcrumbsState`](rustic_ui_headless::breadcrumbs::BreadcrumbsState).
+//!
+//! The helpers emit deterministic attribute collections so adapters across React,
+//! Yew, Leptos, Sycamore and Dioxus share identical markup.  Styling is provided
+//! via `css_with_theme!` ensuring palette and typography adjustments propagate
+//! automatically.
+
+use rustic_ui_headless::breadcrumbs::{
+    BreadcrumbsListAttributes, BreadcrumbsRootAttributes, BreadcrumbsState,
+};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+
+use crate::style_helpers;
+use rustic_ui_utils::attributes_to_html;
+
+/// Describes a single crumb rendered inside the breadcrumb trail.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbItemDescriptor<'a> {
+    /// Optional DOM id for the interactive crumb element.
+    pub id: Option<&'a str>,
+    /// Optional navigation target.
+    pub href: Option<&'a str>,
+    /// Inner HTML rendered inside the crumb anchor.
+    pub content: &'a str,
+    /// Glyph displayed between this crumb and the next one.
+    pub separator: &'a str,
+}
+
+/// Adapter props shared across framework integrations.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbsAdapterProps<'a> {
+    /// Headless state describing focus and analytics semantics.
+    pub state: &'a BreadcrumbsState,
+    /// Root attribute builder returned by the headless state.
+    pub root_attributes: BreadcrumbsRootAttributes<'a>,
+    /// Ordered list attribute builder.
+    pub list_attributes: BreadcrumbsListAttributes<'a>,
+    /// Rendered crumbs.
+    pub items: &'a [BreadcrumbItemDescriptor<'a>],
+    /// Optional event channel surfaced via `data-on-activate`.
+    pub on_activate_event: Option<&'a str>,
+}
+
+/// Rendered output for a single breadcrumb item.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbRenderItem {
+    container_attributes: Vec<(String, String)>,
+    link_attributes: Vec<(String, String)>,
+    separator_attributes: Vec<(String, String)>,
+    content: String,
+    separator: String,
+}
+
+impl BreadcrumbRenderItem {
+    /// Attributes applied to the `<li>` element.
+    pub fn container_attributes(&self) -> &[(String, String)] {
+        &self.container_attributes
+    }
+
+    /// Attributes applied to the `<a>` element.
+    pub fn link_attributes(&self) -> &[(String, String)] {
+        &self.link_attributes
+    }
+
+    /// Attributes applied to the separator element.
+    pub fn separator_attributes(&self) -> &[(String, String)] {
+        &self.separator_attributes
+    }
+
+    /// Returns the crumb content.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Returns the separator glyph.
+    pub fn separator(&self) -> &str {
+        &self.separator
+    }
+}
+
+/// Rendered breadcrumb output.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbRenderOutput {
+    root_attributes: Vec<(String, String)>,
+    list_attributes: Vec<(String, String)>,
+    items: Vec<BreadcrumbRenderItem>,
+}
+
+impl BreadcrumbRenderOutput {
+    /// Attributes for the `<nav>` element.
+    pub fn root_attributes(&self) -> &[(String, String)] {
+        &self.root_attributes
+    }
+
+    /// Attributes for the `<ol>` element.
+    pub fn list_attributes(&self) -> &[(String, String)] {
+        &self.list_attributes
+    }
+
+    /// Rendered crumbs.
+    pub fn items(&self) -> &[BreadcrumbRenderItem] {
+        &self.items
+    }
+}
+
+/// Render breadcrumbs into attribute maps.
+#[must_use]
+pub fn render_breadcrumbs(props: BreadcrumbsAdapterProps<'_>) -> BreadcrumbRenderOutput {
+    let root_attributes = build_root_attributes(props.root_attributes, props.on_activate_event);
+    let list_attributes = build_list_attributes(props.list_attributes);
+    let items = props
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, descriptor)| {
+            build_item(
+                props.state,
+                index,
+                descriptor,
+                index + 1 == props.items.len(),
+            )
+        })
+        .collect();
+
+    BreadcrumbRenderOutput {
+        root_attributes,
+        list_attributes,
+        items,
+    }
+}
+
+/// Render breadcrumbs into serialized HTML.
+#[must_use]
+pub fn render_breadcrumbs_html(props: BreadcrumbsAdapterProps<'_>) -> String {
+    let rendered = render_breadcrumbs(props);
+    let items_html = rendered
+        .items()
+        .iter()
+        .map(|item| {
+            let link_html = format!(
+                "<a {attrs}>{content}</a>",
+                attrs = attributes_to_html(item.link_attributes()),
+                content = item.content()
+            );
+            let separator_html = if item.separator().is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "<span {attrs}>{glyph}</span>",
+                    attrs = attributes_to_html(item.separator_attributes()),
+                    glyph = item.separator()
+                )
+            };
+            format!(
+                "<li {attrs}>{body}</li>",
+                attrs = attributes_to_html(item.container_attributes()),
+                body = format!(
+                    "{link}{separator}",
+                    link = link_html,
+                    separator = separator_html
+                )
+            )
+        })
+        .collect::<String>();
+
+    let list_html = format!(
+        "<ol {attrs}>{items}</ol>",
+        attrs = attributes_to_html(rendered.list_attributes()),
+        items = items_html
+    );
+
+    format!(
+        "<nav {attrs}>{list}</nav>",
+        attrs = attributes_to_html(rendered.root_attributes()),
+        list = list_html
+    )
+}
+
+fn build_root_attributes(
+    attrs: BreadcrumbsRootAttributes<'_>,
+    on_activate_event: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::with_capacity(8);
+    pairs.push(("role".into(), attrs.role().into()));
+    if let Some((key, value)) = attrs.id_attr() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.aria_label_attr() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.analytics_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some(event) = on_activate_event {
+        pairs.push(("data-on-activate".into(), event.into()));
+    }
+    pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("breadcrumbs"),
+    ));
+    pairs.push((
+        style_helpers::automation_data_attr("breadcrumbs", ["root"]),
+        "true".into(),
+    ));
+    style_helpers::themed_attributes(breadcrumb_root_style(), pairs)
+}
+
+fn build_list_attributes(attrs: BreadcrumbsListAttributes<'_>) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::with_capacity(6);
+    pairs.push(("role".into(), attrs.role().into()));
+    if let Some((key, value)) = attrs.id_attr() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.analytics_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    pairs.push((
+        style_helpers::automation_data_attr("breadcrumbs", ["list"]),
+        "true".into(),
+    ));
+    style_helpers::themed_attributes(breadcrumb_list_style(), pairs)
+}
+
+fn build_item(
+    state: &BreadcrumbsState,
+    index: usize,
+    descriptor: &BreadcrumbItemDescriptor<'_>,
+    is_last: bool,
+) -> BreadcrumbRenderItem {
+    let mut container_pairs: Vec<(String, String)> = Vec::with_capacity(6);
+    container_pairs.push((
+        style_helpers::automation_data_attr("breadcrumbs", ["item", &index.to_string()]),
+        "true".into(),
+    ));
+    container_pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("breadcrumbs-item"),
+    ));
+    let container_attributes =
+        style_helpers::themed_attributes(breadcrumb_item_style(), container_pairs);
+
+    let mut item_builder = state.item_attributes(index);
+    if let Some(id) = descriptor.id {
+        item_builder = item_builder.id(id);
+    }
+    if let Some(href) = descriptor.href {
+        item_builder = item_builder.href(href);
+    }
+    let link_pairs: Vec<(String, String)> = item_builder
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    let link_attributes = style_helpers::themed_attributes(breadcrumb_link_style(), link_pairs);
+
+    let separator_builder = state.separator_attributes();
+    let separator_pairs: Vec<(String, String)> = separator_builder
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    let mut separator_attributes =
+        style_helpers::themed_attributes(breadcrumb_separator_style(), separator_pairs);
+    if is_last {
+        separator_attributes.push(("aria-hidden".into(), "true".into()));
+        separator_attributes.push(("data-hidden".into(), "true".into()));
+    }
+
+    BreadcrumbRenderItem {
+        container_attributes,
+        link_attributes,
+        separator_attributes,
+        content: descriptor.content.to_string(),
+        separator: if is_last {
+            String::new()
+        } else {
+            descriptor.separator.to_string()
+        },
+    }
+}
+
+fn breadcrumb_root_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: block;
+        width: 100%;
+        color: ${color};
+        font-family: ${font_family};
+        font-size: ${font_size};
+    "#,
+        color = theme.palette.text_secondary.clone(),
+        font_family = theme.typography.font_family.clone(),
+        font_size = format!("{:.3}rem", theme.typography.body2)
+    )
+}
+
+fn breadcrumb_list_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: ${gap};
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    "#,
+        gap = theme.spacing(1)
+    )
+}
+
+fn breadcrumb_item_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: inline-flex;
+        align-items: center;
+        gap: ${gap};
+        color: inherit;
+    "#,
+        gap = theme.spacing(1)
+    )
+}
+
+fn breadcrumb_link_style() -> Style {
+    css_with_theme!(
+        r#"
+        color: inherit;
+        text-decoration: none;
+        padding: ${padding_y}px ${padding_x}px;
+        border-radius: ${radius};
+        transition: background 120ms ease, color 120ms ease;
+        &[aria-current] {
+            font-weight: ${font_weight};
+            color: ${active_color};
+        }
+        &:hover {
+            background: ${hover};
+        }
+        &[data-disabled="true"] {
+            pointer-events: none;
+            opacity: 0.6;
+        }
+    "#,
+        padding_y = 0u16,
+        padding_x = theme.spacing(1),
+        radius = format!("{}px", theme.joy.radius / 2),
+        font_weight = theme.typography.font_weight_medium,
+        active_color = theme.palette.primary.clone(),
+        hover = format!(
+            "color-mix(in srgb, {} 12%, transparent)",
+            theme.palette.primary.clone()
+        )
+    )
+}
+
+fn breadcrumb_separator_style() -> Style {
+    css_with_theme!(
+        r#"
+        color: ${color};
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 0.5em;
+    "#,
+        color = theme.palette.text_secondary.clone()
+    )
+}
+
+/// React adapter returning deterministic HTML.
+pub mod react {
+    use super::*;
+
+    /// Render breadcrumbs for React SSR pipelines.
+    pub fn render_breadcrumbs(props: BreadcrumbsAdapterProps<'_>) -> String {
+        super::render_breadcrumbs_html(props)
+    }
+}
+
+/// Yew adapter mirroring the React implementation.
+pub mod yew {
+    use super::*;
+
+    /// Render breadcrumbs for snapshot tests.
+    pub fn render_breadcrumbs(props: BreadcrumbsAdapterProps<'_>) -> String {
+        super::render_breadcrumbs_html(props)
+    }
+}
+
+/// Leptos adapter ensuring parity with other frameworks.
+pub mod leptos {
+    use super::*;
+
+    /// Render breadcrumbs into HTML markup.
+    pub fn render_breadcrumbs(props: BreadcrumbsAdapterProps<'_>) -> String {
+        super::render_breadcrumbs_html(props)
+    }
+}
+
+/// Sycamore adapter delegating to the shared renderer.
+pub mod sycamore {
+    use super::*;
+
+    /// Render breadcrumbs into deterministic HTML.
+    pub fn render_breadcrumbs(props: BreadcrumbsAdapterProps<'_>) -> String {
+        super::render_breadcrumbs_html(props)
+    }
+}
+
+/// Dioxus adapter keeping SSR output deterministic.
+pub mod dioxus {
+    use super::*;
+
+    /// Render breadcrumbs for Dioxus SSR pipelines.
+    pub fn render_breadcrumbs(props: BreadcrumbsAdapterProps<'_>) -> String {
+        super::render_breadcrumbs_html(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::ControlStrategy;
+
+    fn build_state() -> BreadcrumbsState {
+        BreadcrumbsState::new(
+            3,
+            Some(2),
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        )
+    }
+
+    fn build_props<'a>(state: &'a BreadcrumbsState) -> BreadcrumbsAdapterProps<'a> {
+        BreadcrumbsAdapterProps {
+            state,
+            root_attributes: state.root_attributes().id("crumbs"),
+            list_attributes: state.list_attributes(),
+            items: &[
+                BreadcrumbItemDescriptor {
+                    id: Some("home"),
+                    href: Some("/"),
+                    content: "<span>Home</span>",
+                    separator: "/",
+                },
+                BreadcrumbItemDescriptor {
+                    id: Some("library"),
+                    href: Some("/library"),
+                    content: "<span>Library</span>",
+                    separator: "/",
+                },
+                BreadcrumbItemDescriptor {
+                    id: Some("current"),
+                    href: None,
+                    content: "<span>Current</span>",
+                    separator: "",
+                },
+            ],
+            on_activate_event: Some("breadcrumb-activate"),
+        }
+    }
+
+    #[test]
+    fn root_attributes_include_event_channel() {
+        let state = build_state();
+        let rendered = render_breadcrumbs(build_props(&state));
+        assert!(rendered
+            .root_attributes()
+            .iter()
+            .any(|(k, v)| k == "data-on-activate" && v == "breadcrumb-activate"));
+        assert!(rendered
+            .list_attributes()
+            .iter()
+            .any(|(k, _)| k == &style_helpers::automation_data_attr("breadcrumbs", ["list"])));
+    }
+
+    #[test]
+    fn html_renderer_includes_ordered_list() {
+        let state = build_state();
+        let html = render_breadcrumbs_html(build_props(&state));
+        assert!(html.contains("<nav"));
+        assert!(html.contains("<ol"));
+        assert!(html.contains(&format!(
+            "data-component=\"{}\"",
+            style_helpers::component_marker("breadcrumbs-item")
+        )));
+    }
+}

--- a/crates/rustic-ui-material/src/lib.rs
+++ b/crates/rustic-ui-material/src/lib.rs
@@ -30,7 +30,9 @@ pub mod avatar;
 #[cfg(feature = "feedback")]
 pub mod backdrop;
 pub mod badge;
+pub mod bottom_navigation;
 pub mod r#box;
+pub mod breadcrumbs;
 pub mod button;
 pub mod card;
 pub mod checkbox;
@@ -53,9 +55,11 @@ pub mod image_list;
 pub mod input_adornment;
 #[cfg(feature = "progress")]
 pub mod linear_progress;
+pub mod link;
 pub mod list;
 pub mod macros;
 pub mod menu;
+pub mod pagination;
 pub mod paper;
 pub mod radio;
 mod render_helpers;
@@ -66,6 +70,7 @@ pub mod skeleton;
 #[cfg(feature = "forms")]
 pub mod slider;
 pub mod snackbar;
+pub mod speed_dial;
 pub mod stack;
 mod style_helpers;
 pub mod switch;
@@ -90,6 +95,14 @@ pub use avatar::{render_avatar, AvatarRenderOutput};
 #[cfg(feature = "feedback")]
 pub use backdrop::{render_backdrop, BackdropAdapterProps, BackdropRenderOutput};
 pub use badge::{render_badge, BadgeRenderOutput};
+pub use bottom_navigation::{
+    render_bottom_navigation, render_bottom_navigation_html, BottomNavigationAdapterProps,
+    BottomNavigationItemDescriptor, BottomNavigationRenderOutput,
+};
+pub use breadcrumbs::{
+    render_breadcrumbs, render_breadcrumbs_html, BreadcrumbItemDescriptor, BreadcrumbRenderOutput,
+    BreadcrumbsAdapterProps,
+};
 #[cfg(feature = "progress")]
 pub use circular_progress::{
     render_circular_progress, CircularProgressAdapterProps, CircularProgressRenderOutput,
@@ -120,11 +133,20 @@ pub use input_adornment::{
 pub use linear_progress::{
     render_linear_progress, LinearProgressAdapterProps, LinearProgressRenderOutput,
 };
+pub use link::{render_link, render_link_html, LinkAdapterProps, LinkRenderOutput};
+pub use pagination::{
+    render_pagination, render_pagination_html, PaginationAdapterProps, PaginationItemDescriptor,
+    PaginationRenderOutput,
+};
 pub use paper::{render_paper, PaperRenderOutput};
 #[cfg(feature = "progress")]
 pub use skeleton::{render_skeleton, SkeletonAdapterProps, SkeletonRenderOutput};
 #[cfg(feature = "forms")]
 pub use slider::{render_slider, SliderAdapterProps, SliderRenderOutput};
+pub use speed_dial::{
+    render_speed_dial, render_speed_dial_html, SpeedDialActionDescriptor, SpeedDialAdapterProps,
+    SpeedDialRenderOutput, SpeedDialTriggerDescriptor,
+};
 pub use stack::{render_stack, StackAdapterProps, StackRenderOutput};
 pub use telemetry::{TelemetryContext, TelemetryError, TelemetryHooks};
 pub use typography::{render_typography, TypographyRenderOutput};

--- a/crates/rustic-ui-material/src/link.rs
+++ b/crates/rustic-ui-material/src/link.rs
@@ -1,0 +1,192 @@
+//! Material renderer for the headless [`LinkState`](rustic_ui_headless::link::LinkState).
+//!
+//! The adapter layers deterministic styling and automation hooks on top of the
+//! headless state so enterprise teams can share the same navigation primitives
+//! across frameworks.
+
+use rustic_ui_headless::link::{LinkAttributes, LinkState};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+use rustic_ui_utils::attributes_to_html;
+
+use crate::style_helpers;
+
+/// Adapter props shared across frameworks.
+#[derive(Debug, Clone)]
+pub struct LinkAdapterProps<'a> {
+    /// Headless link state describing analytics and disabled semantics.
+    pub state: &'a LinkState,
+    /// Attribute builder returned from [`LinkState::attributes`].
+    pub attributes: LinkAttributes<'a>,
+    /// Inner HTML rendered inside the anchor.
+    pub content: &'a str,
+}
+
+/// Render output describing the link attributes.
+#[derive(Debug, Clone)]
+pub struct LinkRenderOutput {
+    attributes: Vec<(String, String)>,
+    content: String,
+}
+
+impl LinkRenderOutput {
+    /// Returns the attribute pairs applied to the anchor element.
+    pub fn attributes(&self) -> &[(String, String)] {
+        &self.attributes
+    }
+
+    /// Returns the inner HTML rendered inside the anchor.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+}
+
+/// Render the link into attribute pairs.
+#[must_use]
+pub fn render_link(props: LinkAdapterProps<'_>) -> LinkRenderOutput {
+    let mut pairs: Vec<(String, String)> = props
+        .attributes
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("link"),
+    ));
+    pairs.push((
+        style_helpers::automation_data_attr("link", style_helpers::EMPTY_SEGMENTS),
+        "true".into(),
+    ));
+    let attributes = style_helpers::themed_attributes(link_style(), pairs);
+
+    LinkRenderOutput {
+        attributes,
+        content: props.content.to_string(),
+    }
+}
+
+/// Render the link into serialized HTML markup.
+#[must_use]
+pub fn render_link_html(props: LinkAdapterProps<'_>) -> String {
+    let rendered = render_link(props);
+    format!(
+        "<a {attrs}>{content}</a>",
+        attrs = attributes_to_html(rendered.attributes()),
+        content = rendered.content()
+    )
+}
+
+fn link_style() -> Style {
+    css_with_theme!(
+        r#"
+        color: ${color};
+        text-decoration: none;
+        font-weight: ${weight};
+        transition: color 120ms ease;
+        &:hover {
+            color: ${hover};
+            text-decoration: underline;
+        }
+        &[data-disabled="true"] {
+            pointer-events: none;
+            color: ${disabled};
+            text-decoration: none;
+        }
+    "#,
+        color = theme.palette.primary.clone(),
+        hover = format!(
+            "color-mix(in srgb, {} 85%, black)",
+            theme.palette.primary.clone()
+        ),
+        disabled = format!(
+            "color-mix(in srgb, {} 40%, transparent)",
+            theme.palette.text_secondary.clone()
+        ),
+        weight = theme.typography.font_weight_medium
+    )
+}
+
+/// React adapter returning deterministic HTML.
+pub mod react {
+    use super::*;
+
+    /// Render the link into HTML markup for React SSR.
+    pub fn render_link(props: LinkAdapterProps<'_>) -> String {
+        super::render_link_html(props)
+    }
+}
+
+/// Yew adapter mirroring the React implementation.
+pub mod yew {
+    use super::*;
+
+    /// Render the link into HTML markup.
+    pub fn render_link(props: LinkAdapterProps<'_>) -> String {
+        super::render_link_html(props)
+    }
+}
+
+/// Leptos adapter delegating to the shared renderer.
+pub mod leptos {
+    use super::*;
+
+    /// Render the link into HTML markup.
+    pub fn render_link(props: LinkAdapterProps<'_>) -> String {
+        super::render_link_html(props)
+    }
+}
+
+/// Sycamore adapter that reuses the shared HTML renderer.
+pub mod sycamore {
+    use super::*;
+
+    /// Render the link into HTML markup.
+    pub fn render_link(props: LinkAdapterProps<'_>) -> String {
+        super::render_link_html(props)
+    }
+}
+
+/// Dioxus adapter mirroring the other implementations.
+pub mod dioxus {
+    use super::*;
+
+    /// Render the link into HTML markup.
+    pub fn render_link(props: LinkAdapterProps<'_>) -> String {
+        super::render_link_html(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_attributes_expose_automation_marker() {
+        let mut state = LinkState::new(true);
+        state.set_analytics_channel(Some("nav"));
+        state.set_analytics_tag(Some("primary"));
+        let output = render_link(LinkAdapterProps {
+            state: &state,
+            attributes: state
+                .attributes()
+                .href("/docs")
+                .id("docs-link")
+                .target("_blank"),
+            content: "Docs",
+        });
+        let marker = style_helpers::automation_data_attr("link", style_helpers::EMPTY_SEGMENTS);
+        assert!(output.attributes().iter().any(|(k, _)| k == &marker));
+    }
+
+    #[test]
+    fn html_renderer_includes_anchor_markup() {
+        let state = LinkState::new(false);
+        let html = render_link_html(LinkAdapterProps {
+            state: &state,
+            attributes: state.attributes().href("/"),
+            content: "Home",
+        });
+        assert!(html.contains("<a"));
+        assert!(html.contains("data-component=\"rustic_ui_link\""));
+    }
+}

--- a/crates/rustic-ui-material/src/pagination.rs
+++ b/crates/rustic-ui-material/src/pagination.rs
@@ -1,0 +1,456 @@
+//! Material renderer for [`PaginationState`](rustic_ui_headless::pagination::PaginationState).
+//!
+//! The adapter merges ARIA metadata from the headless state machine with Material
+//! themed styling and automation identifiers.  Each framework adapter reuses the
+//! same attribute collections, guaranteeing deterministic SSR markup.
+
+use rustic_ui_headless::pagination::{
+    PaginationItemKind, PaginationListAttributes, PaginationRootAttributes, PaginationState,
+};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+use rustic_ui_utils::attributes_to_html;
+
+use crate::style_helpers;
+
+/// Describes a single pagination control rendered inside the list.
+#[derive(Debug, Clone)]
+pub struct PaginationItemDescriptor<'a> {
+    /// Kind of control rendered (page, previous, next...).
+    pub kind: PaginationItemKind,
+    /// Optional DOM id applied to the control.
+    pub id: Option<&'a str>,
+    /// Optional accessible label overriding the default.
+    pub aria_label: Option<&'a str>,
+    /// Inner HTML rendered inside the control button.
+    pub content: &'a str,
+}
+
+/// Adapter props shared across React/Yew/Leptos/Dioxus/Sycamore integrations.
+#[derive(Debug, Clone)]
+pub struct PaginationAdapterProps<'a> {
+    /// Headless state describing focus, selection, and analytics hooks.
+    pub state: &'a PaginationState,
+    /// Root attribute builder returned from [`PaginationState::root_attributes`].
+    pub root_attributes: PaginationRootAttributes<'a>,
+    /// List attribute builder returned from [`PaginationState::list_attributes`].
+    pub list_attributes: PaginationListAttributes<'a>,
+    /// Controls rendered inside the pagination list.
+    pub items: &'a [PaginationItemDescriptor<'a>],
+    /// Optional event channel surfaced via `data-on-select`.
+    pub on_select_event: Option<&'a str>,
+}
+
+/// Rendered pagination output.
+#[derive(Debug, Clone)]
+pub struct PaginationRenderOutput {
+    root_attributes: Vec<(String, String)>,
+    list_attributes: Vec<(String, String)>,
+    items: Vec<PaginationRenderedItem>,
+}
+
+impl PaginationRenderOutput {
+    /// Attributes applied to the `<nav>` wrapper.
+    pub fn root_attributes(&self) -> &[(String, String)] {
+        &self.root_attributes
+    }
+
+    /// Attributes applied to the `<ul>` list container.
+    pub fn list_attributes(&self) -> &[(String, String)] {
+        &self.list_attributes
+    }
+
+    /// Rendered controls.
+    pub fn items(&self) -> &[PaginationRenderedItem] {
+        &self.items
+    }
+}
+
+/// Rendered control metadata.
+#[derive(Debug, Clone)]
+pub struct PaginationRenderedItem {
+    container_attributes: Vec<(String, String)>,
+    control_attributes: Vec<(String, String)>,
+    content: String,
+}
+
+impl PaginationRenderedItem {
+    /// Attributes applied to the `<li>` element.
+    pub fn container_attributes(&self) -> &[(String, String)] {
+        &self.container_attributes
+    }
+
+    /// Attributes applied to the `<button>` element.
+    pub fn control_attributes(&self) -> &[(String, String)] {
+        &self.control_attributes
+    }
+
+    /// Inner HTML rendered inside the control button.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+}
+
+/// Render the pagination controls into attribute maps.
+#[must_use]
+pub fn render_pagination(props: PaginationAdapterProps<'_>) -> PaginationRenderOutput {
+    let root_attributes = build_root_attributes(props.root_attributes, props.on_select_event);
+    let list_attributes = build_list_attributes(props.list_attributes);
+    let items = props
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, descriptor)| build_item(props.state, index, descriptor))
+        .collect();
+
+    PaginationRenderOutput {
+        root_attributes,
+        list_attributes,
+        items,
+    }
+}
+
+/// Render pagination controls into HTML markup.
+#[must_use]
+pub fn render_pagination_html(props: PaginationAdapterProps<'_>) -> String {
+    let rendered = render_pagination(props);
+    let items_html = rendered
+        .items()
+        .iter()
+        .map(|item| {
+            let button_html = format!(
+                "<button {attrs}>{content}</button>",
+                attrs = attributes_to_html(item.control_attributes()),
+                content = item.content()
+            );
+            format!(
+                "<li {attrs}>{button}</li>",
+                attrs = attributes_to_html(item.container_attributes()),
+                button = button_html
+            )
+        })
+        .collect::<String>();
+
+    let list_html = format!(
+        "<ul {attrs}>{items}</ul>",
+        attrs = attributes_to_html(rendered.list_attributes()),
+        items = items_html
+    );
+
+    format!(
+        "<nav {attrs}>{list}</nav>",
+        attrs = attributes_to_html(rendered.root_attributes()),
+        list = list_html
+    )
+}
+
+fn build_root_attributes(
+    attrs: PaginationRootAttributes<'_>,
+    on_select_event: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::with_capacity(8);
+    pairs.push(("role".into(), attrs.role().into()));
+    if let Some((key, value)) = attrs.id_attr() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.aria_label_attr() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.analytics_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some(event) = on_select_event {
+        pairs.push(("data-on-select".into(), event.into()));
+    }
+    pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("pagination"),
+    ));
+    pairs.push((
+        style_helpers::automation_data_attr("pagination", ["root"]),
+        "true".into(),
+    ));
+    style_helpers::themed_attributes(pagination_root_style(), pairs)
+}
+
+fn build_list_attributes(attrs: PaginationListAttributes<'_>) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::with_capacity(6);
+    pairs.push(("role".into(), attrs.role().into()));
+    if let Some((key, value)) = attrs.id_attr() {
+        pairs.push((key.into(), value.into()));
+    }
+    if let Some((key, value)) = attrs.analytics_attribute() {
+        pairs.push((key.into(), value.into()));
+    }
+    pairs.push((
+        style_helpers::automation_data_attr("pagination", ["list"]),
+        "true".into(),
+    ));
+    style_helpers::themed_attributes(pagination_list_style(), pairs)
+}
+
+fn build_item(
+    state: &PaginationState,
+    index: usize,
+    descriptor: &PaginationItemDescriptor<'_>,
+) -> PaginationRenderedItem {
+    let mut container_pairs: Vec<(String, String)> = Vec::with_capacity(6);
+    container_pairs.push((
+        style_helpers::automation_data_attr("pagination", ["item", &index.to_string()]),
+        "true".into(),
+    ));
+    container_pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("pagination-item"),
+    ));
+    let container_attributes =
+        style_helpers::themed_attributes(pagination_item_style(), container_pairs);
+
+    let mut builder = state.item_attributes(descriptor.kind);
+    if let Some(id) = descriptor.id {
+        builder = builder.id(id);
+    }
+    if let Some(label) = descriptor.aria_label {
+        builder = builder.aria_label(label);
+    }
+    let pairs: Vec<(String, String)> = builder
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    let mut attributes = style_helpers::themed_attributes(pagination_button_style(), pairs);
+    attributes.push((
+        style_helpers::automation_data_attr(
+            "pagination",
+            [
+                "control",
+                descriptor.kind.as_data_value(),
+                &index.to_string(),
+            ],
+        ),
+        "true".into(),
+    ));
+
+    PaginationRenderedItem {
+        container_attributes,
+        control_attributes: attributes,
+        content: descriptor.content.to_string(),
+    }
+}
+
+fn pagination_root_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: block;
+        width: 100%;
+    "#
+    )
+}
+
+fn pagination_list_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: ${gap};
+        list-style: none;
+        margin: 0;
+        padding: ${padding_y}px ${padding_x}px;
+        background: ${background};
+        border-radius: ${radius};
+    "#,
+        gap = theme.spacing(1),
+        padding_y = theme.spacing(1),
+        padding_x = theme.spacing(2),
+        background = theme.palette.background_default.clone(),
+        radius = format!("{}px", theme.joy.radius)
+    )
+}
+
+fn pagination_item_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: inline-flex;
+        align-items: center;
+    "#
+    )
+}
+
+fn pagination_button_style() -> Style {
+    css_with_theme!(
+        r#"
+        appearance: none;
+        border: none;
+        background: transparent;
+        color: ${color};
+        font-family: ${font_family};
+        font-size: ${font_size};
+        min-width: 2.25rem;
+        height: 2.25rem;
+        border-radius: ${radius};
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: background 120ms ease, color 120ms ease;
+        &[aria-current="page"] {
+            background: ${active_bg};
+            color: ${active_color};
+        }
+        &:hover {
+            background: ${hover_bg};
+        }
+        &[data-disabled="true"] {
+            cursor: default;
+            opacity: 0.5;
+        }
+    "#,
+        color = theme.palette.text_primary.clone(),
+        font_family = theme.typography.font_family.clone(),
+        font_size = format!("{:.3}rem", theme.typography.button),
+        radius = format!("{}px", theme.joy.radius),
+        active_bg = theme.palette.primary.clone(),
+        active_color = theme.palette.background_paper.clone(),
+        hover_bg = format!(
+            "color-mix(in srgb, {} 16%, transparent)",
+            theme.palette.primary.clone()
+        )
+    )
+}
+
+/// React adapter rendering pagination markup.
+pub mod react {
+    use super::*;
+
+    /// Render the pagination controls for React SSR.
+    pub fn render_pagination(props: PaginationAdapterProps<'_>) -> String {
+        super::render_pagination_html(props)
+    }
+}
+
+/// Yew adapter mirroring the React implementation.
+pub mod yew {
+    use super::*;
+
+    /// Render pagination controls for snapshot tests.
+    pub fn render_pagination(props: PaginationAdapterProps<'_>) -> String {
+        super::render_pagination_html(props)
+    }
+}
+
+/// Leptos adapter delegating to the shared renderer.
+pub mod leptos {
+    use super::*;
+
+    /// Render pagination markup for Leptos SSR.
+    pub fn render_pagination(props: PaginationAdapterProps<'_>) -> String {
+        super::render_pagination_html(props)
+    }
+}
+
+/// Sycamore adapter reusing the shared HTML renderer.
+pub mod sycamore {
+    use super::*;
+
+    /// Render pagination markup.
+    pub fn render_pagination(props: PaginationAdapterProps<'_>) -> String {
+        super::render_pagination_html(props)
+    }
+}
+
+/// Dioxus adapter mirroring the other integrations.
+pub mod dioxus {
+    use super::*;
+
+    /// Render pagination markup.
+    pub fn render_pagination(props: PaginationAdapterProps<'_>) -> String {
+        super::render_pagination_html(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::pagination::PaginationItemKind;
+    use rustic_ui_headless::ControlStrategy;
+
+    fn build_state() -> PaginationState {
+        PaginationState::new(
+            5,
+            Some(2),
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        )
+    }
+
+    fn build_props<'a>(state: &'a PaginationState) -> PaginationAdapterProps<'a> {
+        PaginationAdapterProps {
+            state,
+            root_attributes: state.root_attributes().id("pager"),
+            list_attributes: state.list_attributes(),
+            items: &[
+                PaginationItemDescriptor {
+                    kind: PaginationItemKind::First,
+                    id: Some("first"),
+                    aria_label: Some("First"),
+                    content: "&laquo;",
+                },
+                PaginationItemDescriptor {
+                    kind: PaginationItemKind::Previous,
+                    id: Some("prev"),
+                    aria_label: Some("Previous"),
+                    content: "&lsaquo;",
+                },
+                PaginationItemDescriptor {
+                    kind: PaginationItemKind::Page(0),
+                    id: Some("page-1"),
+                    aria_label: None,
+                    content: "1",
+                },
+                PaginationItemDescriptor {
+                    kind: PaginationItemKind::Page(1),
+                    id: Some("page-2"),
+                    aria_label: None,
+                    content: "2",
+                },
+                PaginationItemDescriptor {
+                    kind: PaginationItemKind::Page(2),
+                    id: Some("page-3"),
+                    aria_label: None,
+                    content: "3",
+                },
+                PaginationItemDescriptor {
+                    kind: PaginationItemKind::Next,
+                    id: Some("next"),
+                    aria_label: Some("Next"),
+                    content: "&rsaquo;",
+                },
+                PaginationItemDescriptor {
+                    kind: PaginationItemKind::Last,
+                    id: Some("last"),
+                    aria_label: Some("Last"),
+                    content: "&raquo;",
+                },
+            ],
+            on_select_event: Some("paginate"),
+        }
+    }
+
+    #[test]
+    fn root_attributes_include_event_channel() {
+        let state = build_state();
+        let rendered = render_pagination(build_props(&state));
+        assert!(rendered
+            .root_attributes()
+            .iter()
+            .any(|(k, v)| k == "data-on-select" && v == "paginate"));
+    }
+
+    #[test]
+    fn html_renderer_emits_buttons_for_each_control() {
+        let state = build_state();
+        let html = render_pagination_html(build_props(&state));
+        assert!(html.contains("<nav"));
+        assert!(html.matches("<button").count() >= 7);
+    }
+}

--- a/crates/rustic-ui-material/src/speed_dial.rs
+++ b/crates/rustic-ui-material/src/speed_dial.rs
@@ -1,0 +1,501 @@
+//! Material renderer for [`SpeedDialState`](rustic_ui_headless::speed_dial::SpeedDialState).
+//!
+//! The adapter centralises styling, automation markers, and analytics hooks so
+//! React, Yew, Leptos, Dioxus, and Sycamore render identical markup.
+
+use rustic_ui_headless::speed_dial::{
+    SpeedDialListAttributes, SpeedDialState, SpeedDialTriggerAttributes,
+};
+use rustic_ui_styled_engine::{css_with_theme, Style};
+use rustic_ui_utils::attributes_to_html;
+
+use crate::style_helpers;
+
+/// Describes the trigger button rendered for the speed dial.
+#[derive(Debug, Clone)]
+pub struct SpeedDialTriggerDescriptor<'a> {
+    /// Optional DOM id applied to the trigger button.
+    pub id: Option<&'a str>,
+    /// Optional analytics identifier overriding the state configuration.
+    pub analytics_tag: Option<&'a str>,
+    /// Inner HTML rendered inside the trigger.
+    pub content: &'a str,
+}
+
+/// Describes an action button rendered inside the floating list.
+#[derive(Debug, Clone)]
+pub struct SpeedDialActionDescriptor<'a> {
+    /// Zero-based action index.
+    pub index: usize,
+    /// Optional DOM id applied to the action button.
+    pub id: Option<&'a str>,
+    /// Optional analytics identifier overriding the state configuration.
+    pub analytics_tag: Option<&'a str>,
+    /// Optional accessible label overriding the default.
+    pub aria_label: Option<&'a str>,
+    /// Inner HTML rendered inside the action.
+    pub content: &'a str,
+}
+
+/// Adapter props shared across framework integrations.
+#[derive(Debug, Clone)]
+pub struct SpeedDialAdapterProps<'a> {
+    /// Headless state describing open/highlight semantics and analytics hooks.
+    pub state: &'a SpeedDialState,
+    /// Trigger attribute builder returned by [`SpeedDialState::trigger_attributes`].
+    pub trigger_attributes: SpeedDialTriggerAttributes<'a>,
+    /// List attribute builder returned by [`SpeedDialState::list_attributes`].
+    pub list_attributes: SpeedDialListAttributes<'a>,
+    /// Trigger descriptor.
+    pub trigger: SpeedDialTriggerDescriptor<'a>,
+    /// Action descriptors rendered inside the dial.
+    pub actions: &'a [SpeedDialActionDescriptor<'a>],
+    /// Optional event channel surfaced via `data-on-activate` when actions fire.
+    pub on_action_event: Option<&'a str>,
+    /// Optional event channel surfaced via `data-on-toggle` when the dial opens/closes.
+    pub on_toggle_event: Option<&'a str>,
+}
+
+/// Rendered speed dial output.
+#[derive(Debug, Clone)]
+pub struct SpeedDialRenderOutput {
+    container_attributes: Vec<(String, String)>,
+    trigger_attributes: Vec<(String, String)>,
+    list_attributes: Vec<(String, String)>,
+    actions: Vec<SpeedDialRenderedAction>,
+    trigger_content: String,
+}
+
+impl SpeedDialRenderOutput {
+    /// Attributes applied to the outer container.
+    pub fn container_attributes(&self) -> &[(String, String)] {
+        &self.container_attributes
+    }
+
+    /// Attributes applied to the trigger button.
+    pub fn trigger_attributes(&self) -> &[(String, String)] {
+        &self.trigger_attributes
+    }
+
+    /// Attributes applied to the action list.
+    pub fn list_attributes(&self) -> &[(String, String)] {
+        &self.list_attributes
+    }
+
+    /// Rendered actions.
+    pub fn actions(&self) -> &[SpeedDialRenderedAction] {
+        &self.actions
+    }
+
+    /// Inner HTML rendered inside the trigger.
+    pub fn trigger_content(&self) -> &str {
+        &self.trigger_content
+    }
+}
+
+/// Rendered action metadata.
+#[derive(Debug, Clone)]
+pub struct SpeedDialRenderedAction {
+    container_attributes: Vec<(String, String)>,
+    button_attributes: Vec<(String, String)>,
+    content: String,
+}
+
+impl SpeedDialRenderedAction {
+    /// Attributes applied to the `<li>` wrapper.
+    pub fn container_attributes(&self) -> &[(String, String)] {
+        &self.container_attributes
+    }
+
+    /// Attributes applied to the `<button>`.
+    pub fn button_attributes(&self) -> &[(String, String)] {
+        &self.button_attributes
+    }
+
+    /// Inner HTML rendered inside the action.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+}
+
+/// Render the speed dial into attribute maps.
+#[must_use]
+pub fn render_speed_dial(props: SpeedDialAdapterProps<'_>) -> SpeedDialRenderOutput {
+    let container_attributes = build_container_attributes(props.on_toggle_event);
+    let trigger_attributes =
+        build_trigger_attributes(props.state, props.trigger_attributes, &props.trigger);
+    let list_attributes = build_list_attributes(props.list_attributes, props.on_action_event);
+    let actions = props
+        .actions
+        .iter()
+        .map(|descriptor| build_action(props.state, descriptor))
+        .collect();
+
+    SpeedDialRenderOutput {
+        container_attributes,
+        trigger_attributes,
+        list_attributes,
+        actions,
+        trigger_content: props.trigger.content.to_string(),
+    }
+}
+
+/// Render the speed dial into HTML markup.
+#[must_use]
+pub fn render_speed_dial_html(props: SpeedDialAdapterProps<'_>) -> String {
+    let rendered = render_speed_dial(props);
+    let trigger_html = format!(
+        "<button {attrs}>{content}</button>",
+        attrs = attributes_to_html(rendered.trigger_attributes()),
+        content = rendered.trigger_content()
+    );
+    let actions_html = rendered
+        .actions()
+        .iter()
+        .map(|action| {
+            let button_html = format!(
+                "<button {attrs}>{content}</button>",
+                attrs = attributes_to_html(action.button_attributes()),
+                content = action.content()
+            );
+            format!(
+                "<li {attrs}>{button}</li>",
+                attrs = attributes_to_html(action.container_attributes()),
+                button = button_html
+            )
+        })
+        .collect::<String>();
+    let list_html = format!(
+        "<ul {attrs}>{items}</ul>",
+        attrs = attributes_to_html(rendered.list_attributes()),
+        items = actions_html
+    );
+
+    format!(
+        "<div {attrs}>{trigger}{list}</div>",
+        attrs = attributes_to_html(rendered.container_attributes()),
+        trigger = trigger_html,
+        list = list_html
+    )
+}
+
+fn build_container_attributes(on_toggle_event: Option<&str>) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::with_capacity(4);
+    pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("speed-dial"),
+    ));
+    pairs.push((
+        style_helpers::automation_data_attr("speed-dial", ["root"]),
+        "true".into(),
+    ));
+    if let Some(event) = on_toggle_event {
+        pairs.push(("data-on-toggle".into(), event.into()));
+    }
+    style_helpers::themed_attributes(speed_dial_container_style(), pairs)
+}
+
+fn build_trigger_attributes(
+    state: &SpeedDialState,
+    attrs: SpeedDialTriggerAttributes<'_>,
+    descriptor: &SpeedDialTriggerDescriptor<'_>,
+) -> Vec<(String, String)> {
+    let mut builder = attrs;
+    if let Some(id) = descriptor.id {
+        builder = builder.id(id);
+    }
+    if let Some(tag) = descriptor.analytics_tag {
+        builder = builder.analytics_tag(tag);
+    }
+    let pairs: Vec<(String, String)> = builder
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    let mut attributes = style_helpers::themed_attributes(speed_dial_trigger_style(), pairs);
+    attributes.push((
+        "data-component".into(),
+        style_helpers::component_marker("speed-dial-trigger"),
+    ));
+    attributes.push((
+        "data-state".into(),
+        if state.is_open() { "open" } else { "closed" }.into(),
+    ));
+    attributes
+}
+
+fn build_list_attributes(
+    attrs: SpeedDialListAttributes<'_>,
+    on_action_event: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = attrs
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    if let Some(event) = on_action_event {
+        pairs.push(("data-on-activate".into(), event.into()));
+    }
+    style_helpers::themed_attributes(speed_dial_list_style(), pairs)
+}
+
+fn build_action(
+    state: &SpeedDialState,
+    descriptor: &SpeedDialActionDescriptor<'_>,
+) -> SpeedDialRenderedAction {
+    let mut container_pairs: Vec<(String, String)> = Vec::with_capacity(6);
+    container_pairs.push((
+        style_helpers::automation_data_attr("speed-dial", ["item", &descriptor.index.to_string()]),
+        "true".into(),
+    ));
+    container_pairs.push((
+        "data-component".into(),
+        style_helpers::component_marker("speed-dial-item"),
+    ));
+    let container_attributes =
+        style_helpers::themed_attributes(speed_dial_item_style(), container_pairs);
+
+    let mut builder = state.action_attributes(descriptor.index);
+    if let Some(id) = descriptor.id {
+        builder = builder.id(id);
+    }
+    if let Some(tag) = descriptor.analytics_tag {
+        builder = builder.analytics_tag(tag);
+    }
+    if let Some(label) = descriptor.aria_label {
+        builder = builder.aria_label(label);
+    }
+    let pairs: Vec<(String, String)> = builder
+        .as_pairs()
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect();
+    let mut button_attributes =
+        style_helpers::themed_attributes(speed_dial_action_button_style(), pairs);
+    button_attributes.push((
+        "data-component".into(),
+        style_helpers::component_marker("speed-dial-action"),
+    ));
+
+    SpeedDialRenderedAction {
+        container_attributes,
+        button_attributes,
+        content: descriptor.content.to_string(),
+    }
+}
+
+fn speed_dial_container_style() -> Style {
+    css_with_theme!(
+        r#"
+        position: relative;
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        gap: ${gap};
+    "#,
+        gap = theme.spacing(1)
+    )
+}
+
+fn speed_dial_trigger_style() -> Style {
+    css_with_theme!(
+        r#"
+        border: none;
+        border-radius: 999px;
+        width: 56px;
+        height: 56px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: ${background};
+        color: ${color};
+        box-shadow: ${shadow};
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+        &[data-state="open"] {
+            transform: rotate(45deg);
+        }
+    "#,
+        background = theme.palette.primary.clone(),
+        color = theme.palette.background_paper.clone(),
+        shadow = theme.joy.shadow.surface.clone()
+    )
+}
+
+fn speed_dial_list_style() -> Style {
+    css_with_theme!(
+        r#"
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column-reverse;
+        gap: ${gap};
+        position: absolute;
+        bottom: 64px;
+        right: 0;
+    "#,
+        gap = theme.spacing(1)
+    )
+}
+
+fn speed_dial_item_style() -> Style {
+    css_with_theme!(
+        r#"
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-end;
+    "#
+    )
+}
+
+fn speed_dial_action_button_style() -> Style {
+    css_with_theme!(
+        r#"
+        border: none;
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        background: ${background};
+        color: ${color};
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: transform 120ms ease, box-shadow 120ms ease;
+        &:hover {
+            transform: translateY(-2px);
+            box-shadow: ${shadow};
+        }
+        &[data-disabled="true"] {
+            cursor: default;
+            opacity: 0.5;
+            box-shadow: none;
+        }
+    "#,
+        background = theme.palette.secondary.clone(),
+        color = theme.palette.background_paper.clone(),
+        shadow = theme.joy.shadow.surface.clone()
+    )
+}
+
+/// React adapter producing deterministic HTML.
+pub mod react {
+    use super::*;
+
+    /// Render the speed dial for React SSR pipelines.
+    pub fn render_speed_dial(props: SpeedDialAdapterProps<'_>) -> String {
+        super::render_speed_dial_html(props)
+    }
+}
+
+/// Yew adapter mirroring the React implementation.
+pub mod yew {
+    use super::*;
+
+    /// Render the speed dial into HTML markup.
+    pub fn render_speed_dial(props: SpeedDialAdapterProps<'_>) -> String {
+        super::render_speed_dial_html(props)
+    }
+}
+
+/// Leptos adapter delegating to the shared renderer.
+pub mod leptos {
+    use super::*;
+
+    /// Render the speed dial into HTML markup.
+    pub fn render_speed_dial(props: SpeedDialAdapterProps<'_>) -> String {
+        super::render_speed_dial_html(props)
+    }
+}
+
+/// Sycamore adapter reusing the shared HTML renderer.
+pub mod sycamore {
+    use super::*;
+
+    /// Render the speed dial into HTML markup.
+    pub fn render_speed_dial(props: SpeedDialAdapterProps<'_>) -> String {
+        super::render_speed_dial_html(props)
+    }
+}
+
+/// Dioxus adapter mirroring every other integration.
+pub mod dioxus {
+    use super::*;
+
+    /// Render the speed dial into HTML markup.
+    pub fn render_speed_dial(props: SpeedDialAdapterProps<'_>) -> String {
+        super::render_speed_dial_html(props)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustic_ui_headless::ControlStrategy;
+
+    fn build_state() -> SpeedDialState {
+        SpeedDialState::new(
+            3,
+            false,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        )
+    }
+
+    fn build_props<'a>(state: &'a SpeedDialState) -> SpeedDialAdapterProps<'a> {
+        SpeedDialAdapterProps {
+            state,
+            trigger_attributes: state.trigger_attributes(),
+            list_attributes: state.list_attributes(),
+            trigger: SpeedDialTriggerDescriptor {
+                id: Some("fab"),
+                analytics_tag: Some("primary"),
+                content: "<span>+</span>",
+            },
+            actions: &[
+                SpeedDialActionDescriptor {
+                    index: 0,
+                    id: Some("action-0"),
+                    analytics_tag: Some("create"),
+                    aria_label: Some("Create document"),
+                    content: "<span>D</span>",
+                },
+                SpeedDialActionDescriptor {
+                    index: 1,
+                    id: Some("action-1"),
+                    analytics_tag: Some("upload"),
+                    aria_label: Some("Upload"),
+                    content: "<span>U</span>",
+                },
+                SpeedDialActionDescriptor {
+                    index: 2,
+                    id: Some("action-2"),
+                    analytics_tag: Some("share"),
+                    aria_label: Some("Share"),
+                    content: "<span>S</span>",
+                },
+            ],
+            on_action_event: Some("speed-dial-action"),
+            on_toggle_event: Some("speed-dial-toggle"),
+        }
+    }
+
+    #[test]
+    fn container_attributes_include_toggle_channel() {
+        let state = build_state();
+        let rendered = render_speed_dial(build_props(&state));
+        assert!(rendered
+            .container_attributes()
+            .iter()
+            .any(|(k, v)| k == "data-on-toggle" && v == "speed-dial-toggle"));
+    }
+
+    #[test]
+    fn html_renderer_emits_trigger_and_actions() {
+        let state = build_state();
+        let html = render_speed_dial_html(build_props(&state));
+        assert!(html.contains("<button"));
+        assert!(html.matches("<li").count() >= 3);
+    }
+}


### PR DESCRIPTION
## Summary
- re-export `ControlStrategy` from the headless crate and update the navigation primitive tests to use the safe API
- refresh the Material navigation renderers to rely on public theme tokens and sanitized automation markers while expanding their unit coverage
- document the focused verification commands for the new navigation stack in the changelog

## Testing
- cargo test -p rustic-ui-headless --test navigation_primitives
- cargo test -p rustic-ui-material --lib

------
https://chatgpt.com/codex/tasks/task_e_68dae733d4bc832e8a7f22230b6cf686