### PR TITLE
Add telemetry imports for checkbox module

### DIFF
--- a/crates/rustic-ui-material/src/checkbox.rs
+++ b/crates/rustic-ui-material/src/checkbox.rs
@@ -22,11 +22,13 @@
 //! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor)
 //! so automation hooks and ARIA metadata remain consistent across frameworks.
 
+use crate::{
+    selection_control::{self, ToggleControlDescriptor},
+    telemetry::{instrument_render, TelemetryContext, TelemetryHooks},
+};
 use rustic_ui_headless::checkbox::CheckboxState;
 use rustic_ui_styled_engine::{css_with_theme, Style};
 use std::collections::HashMap;
-
-use crate::selection_control::{self, ToggleControlDescriptor};
 
 /// Props shared across all framework adapters.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
## Summary
- add telemetry instrumentation imports to the material checkbox module for upcoming analytics work

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc4bfe61dc832e81bad6c9beb6cccc