### PR TITLE
Expose selection control descriptors for SSR and hydration

### DIFF
--- a/crates/rustic-ui-material/src/checkbox.rs
+++ b/crates/rustic-ui-material/src/checkbox.rs
@@ -1,14 +1,14 @@
 //! Material flavored checkbox built on the headless [`CheckboxState`].
 //!
 //! The module orchestrates styling through [`css_with_theme!`](rustic_ui_styled_engine::css_with_theme)
-//! and delegates markup generation to [`selection_control::render_toggle`]
+//! and delegates markup generation to [`selection_control::ToggleControlDescriptor`]
 //! keeping adapters tiny. Extensive inline documentation is provided to help
 //! enterprise teams adapt the component to their own design systems.
 
 use rustic_ui_headless::checkbox::CheckboxState;
 use rustic_ui_styled_engine::{css_with_theme, Style};
 
-use crate::selection_control;
+use crate::selection_control::{self, ToggleControlDescriptor};
 
 /// Props shared across all framework adapters.
 #[derive(Clone, Debug)]
@@ -26,13 +26,14 @@ impl CheckboxProps {
     }
 }
 
+fn build_descriptor(props: &CheckboxProps, state: &CheckboxState) -> ToggleControlDescriptor {
+    ToggleControlDescriptor::new(props.label.clone(), themed_checkbox_style())
+        .with_attributes(state.aria_attributes())
+}
+
 fn render_html(props: &CheckboxProps, state: &CheckboxState) -> String {
-    let attrs = state
-        .aria_attributes()
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
-    selection_control::render_toggle(&props.label, themed_checkbox_style(), attrs)
+    let descriptor = build_descriptor(props, state);
+    selection_control::render_toggle_html(&descriptor)
 }
 
 /// Generates the themed style for the checkbox container. The macro pulls
@@ -97,18 +98,6 @@ fn themed_checkbox_style() -> Style {
     )
 }
 
