### PR TITLE
Refine material select handle integration and analytics coverage

### DIFF
--- a/crates/rustic-ui-headless/src/input_base.rs
+++ b/crates/rustic-ui-headless/src/input_base.rs
@@ -302,6 +302,25 @@ impl InputState {
         &self.errors
     }
 
+    /// Replace the current value without emitting analytics events.
+    ///
+    /// This is primarily consumed by higher level inputs that need to
+    /// synchronise SSR or virtual DOM state without incrementing dirty flags
+    /// or triggering instrumentation hooks.  The dirty flag is recomputed
+    /// against the existing baseline so callers can immediately decide whether
+    /// they also want to update [`InputState::set_initial_value`].
+    pub fn set_value_silently(&mut self, value: impl Into<String>) {
+        let value = value.into();
+        self.value = value;
+        self.pending_controlled = None;
+        self.recompute_dirty();
+    }
+
+    /// Explicitly toggle the visited marker.
+    pub fn set_visited(&mut self, visited: bool) {
+        self.visited = visited;
+    }
+
     fn push_analytics(&mut self, event: InputAnalyticsEvent) {
         self.analytics.push(event);
     }
@@ -422,6 +441,20 @@ impl InputState {
             InputAnalyticsEventKind::Validation,
             self.errors.len().to_string(),
         ));
+    }
+
+    /// Clear the validation error collection without emitting analytics.
+    pub fn clear_errors(&mut self) {
+        self.errors.clear();
+    }
+
+    /// Update the baseline used when calculating the dirty flag.  Callers can
+    /// pair this with [`InputState::set_value_silently`] after hydrating from a
+    /// controlled parent so the state machine mirrors the upstream value
+    /// without appearing dirty.
+    pub fn set_initial_value(&mut self, value: impl Into<String>) {
+        self.initial_value = value.into();
+        self.recompute_dirty();
     }
 }
 

--- a/crates/rustic-ui-headless/src/select.rs
+++ b/crates/rustic-ui-headless/src/select.rs
@@ -3,9 +3,21 @@
 //! The implementation keeps track of open state, the currently highlighted
 //! option, the committed selection and a rolling typeahead buffer.  Framework
 //! adapters can drive the state machine through the provided public API to
-//! implement either controlled or uncontrolled widgets.
+//! implement either controlled or uncontrolled widgets.  Internally the select
+//! state now layers the shared [`crate::input_base::InputState`] so validation,
+//! analytics, and focus telemetry mirror the text-field and future input
+//! primitives without re-implementing the bookkeeping logic.  When paired with
+//! [`SelectControlBuilder`] the select exposes both the [`SelectState`] and
+//! [`FormControlState`](crate::form_control::FormControlState) to adapters in a
+//! single call, keeping controlled/uncontrolled wiring consistent across
+//! frameworks.
 
 use crate::aria;
+use crate::form_control::FormControlState;
+use crate::input_base::{
+    InputAnalyticsEvent, InputCommit, InputControlBuilder, InputControlBundle, InputReset,
+    InputState,
+};
 use crate::interaction::ControlKey;
 use crate::selection::{clamp_index, wrap_index, ControlStrategy, TypeaheadBuffer};
 use std::time::Duration;
@@ -31,6 +43,134 @@ pub struct SelectState {
     open_mode: ControlStrategy,
     selection_mode: ControlStrategy,
     typeahead: TypeaheadBuffer,
+    input: InputState,
+}
+
+/// Bundle aligning [`SelectState`] with the surrounding [`FormControlState`].
+#[derive(Debug)]
+pub struct SelectControlBundle {
+    /// Headless select state machine.
+    pub select: SelectState,
+    /// Form control shell describing labels, helper text and analytics ids.
+    pub form_control: FormControlState,
+}
+
+/// Fluent builder that wires [`SelectState`] and [`FormControlState`] using the
+/// shared [`InputControlBuilder`].
+#[derive(Debug, Clone)]
+pub struct SelectControlBuilder {
+    option_count: usize,
+    initial_selected: Option<usize>,
+    default_open: bool,
+    open_mode: ControlStrategy,
+    selection_mode: ControlStrategy,
+    input: InputControlBuilder,
+}
+
+impl SelectControlBuilder {
+    /// Start a new builder targeting a select with the provided option count.
+    pub fn new(option_count: usize) -> Self {
+        Self {
+            option_count,
+            initial_selected: None,
+            default_open: false,
+            open_mode: ControlStrategy::Uncontrolled,
+            selection_mode: ControlStrategy::Uncontrolled,
+            input: InputControlBuilder::new(""),
+        }
+    }
+
+    /// Configure the zero-based index of the initially selected option.
+    pub fn initial_selected(mut self, selected: Option<usize>) -> Self {
+        self.initial_selected = selected;
+        self
+    }
+
+    /// Indicate whether the popover should start open when uncontrolled.
+    pub fn default_open(mut self, open: bool) -> Self {
+        self.default_open = open;
+        self
+    }
+
+    /// Switch the open flag into controlled mode.
+    pub fn controlled_open(mut self) -> Self {
+        self.open_mode = ControlStrategy::Controlled;
+        self
+    }
+
+    /// Switch the selection into controlled mode.
+    pub fn controlled_selection(mut self) -> Self {
+        self.selection_mode = ControlStrategy::Controlled;
+        self.input = self.input.controlled();
+        self
+    }
+
+    /// Explicitly mark the selection as uncontrolled.
+    pub fn uncontrolled_selection(mut self) -> Self {
+        self.selection_mode = ControlStrategy::Uncontrolled;
+        self.input = self.input.uncontrolled();
+        self
+    }
+
+    /// Assign an id for the underlying form control.
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.input = self.input.id(id);
+        self
+    }
+
+    /// Replace the `aria-describedby` list with the provided collection.
+    pub fn described_by<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.input = self.input.described_by(ids);
+        self
+    }
+
+    /// Set the label id for the control shell.
+    pub fn labelled_by(mut self, id: impl Into<String>) -> Self {
+        self.input = self.input.labelled_by(id);
+        self
+    }
+
+    /// Mark the control as disabled.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.input = self.input.disabled(disabled);
+        self
+    }
+
+    /// Mark the control as required.
+    pub fn required(mut self, required: bool) -> Self {
+        self.input = self.input.required(required);
+        self
+    }
+
+    /// Attach an automation identifier used by analytics probes.
+    pub fn automation_id(mut self, id: impl Into<String>) -> Self {
+        self.input = self.input.automation_id(id);
+        self
+    }
+
+    /// Finalise the builder returning the aligned bundle.
+    pub fn build(self) -> SelectControlBundle {
+        let InputControlBundle {
+            input,
+            form_control,
+        } = self.input.build();
+        let mut select = SelectState::new(
+            self.option_count,
+            self.initial_selected,
+            self.default_open,
+            self.open_mode,
+            self.selection_mode,
+        );
+        select.set_input_state(input);
+        SelectControlBundle {
+            select,
+            form_control,
+        }
+    }
 }
 
 impl SelectState {
@@ -50,6 +190,11 @@ impl SelectState {
     ) -> Self {
         let selected = clamp_index(initial_selected, option_count);
         let highlighted = selected.or(if option_count > 0 { Some(0) } else { None });
+        let initial_value = Self::selection_value(selected);
+        let input = match selection_mode {
+            ControlStrategy::Controlled => InputState::controlled(initial_value.clone(), None),
+            ControlStrategy::Uncontrolled => InputState::uncontrolled(initial_value.clone(), None),
+        };
         let mut state = Self {
             option_count,
             disabled: vec![false; option_count],
@@ -63,6 +208,7 @@ impl SelectState {
             open_mode,
             selection_mode,
             typeahead: TypeaheadBuffer::new(TYPEAHEAD_TIMEOUT),
+            input,
         };
         // Ensure the initial highlight respects disabled bookkeeping even when
         // callers immediately flag items as inert after construction.
@@ -132,6 +278,57 @@ impl SelectState {
         self.selected
     }
 
+    /// Replace the underlying [`InputState`]. Primarily used by builders that
+    /// compose [`InputControlBuilder`] so the select and form control share the
+    /// same value bookkeeping.
+    pub(crate) fn set_input_state(&mut self, input: InputState) {
+        self.input = input;
+        self.sync_input_selection(self.selected, false);
+    }
+
+    /// Borrow the underlying [`InputState`] powering value/validation metadata.
+    #[inline]
+    pub fn input_state(&self) -> &InputState {
+        &self.input
+    }
+
+    /// Mutably borrow the underlying [`InputState`].
+    #[inline]
+    pub fn input_state_mut(&mut self) -> &mut InputState {
+        &mut self.input
+    }
+
+    /// Drain accumulated analytics events from the input state machine.
+    pub fn drain_input_analytics(&mut self) -> Vec<InputAnalyticsEvent> {
+        self.input.drain_analytics()
+    }
+
+    /// Commit the input state reflecting a blur/enter action on the control.
+    pub fn commit_input(&mut self) -> InputCommit<'_> {
+        self.input.commit()
+    }
+
+    /// Reset the input value back to its initial selection.
+    pub fn reset_input(&mut self) -> InputReset<'_> {
+        self.input.set_visited(false);
+        let reset = self.input.reset();
+        reset
+    }
+
+    /// Replace the validation errors tracked by the input state.
+    pub fn set_input_errors<I, S>(&mut self, errors: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.input.set_errors(errors);
+    }
+
+    /// Clear validation errors tracked by the input state.
+    pub fn clear_input_errors(&mut self) {
+        self.input.clear_errors();
+    }
+
     /// Imperatively set the open state (uncontrolled mode) or emit an intent to
     /// open the popover (controlled mode).
     pub fn open<F: FnOnce(bool)>(&mut self, notify: F) {
@@ -172,6 +369,7 @@ impl SelectState {
             }
         }
         self.ensure_highlight();
+        self.sync_input_selection(self.selected, false);
     }
 
     /// Manually override the highlighted index.  This is primarily used by
