### PR TITLE
feat: introduce headless app bar state and navigation example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ archived Material UI change history now lives in [`docs/archives/material-ui-cha
   regressions introduced by new primitives or re-export changes.【F:crates/xtask/src/main.rs†L254-L285】
 - Documented the new guard in the Rust CI guide so contributors run the
   multi-adapter build matrix locally before submitting patches.【F:docs/rust-ci.md†L45-L56】
+- Introduced the headless-driven app bar workflow: `AppBarState` centralises
+  automation and analytics identifiers while the Material adapters, framework
+  shims, and new `surfaces-app-bar-yew` example consume the shared builders for
+  deterministic SSR output.【F:crates/rustic-ui-headless/src/app_bar.rs†L1-L220】【F:crates/rustic-ui-material/src/app_bar.rs†L1-L248】【F:examples/surfaces-app-bar-yew/src/lib.rs†L1-L20】
 
 ### Verification
 

--- a/crates/rustic-ui-headless/CHANGELOG.md
+++ b/crates/rustic-ui-headless/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Headless `AppBarState` capturing automation identifiers, analytics hooks and
+  shared HTML/SVG attribute builders so material adapters emit consistent
+  banner markup across frameworks.
 - Form control, input adornment, alert, backdrop, circular progress, linear
   progress, and skeleton state machines with exhaustive ARIA documentation and
   controlled/uncontrolled ergonomics for automation driven adapters.

--- a/crates/rustic-ui-headless/README.md
+++ b/crates/rustic-ui-headless/README.md
@@ -8,6 +8,12 @@ callbacks.
 
 ## Select state machine quick reference
 
+`app_bar::AppBarState` centralises navigation banner metadata. The builder style
+API exposes HTML/SVG attribute helpers with consistent automation identifiers,
+and optional analytics hooks (`data-analytics-view-id`,
+`data-analytics-interaction-id`) so Material adapters can emit the same SSR
+markup as their client-side counterparts without duplicating telemetry logic.
+
 `SelectState` powers listbox-style widgets (selects, combo boxes, virtualized
 menus). The state machine now tracks which options are disabled alongside the
 open/selected/highlighted bookkeeping so adapters can declaratively toggle

--- a/crates/rustic-ui-headless/src/app_bar.rs
+++ b/crates/rustic-ui-headless/src/app_bar.rs
@@ -1,0 +1,356 @@
+//! Headless app bar state shared across renderer adapters.
+//!
+//! The state object centralises accessibility affordances, telemetry hooks and
+//! automation identifiers for the high-level navigation banner. Renderer
+//! adapters in `rustic-ui-material` and future design systems consume the state
+//! to produce framework specific markup without duplicating ARIA attributes or
+//! analytics plumbing.  The builder-style API keeps call sites ergonomic while
+//! allowing enterprise adopters to opt into deterministic identifiers for their
+//! QA suites.
+//!
+//! ## Accessibility
+//!
+//! * The generated HTML attributes always include `role="banner"` so assistive
+//!   technologies identify the region as the primary application header.
+//! * `aria-label` defaults to the title but can be overridden explicitly. This
+//!   mirrors the Material guidance which prefers a descriptive label even when
+//!   visible text is present.
+//! * SVG focused helpers mirror the HTML attributes by producing an
+//!   `aria-labelledby` relationship suitable for inline logos or navigation
+//!   icons.  Keeping the logic inside the state guarantees that hydration and
+//!   SSR output stay aligned across frameworks.
+//!
+//! ## Telemetry and automation
+//!
+//! The state stores optional analytics identifiers and exposes attribute
+//! builders that render them as `data-*` markers. These hooks allow centralised
+//! telemetry platforms to observe impressions (`data-analytics-view-id`) and
+//! interactions (`data-analytics-interaction-id`) without manual plumbing in
+//! each framework.  The automation id can be wired into existing selectors via
+//! `data-automation-id`.
+//!
+//! ## Concurrency contract
+//!
+//! `AppBarState` is `Clone + Send + Sync` so renderers can memoize or share the
+//! state across tasks (for example, server-side streaming or concurrent Yew
+//! rendering) without additional synchronisation primitives. All builder methods
+//! consume `self` and return the updated state to avoid interior mutability while
+//! still enabling fluent configuration.
+
+/// Colour palette applied to the navigation surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppBarColor {
+    /// Use the design system's primary tone.
+    Primary,
+    /// Use the secondary tone, typically reserved for alternate flows.
+    Secondary,
+}
+
+impl AppBarColor {
+    /// Returns the canonical automation-friendly label for the colour.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Secondary => "secondary",
+        }
+    }
+}
+
+/// Size variants that influence the overall bar height and density.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppBarSize {
+    /// Compact density for dashboard chrome or embedded scenarios.
+    Small,
+    /// Default density recommended by the Material specification.
+    Medium,
+    /// Tall density for marketing heavy surfaces.
+    Large,
+}
+
+impl AppBarSize {
+    /// Returns the canonical automation label for the size variant.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Small => "small",
+            Self::Medium => "medium",
+            Self::Large => "large",
+        }
+    }
+}
+
+/// Optional analytics identifiers applied to rendered attributes.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AppBarAnalytics {
+    view_id: Option<String>,
+    interaction_id: Option<String>,
+}
+
+impl AppBarAnalytics {
+    /// Attach an identifier representing the banner impression event.
+    #[must_use]
+    pub fn with_view_id(mut self, id: impl Into<String>) -> Self {
+        self.view_id = Some(id.into());
+        self
+    }
+
+    /// Attach an identifier representing click/tap interactions.
+    #[must_use]
+    pub fn with_interaction_id(mut self, id: impl Into<String>) -> Self {
+        self.interaction_id = Some(id.into());
+        self
+    }
+
+    fn has_values(&self) -> bool {
+        self.view_id.is_some() || self.interaction_id.is_some()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&'static str, &String)> {
+        self.view_id
+            .iter()
+            .map(|id| ("data-analytics-view-id", id))
+            .chain(
+                self.interaction_id
+                    .iter()
+                    .map(|id| ("data-analytics-interaction-id", id)),
+            )
+    }
+
+    /// Returns the configured view identifier (if any).
+    #[must_use]
+    pub fn view_id(&self) -> Option<&str> {
+        self.view_id.as_deref()
+    }
+
+    /// Returns the configured interaction identifier (if any).
+    #[must_use]
+    pub fn interaction_id(&self) -> Option<&str> {
+        self.interaction_id.as_deref()
+    }
+}
+
+/// Headless representation of the application bar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppBarState {
+    title: String,
+    aria_label: String,
+    color: AppBarColor,
+    size: AppBarSize,
+    automation_id: Option<String>,
+    analytics: AppBarAnalytics,
+    svg_title_id: Option<String>,
+}
+
+impl AppBarState {
+    /// Construct a new app bar state with the provided title.
+    #[must_use]
+    pub fn new(title: impl Into<String>) -> Self {
+        let title = title.into();
+        Self {
+            aria_label: title.clone(),
+            title,
+            color: AppBarColor::Primary,
+            size: AppBarSize::Medium,
+            automation_id: None,
+            analytics: AppBarAnalytics::default(),
+            svg_title_id: None,
+        }
+    }
+
+    /// Override the accessible label announced by assistive technology.
+    #[must_use]
+    pub fn with_aria_label(mut self, label: impl Into<String>) -> Self {
+        self.aria_label = label.into();
+        self
+    }
+
+    /// Change the colour palette variant applied by renderers.
+    #[must_use]
+    pub fn with_color(mut self, color: AppBarColor) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Change the size variant consumed by renderers.
+    #[must_use]
+    pub fn with_size(mut self, size: AppBarSize) -> Self {
+        self.size = size;
+        self
+    }
+
+    /// Attach an automation identifier used by QA tooling.
+    #[must_use]
+    pub fn with_automation_id(mut self, id: impl Into<String>) -> Self {
+        self.automation_id = Some(id.into());
+        self
+    }
+
+    /// Merge analytics identifiers into the state.
+    #[must_use]
+    pub fn with_analytics(mut self, analytics: AppBarAnalytics) -> Self {
+        self.analytics = analytics;
+        self
+    }
+
+    /// Provide an explicit SVG `<title>` id.
+    ///
+    /// Inline SVG logos frequently require deterministic ids so `<svg>` elements
+    /// can reference the title via `aria-labelledby`. The state stores the id and
+    /// reuses it when [`svg_attributes`] is invoked.
+    #[must_use]
+    pub fn with_svg_title_id(mut self, id: impl Into<String>) -> Self {
+        self.svg_title_id = Some(id.into());
+        self
+    }
+
+    /// Returns the configured title.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns the accessible label applied to the header region.
+    #[must_use]
+    pub fn aria_label(&self) -> &str {
+        &self.aria_label
+    }
+
+    /// Returns the palette variant.
+    #[must_use]
+    pub fn color(&self) -> AppBarColor {
+        self.color
+    }
+
+    /// Returns the size variant.
+    #[must_use]
+    pub fn size(&self) -> AppBarSize {
+        self.size
+    }
+
+    /// Returns the optional automation identifier.
+    #[must_use]
+    pub fn automation_id(&self) -> Option<&str> {
+        self.automation_id.as_deref()
+    }
+
+    /// Returns analytics identifiers (if any).
+    #[must_use]
+    pub fn analytics(&self) -> &AppBarAnalytics {
+        &self.analytics
+    }
+
+    /// Returns the SVG title id (if configured).
+    #[must_use]
+    pub fn svg_title_id(&self) -> Option<&str> {
+        self.svg_title_id.as_deref()
+    }
+
+    /// Build attribute pairs for HTML renderers.
+    ///
+    /// The output always includes the semantic banner role and the configured
+    /// accessible label. Automation and analytics identifiers are appended when
+    /// present.
+    #[must_use]
+    pub fn html_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(4);
+        attrs.push(("role", "banner".to_string()));
+        attrs.push(("aria-label", self.aria_label.clone()));
+
+        if let Some(id) = &self.automation_id {
+            attrs.push(("data-automation-id", id.clone()));
+        }
+
+        if self.analytics.has_values() {
+            for (key, value) in self.analytics.iter() {
+                attrs.push((key, value.clone()));
+            }
+        }
+
+        attrs
+    }
+
+    /// Build attribute pairs for inline SVG logos associated with the app bar.
+    ///
+    /// When a dedicated `<svg>` is used for branding it should mirror the
+    /// accessible labelling of the surrounding header. The helper returns a
+    /// tuple of attributes referencing the configured title or aria label so the
+    /// logo participates in the same automation and accessibility flows.
+    #[must_use]
+    pub fn svg_attributes(&self) -> Vec<(&'static str, String)> {
+        let mut attrs = Vec::with_capacity(3);
+        attrs.push(("role", "img".to_string()));
+
+        if let Some(id) = &self.svg_title_id {
+            attrs.push(("aria-labelledby", id.clone()));
+        } else {
+            attrs.push(("aria-label", self.aria_label.clone()));
+        }
+
+        if let Some(id) = &self.automation_id {
+            attrs.push(("data-automation-id", id.clone()));
+        }
+
+        attrs
+    }
+
+    /// Returns attributes for the SVG `<title>` node referenced by
+    /// [`svg_attributes`].
+    #[must_use]
+    pub fn svg_title_attributes(&self) -> Option<Vec<(&'static str, String)>> {
+        self.svg_title_id
+            .as_ref()
+            .map(|id| vec![("id", id.clone())])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_attributes_include_analytics() {
+        let analytics = AppBarAnalytics::default()
+            .with_view_id("view.nav")
+            .with_interaction_id("click.nav");
+        let state = AppBarState::new("Dashboard")
+            .with_aria_label("Main navigation")
+            .with_automation_id("app-bar.global")
+            .with_analytics(analytics);
+        let attrs = state.html_attributes();
+        assert!(attrs.iter().any(|(k, v)| k == &"role" && v == "banner"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == &"data-analytics-view-id" && v == "view.nav"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == &"data-analytics-interaction-id" && v == "click.nav"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == &"data-automation-id" && v == "app-bar.global"));
+    }
+
+    #[test]
+    fn svg_attributes_fall_back_to_label() {
+        let state = AppBarState::new("Dashboard").with_aria_label("Global navigation");
+        let attrs = state.svg_attributes();
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == &"aria-label" && v == "Global navigation"));
+    }
+
+    #[test]
+    fn svg_title_attributes_are_optional() {
+        let state = AppBarState::new("Dashboard")
+            .with_svg_title_id("app-bar-logo-title")
+            .with_automation_id("nav");
+        let svg_attrs = state.svg_attributes();
+        assert!(svg_attrs
+            .iter()
+            .any(|(k, v)| k == &"aria-labelledby" && v == "app-bar-logo-title"));
+        let title_attrs = state.svg_title_attributes().expect("title attrs");
+        assert!(title_attrs
+            .iter()
+            .any(|(k, v)| k == &"id" && v == "app-bar-logo-title"));
+    }
+}

--- a/crates/rustic-ui-headless/src/lib.rs
+++ b/crates/rustic-ui-headless/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod accordion;
 #[cfg(feature = "feedback")]
 pub mod alert;
+pub mod app_bar;
 pub mod aria;
 pub mod autocomplete;
 pub mod avatar;

--- a/crates/rustic-ui-headless/tests/app_bar_state.rs
+++ b/crates/rustic-ui-headless/tests/app_bar_state.rs
@@ -1,0 +1,56 @@
+//! Integration coverage for the headless [`AppBarState`].
+//!
+//! The assertions mirror how renderer adapters integrate with the state: HTML
+//! helpers surface automation identifiers while SVG helpers expose
+//! `aria-labelledby` relationships for inline branding.
+
+use rustic_ui_headless::app_bar::{AppBarAnalytics, AppBarColor, AppBarSize, AppBarState};
+
+#[test]
+fn builder_sets_core_metadata() {
+    let analytics = AppBarAnalytics::default()
+        .with_view_id("nav.view")
+        .with_interaction_id("nav.interaction");
+    let state = AppBarState::new("Console")
+        .with_aria_label("Primary navigation")
+        .with_color(AppBarColor::Secondary)
+        .with_size(AppBarSize::Large)
+        .with_automation_id("console.app-bar")
+        .with_analytics(analytics.clone())
+        .with_svg_title_id("console.branding");
+
+    assert_eq!(state.title(), "Console");
+    assert_eq!(state.aria_label(), "Primary navigation");
+    assert_eq!(state.color(), AppBarColor::Secondary);
+    assert_eq!(state.size(), AppBarSize::Large);
+    assert_eq!(state.automation_id(), Some("console.app-bar"));
+    assert_eq!(state.analytics(), &analytics);
+}
+
+#[test]
+fn html_attributes_surface_automation_hooks() {
+    let attrs = AppBarState::new("Console")
+        .with_aria_label("Primary navigation")
+        .with_automation_id("console.app-bar")
+        .with_analytics(AppBarAnalytics::default().with_view_id("nav.view"))
+        .html_attributes();
+
+    assert!(attrs.iter().any(|(k, v)| k == &"role" && v == "banner"));
+    assert!(attrs
+        .iter()
+        .any(|(k, v)| k == &"data-automation-id" && v == "console.app-bar"));
+    assert!(attrs
+        .iter()
+        .any(|(k, v)| k == &"data-analytics-view-id" && v == "nav.view"));
+}
+
+#[test]
+fn svg_helpers_support_linked_titles() {
+    let state = AppBarState::new("Console").with_svg_title_id("console.branding");
+    let svg_attrs = state.svg_attributes();
+    assert!(svg_attrs
+        .iter()
+        .any(|(k, v)| k == &"aria-labelledby" && v == "console.branding"));
+    let title_attrs = state.svg_title_attributes().expect("title attrs");
+    assert_eq!(title_attrs, vec![("id", "console.branding".to_string())]);
+}

--- a/crates/rustic-ui-material/CHANGELOG.md
+++ b/crates/rustic-ui-material/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- App bar adapters now hydrate from the headless `AppBarState`, aligning
+  automation ids, analytics markers, and SSR friendly attributes across Yew,
+  Leptos, Dioxus, and Sycamore renderers.
 - Material renderers for alerts, backdrops, form controls, input adornments,
   sliders, circular progress, linear progress, and skeleton placeholders built
   on the shared headless state machines with centralized styling helpers.

--- a/crates/rustic-ui-material/README.md
+++ b/crates/rustic-ui-material/README.md
@@ -213,7 +213,12 @@ use yew::prelude::*;
 fn app() -> Html {
     html! {
         <ThemeProvider theme={Theme::default()}>
-            <AppBar title="My App" aria_label="main navigation" />
+            <AppBar
+                title="My App"
+                aria_label="main navigation"
+                automation_id={Some("global.app-bar".into())}
+                analytics_view_id={Some("nav.global.view".into())}
+            />
             // Throttle rapid clicks to once every 200ms
             <Button label="Press" throttle_ms={200} />
             // Debounced text input with custom background color

--- a/crates/rustic-ui-material/src/app_bar.rs
+++ b/crates/rustic-ui-material/src/app_bar.rs
@@ -1,16 +1,21 @@
-//! Material themed application bar that demonstrates centralized styling and
-//! accessibility metadata.
+//! Material themed application bar powered by the headless [`AppBarState`].
 //!
-//! All adapters derive their visual appearance from
-//! [`css_with_theme!`](rustic_ui_styled_engine::css_with_theme) so palette and sizing
-//! decisions track the active [`Theme`](rustic_ui_styled_engine::Theme). The shared
-//! [`style_helpers::themed_class`](crate::style_helpers::themed_class) helper
-//! converts those styles into scoped class names while
-//! [`style_helpers::themed_attributes_html`](crate::style_helpers::themed_attributes_html)
-//! assembles ARIA rich attribute sets for SSR oriented adapters. Each framework
-//! specific module layers the correct role and `aria-label` metadata onto a
-//! semantic `<header>` so screen readers announce the bar as the application's
-//! primary banner region.
+//! The component centralises automation identifiers, analytics hooks and
+//! accessibility metadata so every framework adapter emits the same banner
+//! semantics. Styling remains theme-driven via `css_with_theme!`, while the
+//! headless state wires in telemetry defaults and SSR friendly attribute
+//! builders.
+
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+))]
+use rustic_ui_headless::app_bar::{
+    AppBarAnalytics as HeadlessAnalytics, AppBarColor as HeadlessColor, AppBarSize as HeadlessSize,
+    AppBarState,
+};
 
 #[cfg(any(
     feature = "yew",
@@ -23,10 +28,15 @@ use rustic_ui_styled_engine::{css_with_theme, use_theme, Style, Theme};
 #[cfg(feature = "yew")]
 use yew::prelude::*;
 
-// Re-export the shared enums under component specific names.  This keeps the
-// public API ergonomic while still centralizing the actual definitions in
-// `macros.rs`.
 pub use crate::macros::{Color as AppBarColor, Size as AppBarSize, Variant as AppBarVariant};
+
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+))]
+const COMPONENT_NAME: &str = "app-bar";
 
 #[cfg(any(
     feature = "yew",
@@ -69,36 +79,146 @@ fn app_bar_style(theme: &Theme, color: AppBarColor, size: AppBarSize) -> Style {
     )
 }
 
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+))]
+fn map_color(color: AppBarColor) -> HeadlessColor {
+    match color {
+        AppBarColor::Primary => HeadlessColor::Primary,
+        AppBarColor::Secondary => HeadlessColor::Secondary,
+    }
+}
+
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+))]
+fn map_size(size: AppBarSize) -> HeadlessSize {
+    match size {
+        AppBarSize::Small => HeadlessSize::Small,
+        AppBarSize::Medium => HeadlessSize::Medium,
+        AppBarSize::Large => HeadlessSize::Large,
+    }
+}
+
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+))]
+fn build_headless_state(
+    title: String,
+    aria_label: String,
+    color: AppBarColor,
+    size: AppBarSize,
+    automation_id: Option<&str>,
+    analytics_view_id: Option<&str>,
+    analytics_interaction_id: Option<&str>,
+    svg_title_id: Option<&str>,
+) -> (AppBarState, Option<String>) {
+    let sanitized_label = if aria_label.trim().is_empty() {
+        title.clone()
+    } else {
+        aria_label
+    };
+
+    let automation_dom_id = automation_id.map(|raw| {
+        crate::style_helpers::automation_id(
+            COMPONENT_NAME,
+            Some(raw),
+            crate::style_helpers::EMPTY_SEGMENTS,
+        )
+    });
+
+    let mut state = AppBarState::new(title)
+        .with_aria_label(sanitized_label)
+        .with_color(map_color(color))
+        .with_size(map_size(size));
+
+    if let Some(id) = automation_dom_id.clone() {
+        state = state.with_automation_id(id);
+    }
+
+    let mut analytics = HeadlessAnalytics::default();
+    if let Some(view) = analytics_view_id {
+        analytics = analytics.with_view_id(view);
+    }
+    if let Some(interaction) = analytics_interaction_id {
+        analytics = analytics.with_interaction_id(interaction);
+    }
+    state = state.with_analytics(analytics);
+
+    if let Some(svg_id) = svg_title_id {
+        state = state.with_svg_title_id(svg_id);
+    }
+
+    (state, automation_dom_id)
+}
+
 #[cfg(any(feature = "yew", feature = "leptos"))]
 crate::material_component_props!(AppBarProps {
     /// Title displayed inside the app bar.
     title: String,
     /// Accessible label announced by screen readers describing the app bar.
     aria_label: String,
+    /// Optional automation identifier appended to the banner and SVG helpers.
+    automation_id: Option<String>,
+    /// Analytics impression identifier forwarded to `data-analytics-view-id`.
+    analytics_view_id: Option<String>,
+    /// Analytics interaction identifier forwarded to `data-analytics-interaction-id`.
+    analytics_interaction_id: Option<String>,
+    /// Optional SVG title id for inline branding elements.
+    svg_title_id: Option<String>,
 });
 
 #[cfg(feature = "yew")]
 mod yew_impl {
     //! Yew adapter rendering the [`AppBar`] as a semantic `<header>` element.
     //!
-    //! Styling is resolved through [`css_with_theme!`] which pulls palette
-    //! values from the active [`Theme`]. The resulting class is applied to the
-    //! `<header>` element along with an explicit `role="banner"` and
-    //! configurable `aria-label` to aid screen readers.
+    //! The adapter mirrors SSR output by sourcing ARIA and telemetry attributes
+    //! from the shared [`AppBarState`]. Automation identifiers are formatted via
+    //! `style_helpers::automation_id` so QA selectors remain consistent across
+    //! frameworks.
     use super::*;
 
     /// High level navigation bar rendered at the top of the application.
     #[function_component(AppBar)]
     pub fn app_bar(props: &AppBarProps) -> Html {
         let theme = use_theme();
-        let class =
-            crate::style_helpers::themed_class(app_bar_style(&theme, props.color, props.size));
+        let style = app_bar_style(&theme, props.color, props.size);
+        let class = crate::style_helpers::themed_class(style);
+
+        let (state, automation_dom_id) = build_headless_state(
+            props.title.clone(),
+            props.aria_label.clone(),
+            props.color,
+            props.size,
+            props.automation_id.as_deref(),
+            props.analytics_view_id.as_deref(),
+            props.analytics_interaction_id.as_deref(),
+            props.svg_title_id.as_deref(),
+        );
+
+        let component_marker = crate::style_helpers::component_marker(COMPONENT_NAME);
 
         html! {
             <header
                 class={class}
+                id={automation_dom_id.clone()}
                 role="banner"
-                aria-label={props.aria_label.clone()}
+                aria-label={state.aria_label().to_string()}
+                data-component={component_marker}
+                data-color={state.color().as_str()}
+                data-size={state.size().as_str()}
+                data-automation-id={state.automation_id().map(|id| id.to_string())}
+                data-analytics-view-id={state.analytics().view_id().map(|id| id.to_string())}
+                data-analytics-interaction-id={state.analytics().interaction_id().map(|id| id.to_string())}
             >
                 { &props.title }
             </header>
@@ -112,22 +232,46 @@ pub use yew_impl::AppBar;
 #[cfg(feature = "leptos")]
 mod leptos_impl {
     //! Leptos adapter rendering the [`AppBar`] as a semantic `<header>` element.
+    //!
+    //! Telemetry and automation identifiers flow through the headless state to
+    //! keep SSR and CSR output aligned across frameworks.
     use super::*;
     use leptos::*;
 
     /// High level navigation bar rendered at the top of the application.
-    ///
-    /// The component resolves colors and sizing from the active [`Theme`] and
-    /// attaches an ARIA `role` and `aria-label` so assistive technologies can
-    /// announce the region accurately.
     #[component]
     pub fn AppBar(props: AppBarProps) -> impl IntoView {
         let theme = use_theme();
         let class =
             crate::style_helpers::themed_class(app_bar_style(&theme, props.color, props.size));
 
+        let (state, automation_dom_id) = build_headless_state(
+            props.title.clone(),
+            props.aria_label.clone(),
+            props.color,
+            props.size,
+            props.automation_id.as_deref(),
+            props.analytics_view_id.as_deref(),
+            props.analytics_interaction_id.as_deref(),
+            props.svg_title_id.as_deref(),
+        );
+
+        let component_marker = crate::style_helpers::component_marker(COMPONENT_NAME);
+        let automation_dom_id = automation_dom_id;
+
         view! {
-            <header class=class role="banner" aria-label=props.aria_label>
+            <header
+                class=class
+                id=automation_dom_id
+                role="banner"
+                aria-label=state.aria_label().to_string()
+                data-component=component_marker
+                data-color=state.color().as_str()
+                data-size=state.size().as_str()
+                data-automation-id={state.automation_id().map(|id| id.to_string())}
+                data-analytics-view-id={state.analytics().view_id().map(|id| id.to_string())}
+                data-analytics-interaction-id={state.analytics().interaction_id().map(|id| id.to_string())}
+            >
                 {props.title}
             </header>
         }
@@ -143,14 +287,14 @@ pub use AppBarProps;
 /// Adapter targeting the [`dioxus`] framework.
 ///
 /// Generates a themed `<header>` element and wires up ARIA attributes so the
-/// navigation region is announced correctly by assistive technologies.
+/// navigation region is announced correctly by assistive technologies. The
+/// headless state keeps telemetry and automation hooks aligned with the Yew and
+/// Leptos adapters.
 #[cfg(feature = "dioxus")]
 pub mod dioxus {
     use super::*;
 
-    /// Properties consumed by the Dioxus adapter. The struct intentionally
-    /// mirrors the fields used by other frameworks so business logic remains
-    /// consistent across integrations.
+    /// Properties consumed by the Dioxus adapter.
     #[derive(Default, Clone, PartialEq)]
     pub struct AppBarProps {
         /// Title displayed inside the app bar.
@@ -161,24 +305,48 @@ pub mod dioxus {
         pub color: AppBarColor,
         /// Height variant influencing overall bar size.
         pub size: AppBarSize,
+        /// Optional automation identifier forwarded to `data-automation-id`.
+        pub automation_id: Option<String>,
+        /// Optional analytics impression identifier.
+        pub analytics_view_id: Option<String>,
+        /// Optional analytics interaction identifier.
+        pub analytics_interaction_id: Option<String>,
+        /// Optional SVG title id for inline logos.
+        pub svg_title_id: Option<String>,
     }
 
     /// Render the app bar into a `<header>` tag using a theme derived class.
-    ///
-    /// [`css_with_theme!`] resolves palette values from the active [`Theme`]
-    /// which keeps styles centralized and easily overridable. The generated
-    /// class is merged with ARIA metadata so screen readers can announce the
-    /// banner role and label.
     pub fn render(props: &AppBarProps) -> String {
         let theme = use_theme();
-        // Compose the attributes with the shared helper so HTML-first adapters
-        // stay aligned with the declarative front-end integrations.
+        let (state, automation_dom_id) = build_headless_state(
+            props.title.clone(),
+            props.aria_label.clone(),
+            props.color,
+            props.size,
+            props.automation_id.as_deref(),
+            props.analytics_view_id.as_deref(),
+            props.analytics_interaction_id.as_deref(),
+            props.svg_title_id.as_deref(),
+        );
+
+        let mut attrs = state
+            .html_attributes()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect::<Vec<_>>();
+        attrs.push((
+            "data-component".to_string(),
+            crate::style_helpers::component_marker(COMPONENT_NAME),
+        ));
+        attrs.push(("data-color".to_string(), state.color().as_str().to_string()));
+        attrs.push(("data-size".to_string(), state.size().as_str().to_string()));
+        if let Some(id) = automation_dom_id {
+            attrs.push(("id".to_string(), id));
+        }
+
         let attr_string = crate::style_helpers::themed_attributes_html(
-            app_bar_style(&theme, props.color.clone(), props.size.clone()),
-            vec![
-                ("role".to_string(), "banner".to_string()),
-                ("aria-label".to_string(), props.aria_label.clone()),
-            ],
+            app_bar_style(&theme, props.color, props.size),
+            attrs,
         );
         format!("<header {}>{}</header>", attr_string, props.title)
     }
@@ -187,13 +355,12 @@ pub mod dioxus {
 /// Adapter targeting the [`sycamore`] framework.
 ///
 /// Produces an accessible `<header>` with classes derived from the active
-/// [`Theme`] and optional `aria-label` metadata.
+/// [`Theme`] and optional telemetry metadata.
 #[cfg(feature = "sycamore")]
 pub mod sycamore {
     use super::*;
 
-    /// Sycamore variant of [`AppBar`] sharing identical props with other
-    /// adapters to minimize repetitive setup across frameworks.
+    /// Sycamore variant of [`AppBar`] sharing identical props with other adapters.
     #[derive(Default, Clone, PartialEq)]
     pub struct AppBarProps {
         /// Title displayed inside the app bar.
@@ -204,17 +371,48 @@ pub mod sycamore {
         pub color: AppBarColor,
         /// Height variant controlling the overall size.
         pub size: AppBarSize,
+        /// Optional automation identifier forwarded to `data-automation-id`.
+        pub automation_id: Option<String>,
+        /// Optional analytics impression identifier.
+        pub analytics_view_id: Option<String>,
+        /// Optional analytics interaction identifier.
+        pub analytics_interaction_id: Option<String>,
+        /// Optional SVG title id for inline logos.
+        pub svg_title_id: Option<String>,
     }
 
-    /// Render the app bar into plain HTML with themed styling and ARIA
-    /// attributes for accessibility.
+    /// Render the app bar into plain HTML with themed styling and ARIA attributes.
     pub fn render(props: &AppBarProps) -> String {
         let theme = use_theme();
-        // Compose the attributes with the shared helper so HTML-first adapters
-        // stay aligned with the declarative front-end integrations.
+        let (state, automation_dom_id) = build_headless_state(
+            props.title.clone(),
+            props.aria_label.clone(),
+            props.color,
+            props.size,
+            props.automation_id.as_deref(),
+            props.analytics_view_id.as_deref(),
+            props.analytics_interaction_id.as_deref(),
+            props.svg_title_id.as_deref(),
+        );
+
+        let mut attrs = state
+            .html_attributes()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect::<Vec<_>>();
+        attrs.push((
+            "data-component".to_string(),
+            crate::style_helpers::component_marker(COMPONENT_NAME),
+        ));
+        attrs.push(("data-color".to_string(), state.color().as_str().to_string()));
+        attrs.push(("data-size".to_string(), state.size().as_str().to_string()));
+        if let Some(id) = automation_dom_id {
+            attrs.push(("id".to_string(), id));
+        }
+
         let attr_string = crate::style_helpers::themed_attributes_html(
-            app_bar_style(&theme, props.color.clone(), props.size.clone()),
-            [("role", "banner"), ("aria-label", props.aria_label.clone())],
+            app_bar_style(&theme, props.color, props.size),
+            attrs,
         );
         format!("<header {}>{}</header>", attr_string, props.title)
     }

--- a/crates/rustic-ui-material/tests/app_bar_adapters.rs
+++ b/crates/rustic-ui-material/tests/app_bar_adapters.rs
@@ -15,12 +15,18 @@ mod dioxus_tests {
             aria_label: "Application header".into(),
             color: rustic_ui_material::app_bar::AppBarColor::Primary,
             size: rustic_ui_material::app_bar::AppBarSize::Medium,
+            automation_id: Some("primary".into()),
+            analytics_view_id: Some("nav.view".into()),
+            analytics_interaction_id: Some("nav.click".into()),
+            svg_title_id: None,
         };
         let out = dioxus::render(&props);
         assert!(out.starts_with("<header"));
         assert!(out.contains("class=\""), "missing class attribute: {}", out);
         assert!(out.contains("role=\"banner\""));
         assert!(out.contains("aria-label=\"Application header\""));
+        assert!(out.contains("data-automation-id=\"rustic-app-bar-primary\""));
+        assert!(out.contains("data-analytics-view-id=\"nav.view\""));
     }
 }
 
@@ -35,11 +41,17 @@ mod sycamore_tests {
             aria_label: "Application header".into(),
             color: rustic_ui_material::app_bar::AppBarColor::Primary,
             size: rustic_ui_material::app_bar::AppBarSize::Medium,
+            automation_id: Some("primary".into()),
+            analytics_view_id: Some("nav.view".into()),
+            analytics_interaction_id: Some("nav.click".into()),
+            svg_title_id: None,
         };
         let out = sycamore::render(&props);
         assert!(out.starts_with("<header"));
         assert!(out.contains("class=\""), "missing class attribute: {}", out);
         assert!(out.contains("role=\"banner\""));
         assert!(out.contains("aria-label=\"Application header\""));
+        assert!(out.contains("data-automation-id=\"rustic-app-bar-primary\""));
+        assert!(out.contains("data-analytics-view-id=\"nav.view\""));
     }
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -623,6 +623,10 @@ fn navigation_examples(workspace: &Path) -> Result<Vec<ExampleCrate>> {
             "examples/navigation-bottom-navigation-yew/Cargo.toml",
         ),
         (
+            "surfaces-app-bar-yew",
+            "examples/surfaces-app-bar-yew/Cargo.toml",
+        ),
+        (
             "navigation-pagination-leptos",
             "examples/navigation-pagination-leptos/Cargo.toml",
         ),

--- a/examples/surfaces-app-bar-yew/Cargo.toml
+++ b/examples/surfaces-app-bar-yew/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "surfaces_app_bar_yew"
+version = "0.1.0"
+edition = "2021"
+description = "RusticUI material app bar surface driven by the headless state"
+publish = false
+license.workspace = true
+
+[[bin]]
+name = "surfaces-app-bar-yew"
+path = "src/main.rs"
+
+[dependencies]
+yew = { workspace = true, features = ["csr"] }
+rustic-ui-material = { path = "../../crates/rustic-ui-material", features = ["yew"] }
+wasm-bindgen.workspace = true
+web-sys = { workspace = true, features = ["Window", "Document"] }
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true
+
+[package.metadata.docs]
+summary = "Demonstrates enterprise-ready app bar automation hooks in Yew"

--- a/examples/surfaces-app-bar-yew/README.md
+++ b/examples/surfaces-app-bar-yew/README.md
@@ -1,0 +1,11 @@
+# surfaces-app-bar-yew
+
+Showcases how the Material `AppBar` consumes the shared headless `AppBarState`
+from RusticUI. The example renders a telemetry-ready banner with deterministic
+automation identifiers so QA suites and SSR renders observe the same DOM.
+
+## Running locally
+
+```bash
+trunk serve --open
+```

--- a/examples/surfaces-app-bar-yew/Trunk.toml
+++ b/examples/surfaces-app-bar-yew/Trunk.toml
@@ -1,0 +1,10 @@
+[build]
+target = "wasm32-unknown-unknown"
+
+[serve]
+address = "0.0.0.0"
+port = 8080
+open = false
+
+[[proxy]]
+backend = "http://localhost:3000"

--- a/examples/surfaces-app-bar-yew/index.html
+++ b/examples/surfaces-app-bar-yew/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>RusticUI App Bar (Yew)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/surfaces-app-bar-yew.js"></script>
+  </body>
+</html>

--- a/examples/surfaces-app-bar-yew/src/lib.rs
+++ b/examples/surfaces-app-bar-yew/src/lib.rs
@@ -1,0 +1,21 @@
+use yew::prelude::*;
+
+use rustic_ui_material::{AppBar, AppBarColor, AppBarSize};
+
+#[function_component(App)]
+pub fn app() -> Html {
+    html! {
+        <div data-example="surfaces-app-bar-yew">
+            <AppBar
+                title="Operations Console"
+                aria_label="Primary navigation"
+                color={AppBarColor::Primary}
+                size={AppBarSize::Large}
+                automation_id={Some("operations-console".into())}
+                analytics_view_id={Some("nav.operations.view".into())}
+                analytics_interaction_id={Some("nav.operations.click".into())}
+                svg_title_id={Some("operations-logo".into())}
+            />
+        </div>
+    }
+}

--- a/examples/surfaces-app-bar-yew/src/main.rs
+++ b/examples/surfaces-app-bar-yew/src/main.rs
@@ -1,0 +1,6 @@
+use surfaces_app_bar_yew::App;
+use yew::Renderer;
+
+fn main() {
+    Renderer::<App>::new().render();
+}

--- a/examples/surfaces-app-bar-yew/tests/wasm.rs
+++ b/examples/surfaces-app-bar-yew/tests/wasm.rs
@@ -1,0 +1,32 @@
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use yew::Renderer;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn renders_automation_attributes() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let root = document.create_element("div").unwrap();
+    root.set_id("test-root");
+    document.body().unwrap().append_child(&root).unwrap();
+
+    Renderer::<surfaces_app_bar_yew::App>::with_root(root.into()).render();
+
+    let header = document
+        .query_selector("header[data-component='rustic_ui_app-bar']")
+        .unwrap()
+        .expect("app bar rendered");
+    assert_eq!(
+        header
+            .get_attribute("data-analytics-view-id")
+            .as_deref(),
+        Some("nav.operations.view")
+    );
+    assert_eq!(
+        header
+            .get_attribute("data-automation-id")
+            .as_deref(),
+        Some("rustic-app-bar-operations-console")
+    );
+}


### PR DESCRIPTION
## Summary
- add a headless `AppBarState` with automation, analytics, and SVG helpers plus integration tests
- refactor the material adapters to hydrate from the shared state, extend props with telemetry fields, and update documentation
- add a Yew surfaces app bar example and register it with `cargo xtask`

## Testing
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: multi-framework macro collisions in rustic-ui-material)*
- `cargo test --workspace --all-features` *(aborted: same macro collisions)
- `cargo xtask examples navigation` *(fails building wasm target because `wasm32-unknown-unknown` is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db1b651214832ea0e78fd73039dce3