-/// Helper exposed for tests so we can assert the attribute map contains the
-/// expected ARIA metadata. Production callers should rely on
-/// [`render_html`].
-#[cfg_attr(not(test), allow(dead_code))]
-fn themed_checkbox_attributes(state: &CheckboxState) -> Vec<(String, String)> {
-    state
-        .aria_attributes()
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect()
-}
-
 pub mod yew {
     use super::*;
 
@@ -148,8 +137,10 @@ mod tests {
     #[test]
     fn themed_attributes_include_role() {
         let state = CheckboxState::uncontrolled(false, true);
-        let attrs = themed_checkbox_attributes(&state);
-        assert!(attrs.iter().any(|(k, v)| k == "role" && v == "checkbox"));
+        let attrs = build_descriptor(&CheckboxProps::new("Accept"), &state);
+        assert!(attrs
+            .aria_attributes()
+            .any(|(k, v)| k == "role" && v == "checkbox"));
     }
 
     #[test]

--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -1,12 +1,13 @@
 //! Material radio group built atop the headless [`RadioGroupState`].
 //!
 //! Rendering logic is intentionally centralized so Yew, Leptos, Dioxus and
-//! Sycamore integrations share identical markup.
+//! Sycamore integrations share identical markup while also giving adapters
+//! access to structured descriptors for hydration.
 
 use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
 use rustic_ui_styled_engine::{css_with_theme, Style};
 
-use crate::selection_control;
+use crate::selection_control::{self, RadioGroupDescriptor, RadioOptionDescriptor};
 
 #[derive(Clone, Debug)]
 pub struct RadioGroupProps {
@@ -29,17 +30,11 @@ impl RadioGroupProps {
     }
 }
 
-fn render_html(props: &RadioGroupProps, state: &RadioGroupState) -> String {
-    let mut group_attrs: Vec<(String, String)> = state
-        .group_aria_attributes()
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
+fn build_descriptor(props: &RadioGroupProps, state: &RadioGroupState) -> RadioGroupDescriptor {
     let orientation_value = match state.orientation() {
         RadioOrientation::Horizontal => "horizontal",
         RadioOrientation::Vertical => "vertical",
     };
-    group_attrs.push(("data-orientation".into(), orientation_value.into()));
 
     let labels = if props.option_labels.is_empty() {
         state.options().to_vec()
@@ -47,24 +42,24 @@ fn render_html(props: &RadioGroupProps, state: &RadioGroupState) -> String {
         props.option_labels.clone()
     };
 
-    let mut options = Vec::new();
+    let mut descriptor = RadioGroupDescriptor::new(themed_radio_group_style())
+        .with_group_attributes(state.group_aria_attributes())
+        .group_attribute("data-orientation", orientation_value);
+
     for (index, option) in state.options().iter().enumerate() {
         let label = labels.get(index).cloned().unwrap_or_else(|| option.clone());
-        let mut attrs: Vec<(String, String)> = state
-            .option_aria_attributes(index)
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v))
-            .collect();
-        attrs.push(("data-index".into(), index.to_string()));
-        options.push((label, attrs));
+        let option_descriptor = RadioOptionDescriptor::new(label, themed_radio_option_style())
+            .with_attributes(state.option_aria_attributes(index))
+            .attribute("data-index", index.to_string());
+        descriptor = descriptor.option(option_descriptor);
     }
 
-    selection_control::render_radio_group(
-        themed_radio_group_style(),
-        group_attrs,
-        themed_radio_option_style,
-        &options,
-    )
+    descriptor
+}
+
+fn render_html(props: &RadioGroupProps, state: &RadioGroupState) -> String {
+    let descriptor = build_descriptor(props, state);
+    selection_control::render_radio_group_html(&descriptor)
 }
 
 /// Generates layout styling for the radio group container, including
@@ -143,16 +138,6 @@ fn themed_radio_option_style() -> Style {
     )
 }
 
-/// Exposed for unit tests to assert the ARIA metadata contract.
-#[cfg_attr(not(test), allow(dead_code))]
-fn themed_radio_group_attributes(state: &RadioGroupState) -> Vec<(String, String)> {
-    state
-        .group_aria_attributes()
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect()
-}
-
 pub mod yew {
     use super::*;
 
@@ -199,22 +184,23 @@ mod tests {
             Some(0),
         );
         let html = render_html(&props, &state);
-        assert!(html.contains(">A<"));
-        assert!(html.contains(">B<"));
-        assert!(html.contains("radiogroup"));
+        assert!(html.contains("data-index=\"0\""));
+        assert!(html.contains("data-index=\"1\""));
     }
 
     #[test]
-    fn themed_attributes_include_orientation() {
+    fn descriptor_exposes_aria_metadata() {
+        let props = RadioGroupProps::new(vec!["A".to_string(), "B".to_string()]);
         let state = RadioGroupState::uncontrolled(
-            vec!["A".into()],
+            vec!["A".into(), "B".into()],
             false,
-            RadioOrientation::Vertical,
-            None,
+            RadioOrientation::Horizontal,
+            Some(0),
         );
-        let attrs = themed_radio_group_attributes(&state);
-        assert!(attrs
-            .iter()
-            .any(|(k, v)| k == "aria-orientation" && v == "vertical"));
+        let descriptor = build_descriptor(&props, &state);
+        assert!(descriptor.aria_attributes().any(|(k, _)| k == "role"));
+        assert!(descriptor.options().iter().any(|option| option
+            .aria_attributes()
+            .any(|(k, v)| k == "aria-checked" && v == "true")));
     }
 }

--- a/crates/rustic-ui-material/src/selection_control.rs
+++ b/crates/rustic-ui-material/src/selection_control.rs
@@ -1,33 +1,464 @@
 //! Shared rendering helpers for Material selection controls.
 //!
-//! The helpers convert state machine metadata into HTML strings augmented with
-//! themed styles.  Centralizing the rendering logic keeps the individual
-//! component modules focused on data flow rather than DOM string assembly.
+//! The helpers now surface structured descriptors so adapters can decide whether
+//! to emit HTML strings (SSR) or hydrate individual frameworks with attribute
+//! maps.  Centralizing the metadata keeps the individual component modules
+//! focused on data flow rather than DOM string assembly while making it trivial
+//! to serialize the same descriptor in multiple environments.
 
 use rustic_ui_styled_engine::Style;
+use rustic_ui_utils::attributes_to_html;
 
-/// Render a single toggle style control such as a checkbox or switch.
-pub(crate) fn render_toggle(label: &str, style: Style, attrs: Vec<(String, String)>) -> String {
-    let attr_string = crate::style_helpers::themed_attributes_html(style, attrs);
-    format!("<span {attr_string}>{label}</span>")
+use crate::style_helpers;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttributeKind {
+    Aria,
+    DataState,
+    Standard,
 }
 
-/// Render a radio group with styled options.
-pub(crate) fn render_radio_group<F>(
-    group_style: Style,
-    group_attrs: Vec<(String, String)>,
-    option_style_factory: F,
-    options: &[(String, Vec<(String, String)>)],
-) -> String
-where
-    F: Fn() -> Style,
-{
-    let group_attr_string = crate::style_helpers::themed_attributes_html(group_style, group_attrs);
-    let mut options_html = String::new();
-    for (label, attrs) in options {
-        let option_attr =
-            crate::style_helpers::themed_attributes_html(option_style_factory(), attrs.clone());
-        options_html.push_str(&format!("<span {option_attr}>{label}</span>"));
+#[derive(Debug, Clone)]
+struct AttributeEntry {
+    key: String,
+    value: String,
+    kind: AttributeKind,
+}
+
+impl AttributeEntry {
+    fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = key.into();
+        let kind = if key.starts_with("aria-") || key == "role" || key == "tabindex" {
+            AttributeKind::Aria
+        } else if key.starts_with("data-") {
+            AttributeKind::DataState
+        } else {
+            AttributeKind::Standard
+        };
+        Self {
+            key,
+            value: value.into(),
+            kind,
+        }
     }
-    format!("<div {group_attr_string}>{options_html}</div>")
+}
+
+/// Describes a labelled toggle-style control such as a checkbox or switch.
+///
+/// The descriptor acts as a fluent builder that records ARIA attributes,
+/// automation-focused `data-*` flags, and additional DOM metadata without
+/// stringifying. Framework adapters can request the themed attribute pairs when
+/// hydrating a client render, while SSR pipelines can convert the same
+/// descriptor to HTML using [`render_toggle_html`].
+///
+/// # SSR and hydration flow
+///
+/// 1. Headless state machines expose attribute tuples describing ARIA metadata
+///    and stateful `data-*` flags.
+/// 2. Callers feed those tuples into [`ToggleControlDescriptor::with_attributes`]
+///    which records the metadata and allows inspection without conversion.
+/// 3. Framework adapters call [`ToggleControlDescriptor::themed_attributes`] to
+///    receive a merged `(String, String)` vector suitable for frameworks like
+///    Yew, Leptos, Sycamore or React (through the WASM bridge).
+/// 4. Server renderers invoke [`render_toggle_html`] which serializes the same
+///    descriptor via [`style_helpers::themed_attributes`] and
+///    [`attributes_to_html`].
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use rustic_ui_material::selection_control::{
+///     render_toggle_html, ToggleControlDescriptor,
+/// };
+/// use rustic_ui_styled_engine::Style;
+///
+/// let style = Style::new(rustic_ui_styled_engine::css!("color: red;"))
+///     .expect("valid style");
+/// let descriptor = ToggleControlDescriptor::new("Notifications", style.clone())
+///     .with_attributes([
+///         ("role", "switch"),
+///         ("aria-checked", "true"),
+///         ("data-on", "true"),
+///     ]);
+///
+/// // Framework adapter hydration:
+/// let themed_pairs = descriptor.themed_attributes();
+/// assert!(themed_pairs.iter().any(|(k, _)| k == "class"));
+///
+/// // SSR pipeline:
+/// let html = render_toggle_html(&descriptor);
+/// assert!(html.contains("aria-checked"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct ToggleControlDescriptor {
+    label: String,
+    style: Style,
+    attributes: Vec<AttributeEntry>,
+}
+
+#[allow(dead_code)]
+impl ToggleControlDescriptor {
+    /// Create a new descriptor for a toggle-like control.
+    pub fn new(label: impl Into<String>, style: Style) -> Self {
+        Self {
+            label: label.into(),
+            style,
+            attributes: Vec::new(),
+        }
+    }
+
+    /// Returns the visible label associated with the control.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Returns a clone of the themed style handle so adapters can pre-register
+    /// CSS with their runtime.
+    pub fn style(&self) -> Style {
+        self.style.clone()
+    }
+
+    /// Iterate over ARIA attributes recorded on the descriptor.
+    pub fn aria_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::Aria)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Iterate over `data-*` attributes tracked by the descriptor.
+    pub fn data_state_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::DataState)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Iterate over non-ARIA, non-`data-*` attributes.
+    pub fn standard_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::Standard)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Append raw attributes emitted by the headless state machine.
+    pub fn with_attributes<I, K, V>(mut self, attributes: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        for (key, value) in attributes {
+            self.attributes.push(AttributeEntry::new(key, value));
+        }
+        self
+    }
+
+    /// Add a single attribute to the descriptor.
+    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.push(AttributeEntry::new(key, value));
+        self
+    }
+
+    /// Return the merged themed attributes ready for framework hydration.
+    pub fn themed_attributes(&self) -> Vec<(String, String)> {
+        style_helpers::themed_attributes(self.style.clone(), self.raw_attributes())
+    }
+
+    fn raw_attributes(&self) -> Vec<(String, String)> {
+        let mut standard = Vec::new();
+        let mut aria = Vec::new();
+        let mut data = Vec::new();
+
+        for attr in &self.attributes {
+            let pair = (attr.key.clone(), attr.value.clone());
+            match attr.kind {
+                AttributeKind::Standard => standard.push(pair),
+                AttributeKind::Aria => aria.push(pair),
+                AttributeKind::DataState => data.push(pair),
+            }
+        }
+
+        standard.extend(aria);
+        standard.extend(data);
+        standard
+    }
+}
+
+/// Describes an individual option within a radio group.
+///
+/// The descriptor mirrors [`ToggleControlDescriptor`] but focuses on options
+/// that share a group container.  Each option tracks its own theme handle,
+/// attribute metadata and label so adapters can compose option-level DOM nodes
+/// independently of the surrounding group.
+#[derive(Debug, Clone)]
+pub struct RadioOptionDescriptor {
+    label: String,
+    style: Style,
+    attributes: Vec<AttributeEntry>,
+}
+
+#[allow(dead_code)]
+impl RadioOptionDescriptor {
+    /// Create a new option descriptor.
+    pub fn new(label: impl Into<String>, style: Style) -> Self {
+        Self {
+            label: label.into(),
+            style,
+            attributes: Vec::new(),
+        }
+    }
+
+    /// Returns the option label displayed to end users.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Returns a clone of the themed style handle for the option container.
+    pub fn style(&self) -> Style {
+        self.style.clone()
+    }
+
+    /// Iterate over ARIA metadata for the option.
+    pub fn aria_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::Aria)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Iterate over `data-*` flags exposed for analytics and focus management.
+    pub fn data_state_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::DataState)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Iterate over non-ARIA attributes.
+    pub fn standard_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::Standard)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Append attributes retrieved from the radio state machine.
+    pub fn with_attributes<I, K, V>(mut self, attributes: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        for (key, value) in attributes {
+            self.attributes.push(AttributeEntry::new(key, value));
+        }
+        self
+    }
+
+    /// Add a single attribute to the descriptor.
+    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.push(AttributeEntry::new(key, value));
+        self
+    }
+
+    /// Return the themed attribute pairs for hydration.
+    pub fn themed_attributes(&self) -> Vec<(String, String)> {
+        style_helpers::themed_attributes(self.style.clone(), self.raw_attributes())
+    }
+
+    fn raw_attributes(&self) -> Vec<(String, String)> {
+        let mut standard = Vec::new();
+        let mut aria = Vec::new();
+        let mut data = Vec::new();
+
+        for attr in &self.attributes {
+            let pair = (attr.key.clone(), attr.value.clone());
+            match attr.kind {
+                AttributeKind::Standard => standard.push(pair),
+                AttributeKind::Aria => aria.push(pair),
+                AttributeKind::DataState => data.push(pair),
+            }
+        }
+
+        standard.extend(aria);
+        standard.extend(data);
+        standard
+    }
+}
+
+/// Describes the container and options for a radio group.
+///
+/// The descriptor is intentionally exhaustive, allowing SSR callers to generate
+/// HTML via [`render_radio_group_html`] while giving client renderers direct
+/// access to the themed attribute sets.  Options are stored as
+/// [`RadioOptionDescriptor`] instances so adapters can lazily render only the
+/// portions of the group that changed during hydration.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use rustic_ui_material::selection_control::{
+///     render_radio_group_html, RadioGroupDescriptor, RadioOptionDescriptor,
+/// };
+/// use rustic_ui_styled_engine::Style;
+///
+/// let group_style = Style::new(rustic_ui_styled_engine::css!("display: flex;"))
+///     .expect("valid style");
+/// let option_style = group_style.clone();
+/// let descriptor = RadioGroupDescriptor::new(group_style)
+///     .with_group_attributes([("role", "radiogroup")])
+///     .option(
+///         RadioOptionDescriptor::new("A", option_style.clone()).with_attributes([
+///             ("role", "radio"),
+///             ("aria-checked", "true"),
+///         ]),
+///     )
+///     .option(
+///         RadioOptionDescriptor::new("B", option_style).with_attributes([
+///             ("role", "radio"),
+///             ("aria-checked", "false"),
+///         ]),
+///     );
+///
+/// // Hydration fetches the attribute pairs lazily.
+/// let group_pairs = descriptor.group_thematic_attributes();
+/// assert!(group_pairs.iter().any(|(k, _)| k == "class"));
+///
+/// // SSR renders deterministic markup.
+/// let html = render_radio_group_html(&descriptor);
+/// assert!(html.contains("role=\"radiogroup\""));
+/// ```
+#[derive(Debug, Clone)]
+pub struct RadioGroupDescriptor {
+    style: Style,
+    attributes: Vec<AttributeEntry>,
+    options: Vec<RadioOptionDescriptor>,
+}
+
+#[allow(dead_code)]
+impl RadioGroupDescriptor {
+    /// Create a new descriptor for a radio group container.
+    pub fn new(style: Style) -> Self {
+        Self {
+            style,
+            attributes: Vec::new(),
+            options: Vec::new(),
+        }
+    }
+
+    /// Append attributes emitted by the headless radio group state.
+    pub fn with_group_attributes<I, K, V>(mut self, attributes: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        for (key, value) in attributes {
+            self.attributes.push(AttributeEntry::new(key, value));
+        }
+        self
+    }
+
+    /// Add an individual attribute to the group container.
+    pub fn group_attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.push(AttributeEntry::new(key, value));
+        self
+    }
+
+    /// Push a radio option descriptor into the group.
+    pub fn option(mut self, option: RadioOptionDescriptor) -> Self {
+        self.options.push(option);
+        self
+    }
+
+    /// Returns all option descriptors for further inspection.
+    pub fn options(&self) -> &[RadioOptionDescriptor] {
+        &self.options
+    }
+
+    /// Returns a clone of the group style for preloading CSS rules.
+    pub fn style(&self) -> Style {
+        self.style.clone()
+    }
+
+    /// Iterate over ARIA attributes attached to the group container.
+    pub fn aria_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::Aria)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Iterate over container-level `data-*` flags.
+    pub fn data_state_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::DataState)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Iterate over standard container attributes.
+    pub fn standard_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .filter(|attr| attr.kind == AttributeKind::Standard)
+            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+    }
+
+    /// Returns the themed attribute pairs for the group container.
+    pub fn group_thematic_attributes(&self) -> Vec<(String, String)> {
+        style_helpers::themed_attributes(self.style.clone(), self.raw_attributes())
+    }
+
+    fn raw_attributes(&self) -> Vec<(String, String)> {
+        let mut standard = Vec::new();
+        let mut aria = Vec::new();
+        let mut data = Vec::new();
+
+        for attr in &self.attributes {
+            let pair = (attr.key.clone(), attr.value.clone());
+            match attr.kind {
+                AttributeKind::Standard => standard.push(pair),
+                AttributeKind::Aria => aria.push(pair),
+                AttributeKind::DataState => data.push(pair),
+            }
+        }
+
+        standard.extend(aria);
+        standard.extend(data);
+        standard
+    }
+}
+
+/// Serialize a toggle descriptor into HTML for SSR environments.
+#[must_use]
+pub(crate) fn render_toggle_html(descriptor: &ToggleControlDescriptor) -> String {
+    let attrs = descriptor.themed_attributes();
+    format!(
+        "<span {attrs}>{label}</span>",
+        attrs = attributes_to_html(&attrs),
+        label = descriptor.label()
+    )
+}
+
+/// Serialize a radio group descriptor into HTML for SSR environments.
+#[must_use]
+pub(crate) fn render_radio_group_html(descriptor: &RadioGroupDescriptor) -> String {
+    let group_attrs = descriptor.group_thematic_attributes();
+    let mut options_html = String::new();
+    for option in descriptor.options() {
+        let attrs = option.themed_attributes();
+        options_html.push_str(&format!(
+            "<span {attrs}>{label}</span>",
+            attrs = attributes_to_html(&attrs),
+            label = option.label()
+        ));
+    }
+    format!(
+        "<div {attrs}>{options}</div>",
+        attrs = attributes_to_html(&group_attrs),
+        options = options_html
+    )
 }

