### PR TITLE
feat(headless): scaffold overlay primitives

### DIFF
--- a/crates/rustic-ui-headless/src/lib.rs
+++ b/crates/rustic-ui-headless/src/lib.rs
@@ -70,6 +70,8 @@ pub mod menu;
 pub mod pagination;
 pub mod paper;
 pub mod popover;
+pub mod popper;
+pub mod portal;
 pub mod radio;
 pub mod select;
 #[cfg(feature = "progress")]
@@ -87,6 +89,7 @@ pub mod text_field;
 pub mod timing;
 pub mod toggle_button_group;
 pub mod tooltip;
+pub mod transition;
 pub mod typography;
 #[cfg(feature = "unstable")]
 pub mod unstable_trap_focus;

--- a/crates/rustic-ui-headless/src/modal.rs
+++ b/crates/rustic-ui-headless/src/modal.rs
@@ -1,0 +1,185 @@
+#![deny(missing_docs)]
+//! Modal orchestration built on top of the reusable transition state.
+//!
+//! The modal state machine centralises focus loop bookkeeping, animation
+//! lifecycles, and analytics identifiers.  The controller purposely mirrors the
+//! architecture used by `dialog` and `drawer` to simplify migrations: consumers
+//! can swap to [`ModalState`] and reuse the same notification hooks.
+
+use crate::{
+    selection::ControlStrategy,
+    transition::{TransitionPhase, TransitionState},
+};
+
+/// Strategy used by modal overlays to determine how focus loops behave.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusTrapStrategy {
+    /// Automatically derive focusable elements using DOM queries.
+    Auto,
+    /// Developer supplied focusable identifiers.
+    Manual,
+    /// Focus trap disabled – useful for non-modal disclosure patterns.
+    Disabled,
+}
+
+/// Events emitted by [`ModalState`] when visibility changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModalEvent {
+    /// Modal opened.
+    Opened,
+    /// Modal closed.
+    Closed,
+}
+
+/// State machine coordinating modal visibility, transition lifecycles and focus
+/// behaviour.
+#[derive(Debug, Clone)]
+pub struct ModalState {
+    control: ControlStrategy,
+    focus: FocusTrapStrategy,
+    transition: TransitionState,
+    open: bool,
+}
+
+impl ModalState {
+    /// Creates a new uncontrolled modal.
+    pub fn uncontrolled(default_open: bool, focus: FocusTrapStrategy, automation_id: Option<String>) -> Self {
+        let mut state = Self {
+            control: ControlStrategy::Uncontrolled,
+            focus,
+            transition: TransitionState::new(automation_id),
+            open: default_open,
+        };
+        if default_open {
+            state.transition.begin_enter();
+        }
+        state
+    }
+
+    /// Creates a new controlled modal.  External controllers must call
+    /// [`ModalState::sync_open`] when reacting to emitted events.
+    pub fn controlled(focus: FocusTrapStrategy, automation_id: Option<String>) -> Self {
+        Self {
+            control: ControlStrategy::Controlled,
+            focus,
+            transition: TransitionState::new(automation_id),
+            open: false,
+        }
+    }
+
+    /// Returns whether the modal is currently open.
+    #[inline]
+    pub const fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Returns the control strategy.
+    #[inline]
+    pub const fn control_strategy(&self) -> ControlStrategy {
+        self.control
+    }
+
+    /// Returns the focus trap strategy for the modal surface.
+    #[inline]
+    pub const fn focus_strategy(&self) -> FocusTrapStrategy {
+        self.focus
+    }
+
+    /// Returns the transition snapshot for DOM annotations.
+    #[inline]
+    pub fn transition(&self) -> crate::transition::TransitionSnapshot {
+        self.transition.snapshot()
+    }
+
+    /// Reconciles external state for controlled modals.
+    pub fn sync_open(&mut self, open: bool) {
+        if !self.control.is_controlled() {
+            return;
+        }
+        self.open = open;
+        if open {
+            self.transition.begin_enter();
+        } else if self.transition.begin_exit() {
+            self.transition.complete();
+        }
+    }
+
+    /// Request to open the modal.
+    pub fn open<F: FnOnce(ModalEvent)>(&mut self, notify: F) {
+        if self.open {
+            return;
+        }
+        if !self.control.is_controlled() {
+            self.open = true;
+        }
+        let changed = self.transition.begin_enter();
+        if changed {
+            notify(ModalEvent::Opened);
+        }
+    }
+
+    /// Request to close the modal.
+    pub fn close<F: FnOnce(ModalEvent)>(&mut self, notify: F) {
+        if !self.open {
+            return;
+        }
+        if !self.control.is_controlled() {
+            self.open = false;
+        }
+        let mut changed = false;
+        if self.transition.begin_exit() {
+            changed = true;
+            self.transition.complete();
+        }
+        if changed {
+            notify(ModalEvent::Closed);
+        }
+    }
+
+    /// Returns a tuple describing the modal's `data-state` attribute.
+    pub fn data_state(&self) -> (&'static str, &'static str) {
+        (
+            "data-state",
+            if self.transition.snapshot().phase().is_visible() {
+                "open"
+            } else {
+                "closed"
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modal_uncontrolled_flow() {
+        let mut events = Vec::new();
+        let mut modal = ModalState::uncontrolled(false, FocusTrapStrategy::Auto, None);
+        modal.open(|event| events.push(event));
+        assert!(modal.is_open());
+        assert_eq!(modal.transition().phase(), TransitionPhase::Entering);
+        modal.close(|event| events.push(event));
+        assert!(!modal.is_open());
+        assert_eq!(modal.transition().phase(), TransitionPhase::Completed);
+        assert_eq!(events, vec![ModalEvent::Opened, ModalEvent::Closed]);
+    }
+
+    #[test]
+    fn modal_controlled_flow() {
+        let mut events = Vec::new();
+        let mut modal = ModalState::controlled(FocusTrapStrategy::Auto, Some("modal".into()));
+        modal.open(|event| events.push(event));
+        assert!(!modal.is_open());
+        assert_eq!(events, vec![ModalEvent::Opened]);
+        modal.sync_open(true);
+        assert!(modal.is_open());
+        assert_eq!(modal.transition().phase(), TransitionPhase::Entering);
+        modal.close(|event| events.push(event));
+        modal.sync_open(false);
+        assert!(!modal.is_open());
+        assert_eq!(modal.transition().phase(), TransitionPhase::Completed);
+        assert_eq!(events, vec![ModalEvent::Opened, ModalEvent::Closed]);
+    }
+}

--- a/crates/rustic-ui-headless/src/popper.rs
+++ b/crates/rustic-ui-headless/src/popper.rs
@@ -1,0 +1,198 @@
+#![deny(missing_docs)]
+//! Floating element orchestration with collision awareness.
+//!
+//! Popper state builds upon [`TransitionState`](crate::transition::TransitionState)
+//! and [`PortalState`](crate::portal::PortalState) to provide deterministic
+//! placement metadata for Material adapters.  It mirrors the design of
+//! [`popover`](crate::popover) but exposes additional levers commonly required by
+//! tooltips, menus, and bespoke automation overlays.
+
+use crate::{portal::PortalState, transition::TransitionState};
+
+/// Pointer modality recorded when a popper opens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointerType {
+    /// Mouse pointer.
+    Mouse,
+    /// Touch pointer.
+    Touch,
+    /// Keyboard interaction.
+    Keyboard,
+}
+
+/// Describes how the floating element should react to collisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollisionStrategy {
+    /// Prefer the requested placement even if it overflows.
+    None,
+    /// Flip the placement when an overflow is detected.
+    Flip,
+    /// Shift along the primary axis to keep the surface on-screen.
+    Shift,
+}
+
+impl Default for CollisionStrategy {
+    fn default() -> Self {
+        Self::Flip
+    }
+}
+
+/// Axis aligned placement options for popper surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopperPlacement {
+    /// Above the anchor.
+    Top,
+    /// Below the anchor.
+    Bottom,
+    /// Before the anchor (left in LTR).
+    Start,
+    /// After the anchor (right in LTR).
+    End,
+}
+
+impl Default for PopperPlacement {
+    fn default() -> Self {
+        Self::Bottom
+    }
+}
+
+/// Snapshot describing where the surface should render.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PopperSnapshot {
+    placement: PopperPlacement,
+    pointer: Option<PointerType>,
+    transition: crate::transition::TransitionSnapshot,
+}
+
+impl PopperSnapshot {
+    /// Returns the resolved placement.
+    #[inline]
+    pub const fn placement(&self) -> PopperPlacement {
+        self.placement
+    }
+
+    /// Returns the last pointer type used to open the popper if any.
+    #[inline]
+    pub const fn pointer_type(&self) -> Option<PointerType> {
+        self.pointer
+    }
+
+    /// Returns the embedded transition snapshot.
+    #[inline]
+    pub const fn transition(&self) -> &crate::transition::TransitionSnapshot {
+        &self.transition
+    }
+}
+
+/// Popper controller storing placement resolution, transition state, and
+/// hydration metadata.
+#[derive(Debug, Clone)]
+pub struct PopperState {
+    preferred: PopperPlacement,
+    resolved: PopperPlacement,
+    collision: CollisionStrategy,
+    pointer: Option<PointerType>,
+    transition: TransitionState,
+    portal: PortalState,
+}
+
+impl PopperState {
+    /// Creates a new popper controller.
+    pub fn new(
+        preferred: PopperPlacement,
+        collision: CollisionStrategy,
+        automation_id: Option<String>,
+    ) -> Self {
+        let transition = TransitionState::new(automation_id.clone());
+        let portal = PortalState::new(automation_id, false);
+        Self {
+            preferred,
+            resolved: preferred,
+            collision,
+            pointer: None,
+            transition,
+            portal,
+        }
+    }
+
+    /// Returns the preferred placement before collision handling.
+    #[inline]
+    pub const fn preferred(&self) -> PopperPlacement {
+        self.preferred
+    }
+
+    /// Returns the resolved placement.
+    #[inline]
+    pub const fn resolved(&self) -> PopperPlacement {
+        self.resolved
+    }
+
+    /// Returns the collision strategy.
+    #[inline]
+    pub const fn collision_strategy(&self) -> CollisionStrategy {
+        self.collision
+    }
+
+    /// Returns the portal state.
+    #[inline]
+    pub const fn portal(&self) -> &PortalState {
+        &self.portal
+    }
+
+    /// Mutable portal state for hydration aware adapters.
+    #[inline]
+    pub fn portal_mut(&mut self) -> &mut PortalState {
+        &mut self.portal
+    }
+
+    /// Updates the resolved placement after a collision pass.
+    pub fn set_resolved(&mut self, placement: PopperPlacement) {
+        self.resolved = placement;
+    }
+
+    /// Records the pointer type that opened the popper.
+    pub fn register_pointer(&mut self, pointer: PointerType) {
+        self.pointer = Some(pointer);
+        self.transition.begin_enter();
+    }
+
+    /// Returns a snapshot for rendering layers.
+    pub fn snapshot(&self) -> PopperSnapshot {
+        PopperSnapshot {
+            placement: self.resolved,
+            pointer: self.pointer,
+            transition: self.transition.snapshot(),
+        }
+    }
+
+    /// Requests the popper to close.
+    pub fn close(&mut self) {
+        if self.transition.begin_exit() {
+            self.transition.complete();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transition::TransitionPhase;
+
+    #[test]
+    fn popper_tracks_pointer_and_resolved_state() {
+        let mut popper = PopperState::new(PopperPlacement::Bottom, CollisionStrategy::Flip, None);
+        popper.portal_mut().hydrate();
+        popper.register_pointer(PointerType::Mouse);
+        let snapshot = popper.snapshot();
+        assert_eq!(snapshot.placement(), PopperPlacement::Bottom);
+        assert_eq!(snapshot.pointer_type(), Some(PointerType::Mouse));
+        assert_eq!(snapshot.transition().phase(), TransitionPhase::Entering);
+        popper.set_resolved(PopperPlacement::Start);
+        popper.close();
+        assert_eq!(
+            popper.snapshot().transition().phase(),
+            TransitionPhase::Completed
+        );
+        assert_eq!(popper.resolved(), PopperPlacement::Start);
+    }
+}

--- a/crates/rustic-ui-headless/src/portal.rs
+++ b/crates/rustic-ui-headless/src/portal.rs
@@ -1,0 +1,108 @@
+#![deny(missing_docs)]
+//! Headless portal coordination shared across material renderers.
+//!
+//! The portal state keeps runtime focus orchestration and hydration guards in a
+//! single location so overlay surfaces mount predictably on the client while
+//! remaining safe to render on the server.  `rustic_ui_system::portal::PortalMount`
+//! generates deterministic DOM anchor identifiers; this module captures the
+//! runtime bookkeeping required to coordinate focus loops, hydration windows,
+//! and analytics beacons.
+
+use crate::transition::TransitionState;
+
+/// Portal visibility and hydration guard.
+#[derive(Debug, Clone)]
+pub struct PortalState {
+    transition: TransitionState,
+    hydrated: bool,
+    trap_focus: bool,
+}
+
+impl PortalState {
+    /// Creates a portal state machine.  Portals default to `hydrated = false`
+    /// which keeps SSR markup inert until the first client render confirms the
+    /// environment is interactive.
+    pub fn new(automation_id: Option<String>, trap_focus: bool) -> Self {
+        let mut transition = TransitionState::new(automation_id);
+        // Start idle until hydration toggles visibility.
+        transition.reset();
+        Self {
+            transition,
+            hydrated: false,
+            trap_focus,
+        }
+    }
+
+    /// Marks the portal as hydrated which allows the surface to enter.
+    pub fn hydrate(&mut self) {
+        if !self.hydrated {
+            self.hydrated = true;
+            self.transition.begin_enter();
+        }
+    }
+
+    /// Returns whether the portal has been hydrated.
+    #[inline]
+    pub const fn is_hydrated(&self) -> bool {
+        self.hydrated
+    }
+
+    /// Returns the underlying transition snapshot.
+    #[inline]
+    pub fn transition(&self) -> crate::transition::TransitionSnapshot {
+        self.transition.snapshot()
+    }
+
+    /// Returns whether the portal should trap focus when visible.
+    #[inline]
+    pub const fn trap_focus(&self) -> bool {
+        self.trap_focus
+    }
+
+    /// Requests the portal to close.
+    pub fn close(&mut self) {
+        if self.transition.begin_exit() {
+            self.transition.complete();
+        }
+    }
+
+    /// Immediately hides the portal.  Useful for server side rendering resets.
+    pub fn reset(&mut self) {
+        self.transition.reset();
+        self.hydrated = false;
+    }
+
+    /// Returns a tuple suitable for DOM `data-state` attributes.
+    #[inline]
+    pub fn data_state(&self) -> (&'static str, &'static str) {
+        (
+            "data-state",
+            if self.transition.snapshot().phase().is_visible() {
+                "open"
+            } else {
+                "closed"
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transition::TransitionPhase;
+
+    #[test]
+    fn portal_hydration_flow() {
+        let mut portal = PortalState::new(Some("portal".into()), true);
+        assert!(!portal.is_hydrated());
+        assert_eq!(portal.transition().phase(), TransitionPhase::Idle);
+        portal.hydrate();
+        assert!(portal.is_hydrated());
+        assert_eq!(portal.transition().phase(), TransitionPhase::Entering);
+        portal.close();
+        assert_eq!(portal.transition().phase(), TransitionPhase::Completed);
+        portal.reset();
+        assert!(!portal.is_hydrated());
+        assert_eq!(portal.transition().phase(), TransitionPhase::Idle);
+    }
+}

--- a/crates/rustic-ui-headless/src/transition.rs
+++ b/crates/rustic-ui-headless/src/transition.rs
@@ -1,0 +1,216 @@
+#![deny(missing_docs)]
+//! Declarative transition state shared across overlay primitives.
+//!
+//! Enterprise teams frequently orchestrate multi-step animations, analytics
+//! beacons, and focus management around overlay lifecycles.  Baking these
+//! behaviours into every widget quickly becomes error prone and difficult to
+//! coordinate across frameworks.  The [`TransitionState`] type below captures a
+//! simple deterministic state machine that documents each phase of an overlay
+//! transition.  Headless consumers emit the intents (enter/exit/cancel) while
+//! material renderers decorate the lifecycle with CSS animations, telemetry, and
+//! automation hooks.
+//!
+//! The machine intentionally separates *phase* from *visibility* to make focus
+//! loops easier to audit:
+//!
+//! * `phase` – which semantic stage of the lifecycle we are in (`Entering`,
+//!   `Visible`, `Exiting`, `Completed`).  Analytics pipelines typically record
+//!   these values.
+//! * `is_visible` – boolean flag describing whether the element should be in the
+//!   accessibility tree.  During an exit animation we keep the element visible
+//!   so focus does not jump unexpectedly, but we expose the intermediate phase so
+//!   renderers can attach `aria-hidden` or `data-transition` hints.
+//!
+//! The transition machine is intentionally reusable: [`ModalState`],
+//! [`PortalState`], and [`PopperState`](crate::popper::PopperState) all embed an
+//! instance to ensure every overlay speaks the same language.  Downstream tests
+//! assert on [`TransitionSnapshot::phase`] rather than brittle animation class
+//! names.
+
+/// Enumeration of semantic transition phases for overlays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransitionPhase {
+    /// The overlay has not yet entered and should be hidden from assistive
+    /// technology.
+    Idle,
+    /// Enter animation is running.  The element is visible but not yet fully
+    /// interactive.
+    Entering,
+    /// The overlay finished entering and is fully interactive.
+    Visible,
+    /// Exit animation is running.  Consumers should keep the overlay in the DOM
+    /// until [`TransitionPhase::Completed`] is observed.
+    Exiting,
+    /// Exit animation finished.  Consumers may safely remove the overlay.
+    Completed,
+}
+
+impl TransitionPhase {
+    /// Returns whether the phase indicates a visible surface.
+    #[inline]
+    pub const fn is_visible(self) -> bool {
+        matches!(self, Self::Entering | Self::Visible | Self::Exiting)
+    }
+}
+
+/// Lightweight snapshot returned to UI adapters so they can annotate DOM nodes
+/// without mutating the state machine directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionSnapshot {
+    phase: TransitionPhase,
+    automation_id: Option<String>,
+}
+
+impl TransitionSnapshot {
+    /// Creates a new snapshot from the internal transition state.
+    #[inline]
+    pub(crate) fn new(phase: TransitionPhase, automation_id: Option<String>) -> Self {
+        Self {
+            phase,
+            automation_id,
+        }
+    }
+
+    /// Returns the semantic transition phase.
+    #[inline]
+    pub const fn phase(&self) -> TransitionPhase {
+        self.phase
+    }
+
+    /// Returns the automation identifier if present.
+    #[inline]
+    pub fn automation_id(&self) -> Option<&str> {
+        self.automation_id.as_deref()
+    }
+
+    /// Returns the recommended `data-transition` attribute tuple.
+    #[inline]
+    pub fn data_transition(&self) -> (&'static str, String) {
+        (
+            "data-transition",
+            match self.phase {
+                TransitionPhase::Idle => "idle",
+                TransitionPhase::Entering => "entering",
+                TransitionPhase::Visible => "visible",
+                TransitionPhase::Exiting => "exiting",
+                TransitionPhase::Completed => "completed",
+            }
+            .into(),
+        )
+    }
+}
+
+/// Deterministic transition controller powering all overlay style hooks.
+#[derive(Debug, Clone)]
+pub struct TransitionState {
+    phase: TransitionPhase,
+    automation_id: Option<String>,
+}
+
+impl TransitionState {
+    /// Creates a new transition state configured with an optional automation
+    /// identifier.  The automation id is bubbled up to snapshots enabling Playwright
+    /// tests and analytics collectors to assert on the transition lifecycle.
+    #[must_use]
+    pub fn new(automation_id: Option<String>) -> Self {
+        Self {
+            phase: TransitionPhase::Idle,
+            automation_id,
+        }
+    }
+
+    /// Returns a read only snapshot for UI layers.
+    #[inline]
+    pub fn snapshot(&self) -> TransitionSnapshot {
+        TransitionSnapshot::new(self.phase, self.automation_id.clone())
+    }
+
+    /// Starts the enter animation.  Returns whether the call changed the phase.
+    pub fn begin_enter(&mut self) -> bool {
+        if matches!(
+            self.phase,
+            TransitionPhase::Idle | TransitionPhase::Completed
+        ) {
+            self.phase = TransitionPhase::Entering;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Marks the overlay as visible.  Typically invoked once the enter
+    /// animation completes.
+    pub fn mark_visible(&mut self) -> bool {
+        if matches!(
+            self.phase,
+            TransitionPhase::Entering | TransitionPhase::Idle
+        ) {
+            self.phase = TransitionPhase::Visible;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Starts the exit animation.
+    pub fn begin_exit(&mut self) -> bool {
+        if matches!(
+            self.phase,
+            TransitionPhase::Visible | TransitionPhase::Entering
+        ) {
+            self.phase = TransitionPhase::Exiting;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Completes the exit animation and resets back to [`TransitionPhase::Completed`].
+    pub fn complete(&mut self) -> bool {
+        if matches!(self.phase, TransitionPhase::Exiting) {
+            self.phase = TransitionPhase::Completed;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Resets the controller to [`TransitionPhase::Idle`].
+    pub fn reset(&mut self) {
+        self.phase = TransitionPhase::Idle;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transition_happy_path() {
+        let mut state = TransitionState::new(Some("modal-transition".into()));
+        assert_eq!(state.snapshot().phase(), TransitionPhase::Idle);
+        assert!(state.begin_enter());
+        assert_eq!(state.snapshot().phase(), TransitionPhase::Entering);
+        assert!(state.mark_visible());
+        assert_eq!(state.snapshot().phase(), TransitionPhase::Visible);
+        assert!(state.begin_exit());
+        assert_eq!(state.snapshot().phase(), TransitionPhase::Exiting);
+        assert!(state.complete());
+        assert_eq!(state.snapshot().phase(), TransitionPhase::Completed);
+        state.reset();
+        assert_eq!(state.snapshot().phase(), TransitionPhase::Idle);
+    }
+
+    #[test]
+    fn transition_prevents_duplicate_state_changes() {
+        let mut state = TransitionState::new(None);
+        assert!(state.begin_enter());
+        assert!(!state.begin_enter());
+        assert!(state.mark_visible());
+        assert!(!state.mark_visible());
+        assert!(state.begin_exit());
+        assert!(!state.begin_exit());
+        assert!(state.complete());
+        assert!(!state.complete());
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable transition controller capturing overlay lifecycle metadata
- introduce portal, modal, and popper headless state machines with documentation and tests
- export the new primitives from the headless crate for downstream adapters

## Testing
- cargo fmt
- cargo clippy --workspace --all-targets -- -D warnings *(fails: workspace enables web adapters without framework macros available in this environment)*
- cargo test -p rustic-ui-headless


------
https://chatgpt.com/codex/tasks/task_e_68db3e752878832e9e01a53857cb398a