@@ -197,6 +395,12 @@ impl SelectState {
             self.selected = Some(index);
         }
         on_select(index);
+        let selection_for_input = if self.selection_mode.is_controlled() {
+            Some(index)
+        } else {
+            self.selected
+        };
+        self.sync_input_selection(selection_for_input, true);
     }
 
     /// Commits the current highlight if present.
@@ -263,6 +467,12 @@ impl SelectState {
                     self.selected = Some(index);
                 }
                 on_select(index);
+                let selection_for_input = if self.selection_mode.is_controlled() {
+                    Some(index)
+                } else {
+                    self.selected
+                };
+                self.sync_input_selection(selection_for_input, true);
             }
         }
     }
@@ -345,6 +555,7 @@ impl SelectState {
             if !self.selection_mode.is_controlled() {
                 self.selected = None;
             }
+            self.sync_input_selection(self.selected, false);
             return;
         }
         if !self.selection_mode.is_controlled() {
@@ -357,6 +568,7 @@ impl SelectState {
             }
         }
         self.ensure_highlight();
+        self.sync_input_selection(self.selected, false);
     }
 
     fn has_enabled_options(&self) -> bool {
@@ -417,11 +629,28 @@ impl SelectState {
         }
         None
     }
+
+    fn selection_value(selection: Option<usize>) -> String {
+        selection.map(|index| index.to_string()).unwrap_or_default()
+    }
+
+    fn sync_input_selection(&mut self, selection: Option<usize>, user_initiated: bool) {
+        let value = Self::selection_value(selection);
+        if user_initiated {
+            let _ = self.input.change(value, None);
+        } else if self.selection_mode.is_controlled() {
+            self.input.sync_controlled_value(value);
+        } else {
+            self.input.set_value_silently(value.clone());
+            self.input.set_initial_value(value);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input_base::InputAnalyticsEventKind;
 
     fn noop(_: usize) {}
 
@@ -542,6 +771,10 @@ mod tests {
         );
         uncontrolled.select(2, noop);
         assert_eq!(uncontrolled.selected(), Some(2));
+        assert_eq!(uncontrolled.input_state().value(), "2");
+        assert!(uncontrolled.input_state().dirty());
+        let commit = uncontrolled.commit_input();
+        assert_eq!(commit.value, "2");
 
         // Controlled widgets emit intents but require the parent to synchronize
         // state explicitly.
@@ -554,10 +787,13 @@ mod tests {
         );
         controlled.select(2, noop);
         assert_eq!(controlled.selected(), Some(1));
+        assert_eq!(controlled.input_state().value(), "2");
         controlled.sync_selected(Some(2));
         assert_eq!(controlled.selected(), Some(2));
+        assert_eq!(controlled.input_state().value(), "2");
         controlled.sync_selected(None);
         assert_eq!(controlled.selected(), None);
+        assert_eq!(controlled.input_state().value(), "");
 
         // Disabling a controlled selection keeps the highlight on the next
         // available option while leaving the controlled value untouched.
@@ -565,6 +801,7 @@ mod tests {
         controlled.set_option_disabled(1, true);
         assert_eq!(controlled.selected(), Some(1));
         assert_eq!(controlled.highlighted(), Some(2));
+        assert_eq!(controlled.input_state().value(), "1");
     }
 
     #[test]
@@ -660,6 +897,8 @@ mod tests {
         // Selection and highlight fall forward to the next enabled entry.
         assert_eq!(state.selected(), Some(3));
         assert_eq!(state.highlighted(), Some(3));
+        assert_eq!(state.input_state().value(), "3");
+        assert!(!state.input_state().dirty());
 
         // Shrinking the option count drops disabled state and clamps indices.
         state.set_option_count(2);
@@ -667,6 +906,8 @@ mod tests {
         assert_eq!(state.disabled.len(), 2);
         assert_eq!(state.selected(), None);
         assert_eq!(state.highlighted(), Some(0));
+        assert_eq!(state.input_state().value(), "");
+        assert!(!state.input_state().dirty());
 
         // Expanding restores new slots as enabled by default.
         state.set_option_count(4);
@@ -690,6 +931,51 @@ mod tests {
             "callbacks should not fire for disabled options"
         );
         assert_eq!(state.highlighted(), Some(2));
+    }
+
+    #[test]
+    fn input_state_reset_and_validation_hooks() {
+        let mut state = SelectState::new(
+            2,
+            Some(0),
+            false,
+            ControlStrategy::Uncontrolled,
+            ControlStrategy::Uncontrolled,
+        );
+        state.select(1, noop);
+        state.set_input_errors(["required"]);
+        let commit = state.commit_input();
+        assert!(commit.has_errors);
+        let reset = state.reset_input();
+        assert_eq!(reset.value, "0");
+        assert!(reset
+            .analytics
+            .iter()
+            .any(|event| event.kind == InputAnalyticsEventKind::Reset));
+        state.clear_input_errors();
+        assert!(state.input_state().errors().is_empty());
+    }
+
+    #[test]
+    fn control_builder_produces_aligned_bundle() {
+        let SelectControlBundle {
+            mut select,
+            form_control,
+        } = SelectControlBuilder::new(3)
+            .initial_selected(Some(1))
+            .controlled_selection()
+            .labelled_by("select-label")
+            .automation_id("select.primary")
+            .build();
+        assert_eq!(select.selected(), Some(1));
+        assert_eq!(select.input_state().value(), "1");
+        assert_eq!(form_control.automation_id(), Some("select.primary"));
+        assert!(form_control
+            .aria_attributes()
+            .iter()
+            .any(|(k, v)| *k == "aria-labelledby" && v == "select-label"));
+        select.select(2, noop);
+        assert_eq!(select.input_state().value(), "2");
     }
 
     #[test]

--- a/crates/rustic-ui-headless/src/text_field.rs
+++ b/crates/rustic-ui-headless/src/text_field.rs
@@ -5,98 +5,210 @@
 //! the mutable pieces – current value, dirty/visited flags, validation errors and
 //! debounce configuration – colocated with attribute helpers so adapters across
 //! frameworks behave identically.  The API leans on controlled/uncontrolled
-//! patterns to minimise manual bookkeeping in higher layers.
+//! patterns to minimise manual bookkeeping in higher layers.  Internally the
+//! implementation now composes the shared [`crate::input_base::InputState`]
+//! primitives so analytics, focus tracking, and validation updates behave the
+//! same way across every future input.  This keeps the headless surface area
+//! small while making it trivial for other controls to bolt on text field style
+//! behaviour without copying large chunks of bookkeeping logic.  The
+//! [`TextFieldControlBuilder`] further wraps [`crate::input_base::InputControlBuilder`]
+//! so adapters can grab the [`FormControlState`](crate::form_control::FormControlState)
+//! and [`TextFieldState`] in one shot.
 
+use crate::form_control::FormControlState;
+use crate::input_base::{
+    InputAnalyticsEvent, InputChange, InputChangeEvent, InputCommit, InputCommitEvent,
+    InputControlBuilder, InputControlBundle, InputReset, InputResetEvent, InputSelection,
+    InputState,
+};
 use crate::selection::ControlStrategy;
 use std::time::Duration;
 
 /// Snapshot emitted when the text field value changes.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct TextFieldChange<'a> {
-    /// The latest value provided by the user.
-    pub value: &'a str,
-    /// Whether the new value differs from the initial value.
-    pub dirty: bool,
+    /// Shared [`InputChange`] snapshot capturing the base value/dirty metadata.
+    pub base: InputChange<'a>,
     /// Debounce interval configured for change notifications.
     pub debounce: Option<Duration>,
+}
+
+impl<'a> TextFieldChange<'a> {
+    /// Returns the latest value taking pending controlled edits into account.
+    pub fn value(&self) -> &str {
+        self.base.value
+    }
+
+    /// Indicates whether the value currently diverges from the initial value.
+    pub fn dirty(&self) -> bool {
+        self.base.dirty
+    }
+
+    /// Returns the current selection if adapters provided one during the change.
+    pub fn selection(&self) -> Option<InputSelection> {
+        self.base.selection
+    }
+
+    /// Returns analytics events generated alongside the value mutation.
+    pub fn analytics(&self) -> &[InputAnalyticsEvent] {
+        &self.base.analytics
+    }
+
+    /// Returns the configured debounce interval.
+    pub fn debounce(&self) -> Option<Duration> {
+        self.debounce
+    }
 }
 
 /// Owned variant of [`TextFieldChange`] used by UI adapters that require `'static` lifetimes.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextFieldChangeEvent {
-    /// The latest value provided by the user.
-    pub value: String,
-    /// Whether the new value differs from the initial value.
-    pub dirty: bool,
+    /// Shared [`InputChangeEvent`] snapshot capturing the base change metadata.
+    pub base: InputChangeEvent,
     /// Debounce interval configured for change notifications.
     pub debounce: Option<Duration>,
 }
 
+impl TextFieldChangeEvent {
+    /// Returns the latest value provided by the user.
+    pub fn value(&self) -> &str {
+        &self.base.value
+    }
+
+    /// Indicates whether the value currently diverges from the initial value.
+    pub fn dirty(&self) -> bool {
+        self.base.dirty
+    }
+
+    /// Returns the captured selection, if any.
+    pub fn selection(&self) -> Option<InputSelection> {
+        self.base.selection
+    }
+
+    /// Returns analytics events emitted alongside the change.
+    pub fn analytics(&self) -> &[InputAnalyticsEvent] {
+        &self.base.analytics
+    }
+}
+
 /// Snapshot emitted when the text field commits (blur/enter).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct TextFieldCommit<'a> {
-    /// The value at the time of the commit event.
-    pub value: &'a str,
-    /// Whether the field currently contains validation errors.
-    pub has_errors: bool,
-    /// Tracks whether the field has been visited prior to this commit.
-    pub previously_visited: bool,
+    /// Shared [`InputCommit`] snapshot describing the commit metadata.
+    pub base: InputCommit<'a>,
+}
+
+impl<'a> TextFieldCommit<'a> {
+    /// Returns the value at commit time.
+    pub fn value(&self) -> &str {
+        self.base.value
+    }
+
+    /// Indicates whether validation errors were present during the commit.
+    pub fn has_errors(&self) -> bool {
+        self.base.has_errors
+    }
+
+    /// Returns whether the field was previously visited prior to this commit.
+    pub fn previously_visited(&self) -> bool {
+        self.base.previously_visited
+    }
+
+    /// Returns analytics events associated with the commit.
+    pub fn analytics(&self) -> &[InputAnalyticsEvent] {
+        &self.base.analytics
+    }
 }
 
 /// Owned variant of [`TextFieldCommit`] for frameworks that require `'static` values.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextFieldCommitEvent {
-    /// The value at the time of the commit event.
-    pub value: String,
-    /// Whether the field currently contains validation errors.
-    pub has_errors: bool,
-    /// Tracks whether the field has been visited prior to this commit.
-    pub previously_visited: bool,
+    /// Shared [`InputCommitEvent`] snapshot describing the commit metadata.
+    pub base: InputCommitEvent,
+}
+
+impl TextFieldCommitEvent {
+    /// Returns the value at commit time.
+    pub fn value(&self) -> &str {
+        &self.base.value
+    }
+
+    /// Indicates whether validation errors were present during the commit.
+    pub fn has_errors(&self) -> bool {
+        self.base.has_errors
+    }
+
+    /// Returns whether the field was previously visited prior to this commit.
+    pub fn previously_visited(&self) -> bool {
+        self.base.previously_visited
+    }
+
+    /// Returns analytics events associated with the commit.
+    pub fn analytics(&self) -> &[InputAnalyticsEvent] {
+        &self.base.analytics
+    }
 }
 
 /// Snapshot emitted when the text field resets back to its initial value.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct TextFieldReset<'a> {
-    /// Value after the reset completed.
-    pub value: &'a str,
+    /// Shared [`InputReset`] snapshot describing the reset metadata.
+    pub base: InputReset<'a>,
+}
+
+impl<'a> TextFieldReset<'a> {
+    /// Returns the value after the reset completed.
+    pub fn value(&self) -> &str {
+        self.base.value
+    }
+
     /// Flag describing whether validation errors were present before the reset.
-    pub cleared_errors: bool,
+    pub fn cleared_errors(&self) -> bool {
+        self.base.cleared_errors
+    }
+
+    /// Returns analytics events generated by the reset operation.
+    pub fn analytics(&self) -> &[InputAnalyticsEvent] {
+        &self.base.analytics
+    }
 }
 
 /// Owned variant of [`TextFieldReset`] for stateful UI adapters.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextFieldResetEvent {
-    /// Value after the reset completed.
-    pub value: String,
+    /// Shared [`InputResetEvent`] snapshot describing the reset metadata.
+    pub base: InputResetEvent,
+}
+
+impl TextFieldResetEvent {
+    /// Returns the value after the reset completed.
+    pub fn value(&self) -> &str {
+        &self.base.value
+    }
+
     /// Flag describing whether validation errors were present before the reset.
-    pub cleared_errors: bool,
+    pub fn cleared_errors(&self) -> bool {
+        self.base.cleared_errors
+    }
+
+    /// Returns analytics events generated by the reset operation.
+    pub fn analytics(&self) -> &[InputAnalyticsEvent] {
+        &self.base.analytics
+    }
 }
 
 /// Aggregates text field state including validation and automation metadata.
 #[derive(Debug, Clone)]
 pub struct TextFieldState {
-    control_mode: ControlStrategy,
-    value: String,
-    initial_value: String,
-    pending_controlled: Option<String>,
-    dirty: bool,
-    visited: bool,
-    errors: Vec<String>,
+    base: InputState,
     debounce: Option<Duration>,
 }
 
 impl TextFieldState {
     /// Construct an uncontrolled text field with an initial value and optional debounce window.
     pub fn uncontrolled(initial: impl Into<String>, debounce: Option<Duration>) -> Self {
-        let value = initial.into();
         Self {
-            control_mode: ControlStrategy::Uncontrolled,
-            initial_value: value.clone(),
-            value,
-            pending_controlled: None,
-            dirty: false,
-            visited: false,
-            errors: Vec::new(),
+            base: InputState::uncontrolled(initial, None),
             debounce,
         }
     }
@@ -104,57 +216,56 @@ impl TextFieldState {
     /// Construct a controlled text field.  The parent component must call
     /// [`TextFieldState::sync_value`] after receiving change notifications.
     pub fn controlled(initial: impl Into<String>, debounce: Option<Duration>) -> Self {
-        let value = initial.into();
         Self {
-            control_mode: ControlStrategy::Controlled,
-            initial_value: value.clone(),
-            value,
-            pending_controlled: None,
-            dirty: false,
-            visited: false,
-            errors: Vec::new(),
+            base: InputState::controlled(initial, None),
             debounce,
         }
+    }
+
+    /// Internal constructor used by [`TextFieldControlBuilder`] to wrap an [`InputState`].
+    pub(crate) fn from_input_state(base: InputState, debounce: Option<Duration>) -> Self {
+        Self { base, debounce }
     }
 
     /// Returns the current value taking pending controlled edits into account.
     #[inline]
     pub fn value(&self) -> &str {
-        if let Some(ref pending) = self.pending_controlled {
-            pending.as_str()
-        } else {
-            self.value.as_str()
-        }
+        self.base.value()
     }
 
     /// Returns the configured control strategy.
     #[inline]
-    pub const fn control_strategy(&self) -> ControlStrategy {
-        self.control_mode
+    pub fn control_strategy(&self) -> ControlStrategy {
+        self.base.control_strategy()
     }
 
     /// Returns whether the field has unsaved changes.
     #[inline]
-    pub const fn dirty(&self) -> bool {
-        self.dirty
+    pub fn dirty(&self) -> bool {
+        self.base.dirty()
     }
 
     /// Returns whether the field has been visited.
     #[inline]
-    pub const fn visited(&self) -> bool {
-        self.visited
+    pub fn visited(&self) -> bool {
+        self.base.visited()
     }
 
     /// Returns the configured debounce interval.
     #[inline]
-    pub const fn debounce(&self) -> Option<Duration> {
+    pub fn debounce(&self) -> Option<Duration> {
         self.debounce
     }
 
     /// Returns the currently captured validation errors.
     #[inline]
     pub fn errors(&self) -> &[String] {
-        &self.errors
+        self.base.errors()
+    }
+
+    /// Drain accumulated analytics events.
+    pub fn drain_analytics(&mut self) -> Vec<InputAnalyticsEvent> {
+        self.base.drain_analytics()
     }
 
     /// Update the current value emitting a [`TextFieldChange`] snapshot.
@@ -162,16 +273,9 @@ impl TextFieldState {
     where
         F: FnOnce(TextFieldChange<'_>),
     {
-        let value = next.into();
-        if self.control_mode.is_controlled() {
-            self.pending_controlled = Some(value);
-        } else {
-            self.value = value;
-        }
-        self.recompute_dirty();
+        let change = self.base.change(next, None);
         let snapshot = TextFieldChange {
-            value: self.value(),
-            dirty: self.dirty,
+            base: change,
             debounce: self.debounce,
         };
         notify(snapshot);
@@ -182,13 +286,8 @@ impl TextFieldState {
     where
         F: FnOnce(TextFieldCommit<'_>),
     {
-        let previously_visited = self.visited;
-        self.visited = true;
-        let snapshot = TextFieldCommit {
-            value: self.value(),
-            has_errors: !self.errors.is_empty(),
-            previously_visited,
-        };
+        let commit = self.base.commit();
+        let snapshot = TextFieldCommit { base: commit };
         notify(snapshot);
     }
 
@@ -197,19 +296,9 @@ impl TextFieldState {
     where
         F: FnOnce(TextFieldReset<'_>),
     {
-        let cleared_errors = !self.errors.is_empty();
-        self.errors.clear();
-        if self.control_mode.is_controlled() {
-            self.pending_controlled = Some(self.initial_value.clone());
-        } else {
-            self.value = self.initial_value.clone();
-        }
-        self.dirty = false;
-        self.visited = false;
-        let snapshot = TextFieldReset {
-            value: self.value(),
-            cleared_errors,
-        };
+        self.base.set_visited(false);
+        let reset = self.base.reset();
+        let snapshot = TextFieldReset { base: reset };
         notify(snapshot);
     }
 
@@ -217,30 +306,37 @@ impl TextFieldState {
     /// also call this method during hydration to align SSR renders.
     pub fn sync_value(&mut self, value: impl Into<String>) {
         let value = value.into();
-        self.value = value.clone();
-        self.pending_controlled = None;
-        self.initial_value = value;
-        self.dirty = false;
+        self.base.set_value_silently(value.clone());
+        self.base.set_initial_value(value);
     }
 
     /// Replace the validation errors with a new collection.
-    pub fn set_errors(&mut self, errors: impl Into<Vec<String>>) {
-        self.errors = errors.into();
+    pub fn set_errors<I, S>(&mut self, errors: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.base.set_errors(errors);
     }
 
     /// Clear any captured validation errors.
     pub fn clear_errors(&mut self) {
-        self.errors.clear();
+        self.base.clear_errors();
     }
 
     /// Update the initial baseline used to calculate the dirty flag.
     pub fn set_initial_value(&mut self, value: impl Into<String>) {
-        self.initial_value = value.into();
-        self.recompute_dirty();
+        self.base.set_initial_value(value);
     }
 
-    fn recompute_dirty(&mut self) {
-        self.dirty = self.value() != self.initial_value;
+    /// Returns a handle to the underlying [`InputState`].
+    pub fn base(&self) -> &InputState {
+        &self.base
+    }
+
+    /// Returns a mutable handle to the underlying [`InputState`].
+    pub fn base_mut(&mut self) -> &mut InputState {
+        &mut self.base
     }
 
     /// Returns an attribute helper that emits ARIA/data metadata.
@@ -281,7 +377,7 @@ impl<'a> TextFieldAttributes<'a> {
     /// Returns an `aria-invalid` tuple when validation errors are present.
     #[inline]
     pub fn aria_invalid(&self) -> Option<(&'static str, &'static str)> {
-        (!self.state.errors.is_empty()).then_some(("aria-invalid", "true"))
+        (!self.state.errors().is_empty()).then_some(("aria-invalid", "true"))
     }
 
     /// Returns an `aria-describedby` tuple linking to a validation status node.
@@ -295,7 +391,7 @@ impl<'a> TextFieldAttributes<'a> {
     pub fn data_dirty(&self) -> (&'static str, &'static str) {
         (
             "data-dirty",
-            if self.state.dirty { "true" } else { "false" },
+            if self.state.dirty() { "true" } else { "false" },
         )
     }
 
@@ -304,7 +400,11 @@ impl<'a> TextFieldAttributes<'a> {
     pub fn data_visited(&self) -> (&'static str, &'static str) {
         (
             "data-visited",
-            if self.state.visited { "true" } else { "false" },
+            if self.state.visited() {
+                "true"
+            } else {
+                "false"
+            },
         )
     }
 
@@ -316,10 +416,113 @@ impl<'a> TextFieldAttributes<'a> {
 
     /// Returns a condensed status message by joining validation errors.
     pub fn status_message(&self) -> Option<String> {
-        if self.state.errors.is_empty() {
+        if self.state.errors().is_empty() {
             None
         } else {
-            Some(self.state.errors.join("\n"))
+            Some(self.state.errors().join("\n"))
+        }
+    }
+}
+
+/// Tuple aligning [`TextFieldState`] with the surrounding [`FormControlState`].
+#[derive(Debug)]
+pub struct TextFieldControlBundle {
+    /// Headless text field state machine backed by [`InputState`].
+    pub text_field: TextFieldState,
+    /// Form control shell providing label/description ARIA metadata.
+    pub form_control: FormControlState,
+}
+
+/// Fluent builder that wraps [`InputControlBuilder`] while layering debounce
+/// configuration specific to text fields.
+#[derive(Debug, Clone)]
+pub struct TextFieldControlBuilder {
+    base: InputControlBuilder,
+    debounce: Option<Duration>,
+}
+
+impl TextFieldControlBuilder {
+    /// Start a new builder using the provided initial value.
+    pub fn new(initial: impl Into<String>) -> Self {
+        Self {
+            base: InputControlBuilder::new(initial),
+            debounce: None,
+        }
+    }
+
+    /// Apply a debounce interval to the derived [`TextFieldState`].
+    pub fn debounce(mut self, debounce: Option<Duration>) -> Self {
+        self.debounce = debounce;
+        self
+    }
+
+    /// Switch the builder into controlled mode.
+    pub fn controlled(mut self) -> Self {
+        self.base = self.base.controlled();
+        self
+    }
+
+    /// Switch the builder into uncontrolled mode explicitly.
+    pub fn uncontrolled(mut self) -> Self {
+        self.base = self.base.uncontrolled();
+        self
+    }
+
+    /// Configure an initial selection range for the underlying [`InputState`].
+    pub fn selection(mut self, selection: Option<InputSelection>) -> Self {
+        self.base = self.base.selection(selection);
+        self
+    }
+
+    /// Assign an id for the underlying form control.
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.base = self.base.id(id);
+        self
+    }
+
+    /// Replace the `aria-describedby` list with the provided collection.
+    pub fn described_by<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.base = self.base.described_by(ids);
+        self
+    }
+
+    /// Set the label id for the control shell.
+    pub fn labelled_by(mut self, id: impl Into<String>) -> Self {
+        self.base = self.base.labelled_by(id);
+        self
+    }
+
+    /// Mark the control as disabled.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.base = self.base.disabled(disabled);
+        self
+    }
+
+    /// Mark the control as required.
+    pub fn required(mut self, required: bool) -> Self {
+        self.base = self.base.required(required);
+        self
+    }
+
+    /// Attach an automation identifier used by analytics probes.
+    pub fn automation_id(mut self, id: impl Into<String>) -> Self {
+        self.base = self.base.automation_id(id);
+        self
+    }
+
+    /// Finalise the builder returning the aligned bundle.
+    pub fn build(self) -> TextFieldControlBundle {
+        let InputControlBundle {
+            input,
+            form_control,
+        } = self.base.build();
+        TextFieldControlBundle {
+            text_field: TextFieldState::from_input_state(input, self.debounce),
+            form_control,
         }
     }
 }
@@ -327,8 +530,7 @@ impl<'a> TextFieldAttributes<'a> {
 impl<'a> From<TextFieldChange<'a>> for TextFieldChangeEvent {
     fn from(snapshot: TextFieldChange<'a>) -> Self {
         Self {
-            value: snapshot.value.to_string(),
-            dirty: snapshot.dirty,
+            base: InputChangeEvent::from(snapshot.base),
             debounce: snapshot.debounce,
         }
     }
@@ -337,9 +539,7 @@ impl<'a> From<TextFieldChange<'a>> for TextFieldChangeEvent {
 impl<'a> From<TextFieldCommit<'a>> for TextFieldCommitEvent {
     fn from(snapshot: TextFieldCommit<'a>) -> Self {
         Self {
-            value: snapshot.value.to_string(),
-            has_errors: snapshot.has_errors,
-            previously_visited: snapshot.previously_visited,
+            base: InputCommitEvent::from(snapshot.base),
         }
     }
 }
@@ -347,8 +547,7 @@ impl<'a> From<TextFieldCommit<'a>> for TextFieldCommitEvent {
 impl<'a> From<TextFieldReset<'a>> for TextFieldResetEvent {
     fn from(snapshot: TextFieldReset<'a>) -> Self {
         Self {
-            value: snapshot.value.to_string(),
-            cleared_errors: snapshot.cleared_errors,
+            base: InputResetEvent::from(snapshot.base),
         }
     }
 }
@@ -362,8 +561,8 @@ mod tests {
         let mut state = TextFieldState::uncontrolled("hello", None);
         let mut snapshot_value = String::new();
         state.change("world", |snapshot| {
-            snapshot_value = snapshot.value.to_string();
-            assert!(snapshot.dirty);
+            snapshot_value = snapshot.value().to_string();
+            assert!(snapshot.dirty());
         });
         assert_eq!(snapshot_value, "world");
         assert!(state.dirty());
@@ -375,8 +574,8 @@ mod tests {
         let mut state = TextFieldState::controlled("hello", None);
         let mut change_called = false;
         state.change("world", |snapshot| {
-            change_called = snapshot.value == "world";
-            assert!(snapshot.dirty);
+            change_called = snapshot.value() == "world";
+            assert!(snapshot.dirty());
         });
         assert!(change_called);
         assert_eq!(state.value(), "world");
@@ -390,7 +589,7 @@ mod tests {
     fn commit_marks_visited_and_reports_previous_state() {
         let mut state = TextFieldState::uncontrolled("a", None);
         let mut visited_before = None;
-        state.commit(|snapshot| visited_before = Some(snapshot.previously_visited));
+        state.commit(|snapshot| visited_before = Some(snapshot.previously_visited()));
         assert_eq!(visited_before, Some(false));
         assert!(state.visited());
     }
@@ -398,11 +597,11 @@ mod tests {
     #[test]
     fn reset_restores_initial_state_and_clears_errors() {
         let mut state = TextFieldState::uncontrolled("baseline", None);
-        state.set_errors(vec!["Required".to_string()]);
+        state.set_errors([String::from("Required")]);
         state.change("updated", |_| {});
         state.commit(|_| {});
         let mut cleared = None;
-        state.reset(|snapshot| cleared = Some(snapshot.cleared_errors));
+        state.reset(|snapshot| cleared = Some(snapshot.cleared_errors()));
         assert_eq!(cleared, Some(true));
         assert_eq!(state.value(), "baseline");
         assert!(!state.dirty());
@@ -413,7 +612,7 @@ mod tests {
     #[test]
     fn attribute_builder_emits_expected_metadata() {
         let mut state = TextFieldState::uncontrolled("", None);
-        state.set_errors(vec!["Required".to_string(), "Must be unique".to_string()]);
+        state.set_errors([String::from("Required"), String::from("Must be unique")]);
         state.commit(|_| {});
         let attrs = state
             .attributes()
@@ -443,35 +642,35 @@ mod tests {
             last_event = Some(TextFieldChangeEvent::from(snapshot));
         });
         let event = last_event.expect("change event");
-        assert_eq!(event.value, "updated");
-        assert!(event.dirty);
+        assert_eq!(event.value(), "updated");
+        assert!(event.dirty());
         assert_eq!(event.debounce, Some(Duration::from_millis(150)));
     }
 
     #[test]
     fn owned_commit_event_preserves_flags() {
         let mut state = TextFieldState::uncontrolled("value", None);
-        state.set_errors(vec!["Required".into()]);
+        state.set_errors([String::from("Required")]);
         let mut event = None;
         state.commit(|snapshot| {
             event = Some(TextFieldCommitEvent::from(snapshot));
         });
         let event = event.expect("commit event");
-        assert_eq!(event.value, "value");
-        assert!(event.has_errors);
-        assert!(!event.previously_visited);
+        assert_eq!(event.value(), "value");
+        assert!(event.has_errors());
+        assert!(!event.previously_visited());
     }
 
     #[test]
     fn owned_reset_event_captures_cleared_errors() {
         let mut state = TextFieldState::uncontrolled("value", None);
-        state.set_errors(vec!["Required".into()]);
+        state.set_errors([String::from("Required")]);
         let mut event = None;
         state.reset(|snapshot| {
             event = Some(TextFieldResetEvent::from(snapshot));
         });
         let event = event.expect("reset event");
-        assert_eq!(event.value, "value");
-        assert!(event.cleared_errors);
+        assert_eq!(event.value(), "value");
+        assert!(event.cleared_errors());
     }
 }

--- a/crates/rustic-ui-headless/tests/input_base.rs
+++ b/crates/rustic-ui-headless/tests/input_base.rs
@@ -112,3 +112,17 @@ fn builder_respects_mode_switching() {
         rustic_ui_headless::ControlStrategy::Uncontrolled
     );
 }
+
+#[test]
+fn silent_mutations_keep_analytics_clean() {
+    let mut state = InputState::controlled("baseline", None);
+    state.set_value_silently("override");
+    state.set_initial_value("override");
+    state.set_visited(true);
+    state.clear_errors();
+    assert_eq!(state.value(), "override");
+    assert!(!state.dirty());
+    assert!(state.drain_analytics().is_empty());
+    state.set_visited(false);
+    assert!(!state.visited());
+}

--- a/crates/rustic-ui-headless/tests/text_field_state.rs
+++ b/crates/rustic-ui-headless/tests/text_field_state.rs
@@ -26,7 +26,7 @@ proptest! {
 
         let mut observed = None;
         state.change(next.clone(), |snapshot| {
-            observed = Some((snapshot.value.to_string(), snapshot.dirty, snapshot.debounce));
+            observed = Some((snapshot.value().to_string(), snapshot.dirty(), snapshot.debounce));
         });
 
         let (value, dirty, emitted_debounce) = observed.expect("change handler not invoked");
@@ -56,14 +56,18 @@ proptest! {
         state.set_errors(errors.clone());
 
         let mut commit_snapshot = None;
-        state.commit(|snapshot| commit_snapshot = Some((snapshot.has_errors, snapshot.previously_visited)));
+        state.commit(|snapshot| {
+            commit_snapshot = Some((snapshot.has_errors(), snapshot.previously_visited()));
+        });
         let (has_errors, previously_visited) = commit_snapshot.expect("commit snapshot missing");
         prop_assert_eq!(has_errors, !errors.is_empty());
         prop_assert!(!previously_visited);
         prop_assert!(state.visited());
 
         let mut reset_snapshot = None;
-        state.reset(|snapshot| reset_snapshot = Some((snapshot.value.to_string(), snapshot.cleared_errors)));
+        state.reset(|snapshot| {
+            reset_snapshot = Some((snapshot.value().to_string(), snapshot.cleared_errors()));
+        });
         let (value, cleared) = reset_snapshot.expect("reset snapshot missing");
         prop_assert_eq!(value, initial);
         prop_assert_eq!(cleared, !errors.is_empty());

--- a/crates/rustic-ui-material/src/click_away.rs
+++ b/crates/rustic-ui-material/src/click_away.rs
@@ -88,6 +88,8 @@ pub fn click_away_root_attributes(
     }
     if let Some((key, value)) = attrs.analytics_attribute() {
         pairs.push((key.into(), value.into()));
+    } else if let Some(analytics) = &options.analytics_id {
+        pairs.push(("data-rustic-analytics-id".into(), analytics.to_string()));
     }
     let automation_id = options
         .automation_id

--- a/crates/rustic-ui-material/src/input_base.rs
+++ b/crates/rustic-ui-material/src/input_base.rs
@@ -30,7 +30,7 @@
 use rustic_ui_headless::input_base::{
     InputChangeEvent, InputCommitEvent, InputResetEvent, InputSelection, InputState,
 };
-use rustic_ui_styled_engine::{css_with_theme, use_theme, Style, Theme};
+use rustic_ui_styled_engine::{use_theme, Style, Theme};
 
 use crate::style_helpers;
 
@@ -50,13 +50,6 @@ fn bool_token(value: bool) -> String {
     }
 }
 
-#[cfg(any(
-    feature = "react",
-    feature = "yew",
-    feature = "leptos",
-    feature = "dioxus",
-    feature = "sycamore",
-))]
 fn compute_parts(
     theme: &Theme,
     color: InputBaseColor,
@@ -80,13 +73,6 @@ fn compute_parts(
     (color, font_size, border)
 }
 
-#[cfg(any(
-    feature = "react",
-    feature = "yew",
-    feature = "leptos",
-    feature = "dioxus",
-    feature = "sycamore",
-))]
 fn resolve_style(
     color: InputBaseColor,
     size: InputBaseSize,
@@ -96,22 +82,14 @@ fn resolve_style(
     let theme = use_theme();
     let (color, font_size, border) = compute_parts(&theme, color, size, variant);
     let extra = style_overrides.unwrap_or_default();
-    css_with_theme!(
-        theme,
-        r#"
-        color: ${color};
-        font-size: ${font_size};
-        border: ${border};
-        padding: 4px 8px;
-        width: 100%;
-        box-sizing: border-box;
-        ${extra}
-        "#,
+    Style::new(format!(
+        "color: {color};\nfont-size: {font_size};\nborder: {border};\npadding: 4px 8px;\nwidth: 100%;\nbox-sizing: border-box;\n{extra}",
         color = color,
         font_size = font_size,
         border = border,
         extra = extra
-    )
+    ))
+    .expect("static input base stylesheet")
 }
 
 /// Construct the automation/data attributes that mirror headless analytics state.

--- a/crates/rustic-ui-material/src/select.rs
+++ b/crates/rustic-ui-material/src/select.rs
@@ -15,10 +15,92 @@
 //!   through every select.
 //! * Automation hooks (`data-*` attributes) are standardized so QA teams can
 //!   target components reliably regardless of hosting framework.
+//!
+//! ## Headless layering
+//! The Material select now builds atop [`SelectControlBuilder`], returning both
+//! the [`SelectState`] and its companion [`FormControlState`].  This mirrors the
+//! text-field integration so analytics identifiers, labels, and helper text flow
+//! from a single shared builder.  Consumers targeting interactive runtimes can
+//! call [`SelectStateHandle::with_control_builder`] to receive the shared
+//! [`Rc<RefCell<_>>`](std::rc::Rc) wrapper used by the Yew text field, ensuring
+//! inputs follow the same `InputBase` lifecycle hooks without manual wiring.
+//! Adapters therefore spend less time creating ARIA attributes and more time
+//! focusing on the ergonomics of the rendered trigger and popover.
 
-use rustic_ui_headless::select::SelectState;
+use rustic_ui_headless::form_control::FormControlState;
+use rustic_ui_headless::select::{SelectControlBuilder, SelectControlBundle, SelectState};
 use rustic_ui_styled_engine::{css_with_theme, Style};
 use rustic_ui_system::portal::PortalMount;
+
+mod shared_state_handle {
+    use super::*;
+    use std::cell::{Ref, RefCell, RefMut};
+    use std::rc::Rc;
+
+    /// Shared pointer wrapper that mirrors [`TextFieldStateHandle`](crate::text_field::TextFieldStateHandle)
+    /// so framework adapters can coordinate around a single [`SelectState`].
+    ///
+    /// Yew/Leptos/Sycamore integrations often need to mutate the state from multiple closures
+    /// (trigger click, option activation, blur handlers) while still exposing a stable handle to
+    /// user code.  Wrapping the state in `Rc<RefCell<_>>` keeps that workflow ergonomic without
+    /// leaking the lower level [`SelectControlBundle`].  The bundle methods remain available for
+    /// server rendered contexts that only require owned values.
+    #[derive(Clone)]
+    pub struct SelectStateHandle {
+        inner: Rc<RefCell<SelectState>>,
+    }
+
+    impl SelectStateHandle {
+        /// Construct a new handle from an owned [`SelectState`].
+        pub fn new(state: SelectState) -> Self {
+            Self {
+                inner: Rc::new(RefCell::new(state)),
+            }
+        }
+
+        /// Construct a new handle while also returning the aligned [`FormControlState`].
+        ///
+        /// This mirrors [`TextFieldStateHandle::with_control_builder`](crate::text_field::TextFieldStateHandle::with_control_builder)
+        /// so callers configuring analytics ids or helper text can do so once on the builder and
+        /// receive both state machines in lockstep.
+        pub fn with_control_builder(builder: SelectControlBuilder) -> (Self, FormControlState) {
+            let SelectControlBundle {
+                select,
+                form_control,
+            } = builder.build();
+            (Self::new(select), form_control)
+        }
+
+        /// Attach an existing bundle produced by [`SelectControlBuilder`].
+        pub fn from_control_bundle(bundle: SelectControlBundle) -> (Self, FormControlState) {
+            (Self::new(bundle.select), bundle.form_control)
+        }
+
+        /// Immutable access to the underlying state machine.
+        pub fn borrow(&self) -> Ref<'_, SelectState> {
+            self.inner.borrow()
+        }
+
+        /// Mutable access to the underlying state machine.
+        pub fn borrow_mut(&self) -> RefMut<'_, SelectState> {
+            self.inner.borrow_mut()
+        }
+    }
+
+    impl From<SelectState> for SelectStateHandle {
+        fn from(state: SelectState) -> Self {
+            Self::new(state)
+        }
+    }
+
+    impl PartialEq for SelectStateHandle {
+        fn eq(&self, other: &Self) -> bool {
+            Rc::ptr_eq(&self.inner, &other.inner)
+        }
+    }
+}
+
+pub use shared_state_handle::SelectStateHandle;
 
 /// Discrete option rendered inside the Material select popover.
 #[derive(Clone, Debug)]
@@ -445,17 +527,7 @@ mod tests {
     use super::*;
 
     fn build_state(option_count: usize) -> SelectState {
-        SelectState::new(
-            option_count,
-            None,
-            false,
-            // `ControlStrategy` lives in a private module inside `rustic_ui_headless`.
-            // The discriminant order is stable (documented within that crate),
-            // so the test recreates the `Uncontrolled` variant via transmute to
-            // keep the public surface lean while still exercising integration.
-            unsafe { std::mem::transmute(1u8) },
-            unsafe { std::mem::transmute(1u8) },
-        )
+        SelectControlBuilder::new(option_count).build().select
     }
 
     fn sample_props() -> SelectProps {

--- a/crates/rustic-ui-material/src/text_field.rs
+++ b/crates/rustic-ui-material/src/text_field.rs
@@ -43,6 +43,23 @@
 //! eliminating brittle QA issues in pre-production environments. ARIA flags and
 //! analytics identifiers originate from the shared [`TextFieldState`] so SSR and
 //! hydrated behaviour stay perfectly aligned.
+//!
+//! ## Headless layering
+//! The Material adapters now consume [`TextFieldControlBuilder`] to assemble the
+//! [`TextFieldState`] alongside the surrounding
+//! [`FormControlState`](rustic_ui_headless::form_control::FormControlState).  This
+//! ensures labels, helper text and automation identifiers flow from the same
+//! source of truth while keeping adapter code focused on rendering concerns. The
+//! builder mirrors the low-level [`InputControlBuilder`](rustic_ui_headless::InputControlBuilder)
+//! exposed by the headless crate so future inputs (numeric, password, search)
+//! can reuse the exact same wiring without copy/pasting boilerplate.
+#[cfg(any(
+    feature = "yew",
+    feature = "leptos",
+    feature = "dioxus",
+    feature = "sycamore"
+))]
+use rustic_ui_headless::form_control::FormControlState;
 #[cfg(any(
     feature = "yew",
     feature = "leptos",
@@ -50,8 +67,8 @@
     feature = "sycamore"
 ))]
 use rustic_ui_headless::text_field::{
-    TextFieldAttributes, TextFieldChangeEvent, TextFieldCommitEvent, TextFieldResetEvent,
-    TextFieldState,
+    TextFieldAttributes, TextFieldChangeEvent, TextFieldCommitEvent, TextFieldControlBuilder,
+    TextFieldControlBundle, TextFieldResetEvent, TextFieldState,
 };
 #[cfg(any(
     feature = "yew",
@@ -217,6 +234,20 @@ mod shared_state_handle {
             Self {
                 inner: Rc::new(RefCell::new(state)),
             }
+        }
+
+        /// Construct a new handle while also returning the aligned [`FormControlState`].
+        pub fn with_control_builder(builder: TextFieldControlBuilder) -> (Self, FormControlState) {
+            let TextFieldControlBundle {
+                text_field,
+                form_control,
+            } = builder.build();
+            (Self::new(text_field), form_control)
+        }
+
+        /// Attach an existing bundle produced by [`TextFieldControlBuilder`].
+        pub fn from_control_bundle(bundle: TextFieldControlBundle) -> (Self, FormControlState) {
+            (Self::new(bundle.text_field), bundle.form_control)
         }
 
         /// Immutable access to the underlying state.
@@ -833,12 +864,13 @@ pub mod sycamore {
     )
 ))]
 mod tests {
+    use super::TextFieldStateHandle;
     use super::{build_text_field_attributes, input_attribute_pairs, ssr_input_attributes};
-    use rustic_ui_headless::text_field::TextFieldState;
+    use rustic_ui_headless::text_field::{TextFieldControlBuilder, TextFieldState};
 
     #[test]
     fn input_pairs_reflect_dirty_and_visited_flags() {
-        let mut state = TextFieldState::uncontrolled("seed", None);
+        let mut state = TextFieldControlBuilder::new("seed").build().text_field;
         let attrs = build_text_field_attributes(&state, None, None);
         let pairs = input_attribute_pairs(attrs, state.value(), "Placeholder", "Label");
         let lookup = |key: &str| {
@@ -877,7 +909,7 @@ mod tests {
 
     #[test]
     fn ssr_attributes_include_error_status() {
-        let mut state = TextFieldState::uncontrolled("", None);
+        let mut state = TextFieldControlBuilder::new("").build().text_field;
         state.set_errors(vec!["Required".into()]);
         let builder = build_text_field_attributes(&state, Some("status"), Some("analytics-1"));
         let attrs = ssr_input_attributes(builder, state.value(), "Placeholder", "Label");
@@ -895,7 +927,7 @@ mod tests {
 
     #[test]
     fn input_pairs_toggle_analytics_metadata() {
-        let state = TextFieldState::uncontrolled("", None);
+        let state = TextFieldControlBuilder::new("").build().text_field;
         let with_id = build_text_field_attributes(&state, None, Some("field-1"));
         let with_pairs = input_attribute_pairs(with_id, state.value(), "Hint", "Label");
         assert!(with_pairs
@@ -905,5 +937,14 @@ mod tests {
         let without_id = build_text_field_attributes(&state, None, None);
         let without_pairs = input_attribute_pairs(without_id, state.value(), "Hint", "Label");
         assert!(without_pairs.iter().all(|(k, _)| k != "data-analytics-id"));
+    }
+
+    #[test]
+    fn state_handle_builder_returns_form_control() {
+        let (handle, form_control) = TextFieldStateHandle::with_control_builder(
+            TextFieldControlBuilder::new("seed").automation_id("field-1"),
+        );
+        assert_eq!(handle.borrow().value(), "seed");
+        assert_eq!(form_control.automation_id(), Some("field-1"));
     }
 }

--- a/crates/rustic-ui-material/tests/click_away_parity.rs
+++ b/crates/rustic-ui-material/tests/click_away_parity.rs
@@ -33,7 +33,6 @@ fn root_attributes_mirror_automation_contract() {
     let state = seeded_state();
     let options = boundary_options();
     let attrs = click_away_root_attributes(state.root_attributes(), "dialog::checkout", &options);
-
     assert_eq!(attrs.len(), 4);
     assert!(attrs
         .iter()

--- a/crates/rustic-ui-material/tests/select_adapters.rs
+++ b/crates/rustic-ui-material/tests/select_adapters.rs
@@ -1,4 +1,4 @@
-use rustic_ui_headless::select::SelectState;
+use rustic_ui_headless::select::{SelectControlBuilder, SelectState};
 use rustic_ui_material::select::{self, SelectOption, SelectProps};
 
 fn sample_props() -> SelectProps {
@@ -13,13 +13,7 @@ fn sample_props() -> SelectProps {
 }
 
 fn build_state(count: usize) -> SelectState {
-    SelectState::new(
-        count,
-        None,
-        true,
-        unsafe { std::mem::transmute(1u8) },
-        unsafe { std::mem::transmute(1u8) },
-    )
+    SelectControlBuilder::new(count).build().select
 }
 
 fn assert_portal_markup(html: &str) {


### PR DESCRIPTION
## Summary
- add a SelectStateHandle wrapper in the material select module to expose InputBase-driven builders to adapters and document the layering
- make the material input base style resolver available without UI feature gates and rebuild the style via stylist::Style for default test builds
- update material integration tests to construct select state through SelectControlBuilder and ensure click-away analytics fall back to boundary options

## Testing
- cargo test -p rustic-ui-material

------
https://chatgpt.com/codex/tasks/task_e_68db58d2bf54832e8b1f3398454ab7f0