--- a/crates/rustic-ui-material/src/switch.rs
+++ b/crates/rustic-ui-material/src/switch.rs
@@ -1,12 +1,12 @@
 //! Material switch built from the headless [`SwitchState`].
 //!
-//! Switches reuse the shared selection control renderer ensuring identical
+//! Switches reuse the shared selection control descriptor ensuring identical
 //! markup across frameworks while leveraging theme tokens for styling.
 
 use rustic_ui_headless::switch::SwitchState;
 use rustic_ui_styled_engine::{css_with_theme, Style};
 
-use crate::selection_control;
+use crate::selection_control::{self, ToggleControlDescriptor};
 
 #[derive(Clone, Debug)]
 pub struct SwitchProps {
@@ -22,13 +22,14 @@ impl SwitchProps {
     }
 }
 
+fn build_descriptor(props: &SwitchProps, state: &SwitchState) -> ToggleControlDescriptor {
+    ToggleControlDescriptor::new(props.label.clone(), themed_switch_style())
+        .with_attributes(state.aria_attributes())
+}
+
 fn render_html(props: &SwitchProps, state: &SwitchState) -> String {
-    let attrs = state
-        .aria_attributes()
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
-    selection_control::render_toggle(&props.label, themed_switch_style(), attrs)
+    let descriptor = build_descriptor(props, state);
+    selection_control::render_toggle_html(&descriptor)
 }
 
 /// Builds the switch track and thumb styling from the active theme tokens. By
@@ -107,16 +108,6 @@ fn themed_switch_style() -> Style {
     )
 }
 
-/// Testing hook mirroring the one provided in [`checkbox`].
-#[cfg_attr(not(test), allow(dead_code))]
-fn themed_switch_attributes(state: &SwitchState) -> Vec<(String, String)> {
-    state
-        .aria_attributes()
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect()
-}
-
 pub mod yew {
     use super::*;
 
@@ -156,8 +147,10 @@ mod tests {
     #[test]
     fn themed_attributes_include_role() {
         let state = SwitchState::uncontrolled(false, true);
-        let attrs = themed_switch_attributes(&state);
-        assert!(attrs.iter().any(|(k, v)| k == "role" && v == "switch"));
+        let descriptor = build_descriptor(&SwitchProps::new("Notifications"), &state);
+        assert!(descriptor
+            .aria_attributes()
+            .any(|(k, v)| k == "role" && v == "switch"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the legacy selection control render helpers with toggle and radio descriptors that expose raw ARIA/data attributes, theming handles, and SSR documentation
- update the checkbox, switch, and radio material adapters to construct the descriptors and reuse the shared HTML serialization helpers
- add dedicated `render_*_html` helpers so server renderers can serialize the descriptors while keeping hydration paths attribute driven

## Testing
- cargo test -p rustic-ui-material
- cargo test -p rustic-ui-material --lib checkbox::tests::themed_attributes_include_role
- cargo test -p rustic-ui-material --lib switch::tests::themed_attributes_include_role
- cargo test -p rustic-ui-material --lib radio::tests::descriptor_exposes_aria_metadata


------
https://chatgpt.com/codex/tasks/task_e_68dc09882efc832e878888b07d855b17