### PR TITLE
feat: instrument switch adapters with telemetry hooks

### DIFF
--- a/crates/rustic-ui-material/src/switch.rs
+++ b/crates/rustic-ui-material/src/switch.rs
@@ -1,8 +1,9 @@
 //! Material switch built from the headless [`SwitchState`].
 //!
 //! Feature-gated adapters expose idiomatic components per framework while
-//! sharing styling and accessibility metadata via
-//! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor):
+//! sharing styling, accessibility metadata, and telemetry ordering via
+//! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor)
+//! and the helper dispatchers defined below.
 //!
 //! * `react` – [`react::ReactSwitch`] returns [`Jsx`] using the `wasm_bindgen`
 //!   bridge and the shared descriptor metadata.
@@ -16,43 +17,193 @@
 //!   [`Template`](sycamore::view::Template) for signal-driven experiences.
 //!
 //! All adapters derive their attributes from the same descriptor ensuring parity
-//! between SSR and client renders regardless of framework.
+//! between SSR and client renders regardless of framework. Telemetry hooks and
+//! analytics callbacks are routed through [`instrument_render`],
+//! [`TelemetryContext`], and the dispatch helpers so analytics capture always
+//! precedes local side effects.
 
-use rustic_ui_headless::switch::SwitchState;
+use crate::{
+    selection_control::{self, ToggleControlDescriptor},
+    telemetry::{instrument_render, TelemetryContext, TelemetryHooks},
+};
+use rustic_ui_headless::{interaction::ControlKey, switch::SwitchState};
 use rustic_ui_styled_engine::{css_with_theme, Style};
 
-use crate::selection_control::{self, ToggleControlDescriptor};
+#[cfg(feature = "react")]
+use wasm_bindgen::JsValue;
 
+/// Props shared across all framework adapters.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SwitchProps {
     /// Human friendly label rendered adjacent to the switch track.
     pub label: String,
+    /// Telemetry hooks used to decorate render lifecycles with analytics and
+    /// automation identifiers.
+    pub telemetry: TelemetryHooks,
 }
 
 impl SwitchProps {
+    /// Convenience constructor for tests and examples.
     pub fn new(label: impl Into<String>) -> Self {
         Self {
             label: label.into(),
+            telemetry: TelemetryHooks::default(),
         }
+    }
+}
+
+/// Canonical payload emitted when switch state changes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwitchChangeEvent {
+    /// Previously resolved on/off state prior to the interaction.
+    pub previous: bool,
+    /// Next logical state requested by the user interaction.
+    pub next: bool,
+    /// Whether the switch was disabled when the interaction was attempted.
+    pub disabled: bool,
+    /// Identifier mirrored to analytics sinks (if configured).
+    pub analytics_id: Option<String>,
+    /// Identifier mirrored to automation sinks (if configured).
+    pub automation_id: Option<String>,
+    /// Human friendly label rendered alongside the switch.
+    pub label: String,
+}
+
+/// Canonical payload emitted when focus visibility changes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwitchFocusEvent {
+    /// Whether focus was gained (`true`) or lost (`false`).
+    pub focused: bool,
+    /// Current on/off state at the time the focus transition occurred.
+    pub on: bool,
+    /// Whether the switch was disabled while the focus event fired.
+    pub disabled: bool,
+    /// Identifier mirrored to analytics sinks (if configured).
+    pub analytics_id: Option<String>,
+    /// Identifier mirrored to automation sinks (if configured).
+    pub automation_id: Option<String>,
+    /// Human friendly label rendered alongside the switch.
+    pub label: String,
+}
+
+/// Canonical payload emitted for keyboard interactions.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwitchKeyEvent {
+    /// Normalised control key derived from the browser event.
+    pub key: ControlKey,
+    /// Previously resolved on/off state prior to the key interaction.
+    pub previous: bool,
+    /// Next logical state requested by the key press (if any).
+    pub next: bool,
+    /// Whether the switch was disabled when the key was pressed.
+    pub disabled: bool,
+    /// Identifier mirrored to analytics sinks (if configured).
+    pub analytics_id: Option<String>,
+    /// Identifier mirrored to automation sinks (if configured).
+    pub automation_id: Option<String>,
+    /// Human friendly label rendered alongside the switch.
+    pub label: String,
+}
+
+/// Telemetry payload variants surfaced across adapters.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SwitchTelemetryEvent {
+    /// Change request triggered via pointer or keyboard interaction.
+    Change(SwitchChangeEvent),
+    /// Focus gained with the accompanying state metadata.
+    Focus(SwitchFocusEvent),
+    /// Focus lost with the accompanying state metadata.
+    Blur(SwitchFocusEvent),
+    /// Raw keyboard interaction payload.
+    Key(SwitchKeyEvent),
+}
+
+#[allow(dead_code)]
+fn analytics_id(props: &SwitchProps) -> Option<String> {
+    props.telemetry.analytics_id.clone()
+}
+
+#[allow(dead_code)]
+fn automation_id(props: &SwitchProps) -> Option<String> {
+    props.telemetry.automation_id.clone()
+}
+
+#[allow(dead_code)]
+fn build_change_event(props: &SwitchProps, state: &SwitchState) -> SwitchChangeEvent {
+    let previous = state.on();
+    let next = if state.disabled() {
+        previous
+    } else {
+        !previous
+    };
+    SwitchChangeEvent {
+        previous,
+        next,
+        disabled: state.disabled(),
+        analytics_id: analytics_id(props),
+        automation_id: automation_id(props),
+        label: props.label.clone(),
+    }
+}
+
+fn build_focus_event(props: &SwitchProps, state: &SwitchState, focused: bool) -> SwitchFocusEvent {
+    SwitchFocusEvent {
+        focused,
+        on: state.on(),
+        disabled: state.disabled(),
+        analytics_id: analytics_id(props),
+        automation_id: automation_id(props),
+        label: props.label.clone(),
+    }
+}
+
+#[allow(dead_code)]
+fn build_key_event(props: &SwitchProps, state: &SwitchState, key: ControlKey) -> SwitchKeyEvent {
+    let previous = state.on();
+    let next = if state.disabled() {
+        previous
+    } else {
+        !previous
+    };
+    SwitchKeyEvent {
+        key,
+        previous,
+        next,
+        disabled: state.disabled(),
+        analytics_id: analytics_id(props),
+        automation_id: automation_id(props),
+        label: props.label.clone(),
+    }
+}
+
+#[allow(dead_code)]
+fn control_key_from_str(key: &str) -> Option<ControlKey> {
+    match key {
+        " " | "Spacebar" | "Space" => Some(ControlKey::Space),
+        "Enter" => Some(ControlKey::Enter),
+        _ => None,
     }
 }
 
 #[allow(dead_code)]
 fn build_descriptor(props: &SwitchProps, state: &SwitchState) -> ToggleControlDescriptor {
-    ToggleControlDescriptor::new(props.label.clone(), themed_switch_style())
-        .with_attributes(state.aria_attributes())
+    let descriptor = ToggleControlDescriptor::new(props.label.clone(), themed_switch_style())
+        .with_attributes(state.aria_attributes());
+    merge_descriptor_telemetry(descriptor, &props.telemetry)
 }
 
 #[allow(dead_code)]
 fn render_html(props: &SwitchProps, state: &SwitchState) -> String {
-    let descriptor = build_descriptor(props, state);
-    selection_control::render_toggle_html(&descriptor)
+    let (context, descriptor, _snapshot) =
+        descriptor_with_context("rustic_ui_material::switch::render_html", props, state);
+    instrument_render(&props.telemetry, context, || {
+        selection_control::render_toggle_html(&descriptor)
+    })
 }
 
 /// Builds the switch track and thumb styling from the active theme tokens. By
 /// leaning on `css_with_theme!` we avoid scattering literal values and keep the
 /// component responsive to palette or spacing overrides.
-#[allow(dead_code)]
 fn themed_switch_style() -> Style {
     css_with_theme!(
         r#"
@@ -126,23 +277,404 @@ fn themed_switch_style() -> Style {
     )
 }
 
+fn merge_descriptor_telemetry(
+    mut descriptor: ToggleControlDescriptor,
+    telemetry: &TelemetryHooks,
+) -> ToggleControlDescriptor {
+    let has_analytics = descriptor
+        .data_state_attributes()
+        .any(|(key, _)| key == "data-rustic-analytics-id");
+    if !has_analytics {
+        if let Some(analytics) = &telemetry.analytics_id {
+            descriptor = descriptor.attribute("data-rustic-analytics-id", analytics.clone());
+        }
+    }
+
+    let has_automation = descriptor
+        .data_state_attributes()
+        .any(|(key, _)| key == "data-automation-id");
+    if !has_automation {
+        if let Some(automation) = &telemetry.automation_id {
+            descriptor = descriptor.attribute("data-automation-id", automation.clone());
+        }
+    }
+
+    descriptor
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SwitchDescriptorSnapshot {
+    label: String,
+    themed_attributes: Vec<(String, String)>,
+    class: String,
+    role: String,
+    aria_checked: String,
+    aria_disabled: Option<String>,
+    tabindex: String,
+    data_on: String,
+    data_focus_visible: String,
+}
+
+impl SwitchDescriptorSnapshot {
+    fn from_descriptor(descriptor: &ToggleControlDescriptor) -> Self {
+        let themed_attributes = descriptor.themed_attributes();
+        let mut class = String::new();
+        let mut role = String::from("switch");
+        let mut aria_checked = String::from("false");
+        let mut aria_disabled = None;
+        let mut tabindex = String::from("0");
+        let mut data_on = String::from("false");
+        let mut data_focus_visible = String::from("false");
+
+        for (key, value) in &themed_attributes {
+            match key.as_str() {
+                "class" => class = value.clone(),
+                "role" => role = value.clone(),
+                "aria-checked" => aria_checked = value.clone(),
+                "aria-disabled" => aria_disabled = Some(value.clone()),
+                "tabindex" => tabindex = value.clone(),
+                "data-on" => data_on = value.clone(),
+                "data-focus-visible" => data_focus_visible = value.clone(),
+                _ => {}
+            }
+        }
+
+        Self {
+            label: descriptor.label().to_string(),
+            themed_attributes,
+            class,
+            role,
+            aria_checked,
+            aria_disabled,
+            tabindex,
+            data_on,
+            data_focus_visible,
+        }
+    }
+}
+
+fn descriptor_with_context(
+    component: &'static str,
+    props: &SwitchProps,
+    state: &SwitchState,
+) -> (
+    TelemetryContext,
+    ToggleControlDescriptor,
+    SwitchDescriptorSnapshot,
+) {
+    let descriptor = merge_descriptor_telemetry(build_descriptor(props, state), &props.telemetry);
+    let snapshot = SwitchDescriptorSnapshot::from_descriptor(&descriptor);
+    let context = TelemetryContext::new(component)
+        .with_analytics(props.telemetry.analytics_id.clone())
+        .with_automation(props.telemetry.automation_id.clone())
+        .with_descriptor_metadata(snapshot.label.clone(), snapshot.themed_attributes.clone());
+    (context, descriptor, snapshot)
+}
+
+fn dispatch_change_event(
+    props: &SwitchProps,
+    state: &mut SwitchState,
+    telemetry: Option<&mut dyn FnMut(SwitchTelemetryEvent)>,
+    change_callback: Option<&mut dyn FnMut(SwitchChangeEvent)>,
+) -> SwitchChangeEvent {
+    let change = build_change_event(props, state);
+    if let Some(callback) = telemetry {
+        callback(SwitchTelemetryEvent::Change(change.clone()));
+    }
+    if let Some(callback) = change_callback {
+        callback(change.clone());
+    }
+    state.toggle(|_| {});
+    change
+}
+
+fn dispatch_focus_event(
+    props: &SwitchProps,
+    state: &mut SwitchState,
+    focused: bool,
+    telemetry: Option<&mut dyn FnMut(SwitchTelemetryEvent)>,
+    focus_callback: Option<&mut dyn FnMut(SwitchFocusEvent)>,
+) -> SwitchFocusEvent {
+    let focus = build_focus_event(props, state, focused);
+    if let Some(callback) = telemetry {
+        let event = if focused {
+            SwitchTelemetryEvent::Focus(focus.clone())
+        } else {
+            SwitchTelemetryEvent::Blur(focus.clone())
+        };
+        callback(event);
+    }
+    if let Some(callback) = focus_callback {
+        callback(focus.clone());
+    }
+    if focused {
+        state.focus();
+    } else {
+        state.blur();
+    }
+    focus
+}
+
+fn dispatch_key_event(
+    props: &SwitchProps,
+    state: &mut SwitchState,
+    key: ControlKey,
+    telemetry: Option<&mut dyn FnMut(SwitchTelemetryEvent)>,
+    key_callback: Option<&mut dyn FnMut(SwitchKeyEvent)>,
+    change_callback: Option<&mut dyn FnMut(SwitchChangeEvent)>,
+) -> (SwitchKeyEvent, SwitchChangeEvent) {
+    let key_event = build_key_event(props, state, key);
+    let change_event = build_change_event(props, state);
+
+    if let Some(callback) = telemetry {
+        callback(SwitchTelemetryEvent::Key(key_event.clone()));
+        callback(SwitchTelemetryEvent::Change(change_event.clone()));
+    }
+    if let Some(callback) = key_callback {
+        callback(key_event.clone());
+    }
+    if let Some(callback) = change_callback {
+        callback(change_event.clone());
+    }
+    state.on_key(key, |_| {});
+    (key_event, change_event)
+}
+
+#[cfg(feature = "react")]
+fn control_key_to_str(key: ControlKey) -> &'static str {
+    match key {
+        ControlKey::Space => "space",
+        ControlKey::Enter => "enter",
+        ControlKey::ArrowUp => "arrow-up",
+        ControlKey::ArrowDown => "arrow-down",
+        ControlKey::ArrowLeft => "arrow-left",
+        ControlKey::ArrowRight => "arrow-right",
+        ControlKey::Home => "home",
+        ControlKey::End => "end",
+    }
+}
+
+#[cfg(feature = "react")]
+fn push_optional_string(
+    object: &js_sys::Object,
+    key: &str,
+    value: &Option<String>,
+) -> Result<(), JsValue> {
+    if let Some(value) = value {
+        js_sys::Reflect::set(object, &JsValue::from_str(key), &JsValue::from_str(value))?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "react")]
+fn telemetry_event_to_js(event: SwitchTelemetryEvent) -> JsValue {
+    use js_sys::Reflect;
+    use SwitchTelemetryEvent as Event;
+
+    let object = js_sys::Object::new();
+    match event {
+        Event::Change(change) => {
+            Reflect::set(
+                &object,
+                &JsValue::from_str("kind"),
+                &JsValue::from_str("change"),
+            )
+            .expect("set kind");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("previous"),
+                &JsValue::from_bool(change.previous),
+            )
+            .expect("set previous");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("next"),
+                &JsValue::from_bool(change.next),
+            )
+            .expect("set next");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("disabled"),
+                &JsValue::from_bool(change.disabled),
+            )
+            .expect("set disabled");
+            push_optional_string(&object, "analyticsId", &change.analytics_id)
+                .expect("set analyticsId");
+            push_optional_string(&object, "automationId", &change.automation_id)
+                .expect("set automationId");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("label"),
+                &JsValue::from_str(&change.label),
+            )
+            .expect("set label");
+        }
+        Event::Focus(focus) => {
+            Reflect::set(
+                &object,
+                &JsValue::from_str("kind"),
+                &JsValue::from_str("focus"),
+            )
+            .expect("set kind");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("focused"),
+                &JsValue::from_bool(focus.focused),
+            )
+            .expect("set focused");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("on"),
+                &JsValue::from_bool(focus.on),
+            )
+            .expect("set on");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("disabled"),
+                &JsValue::from_bool(focus.disabled),
+            )
+            .expect("set disabled");
+            push_optional_string(&object, "analyticsId", &focus.analytics_id)
+                .expect("set analyticsId");
+            push_optional_string(&object, "automationId", &focus.automation_id)
+                .expect("set automationId");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("label"),
+                &JsValue::from_str(&focus.label),
+            )
+            .expect("set label");
+        }
+        Event::Blur(focus) => {
+            Reflect::set(
+                &object,
+                &JsValue::from_str("kind"),
+                &JsValue::from_str("blur"),
+            )
+            .expect("set kind");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("focused"),
+                &JsValue::from_bool(focus.focused),
+            )
+            .expect("set focused");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("on"),
+                &JsValue::from_bool(focus.on),
+            )
+            .expect("set on");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("disabled"),
+                &JsValue::from_bool(focus.disabled),
+            )
+            .expect("set disabled");
+            push_optional_string(&object, "analyticsId", &focus.analytics_id)
+                .expect("set analyticsId");
+            push_optional_string(&object, "automationId", &focus.automation_id)
+                .expect("set automationId");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("label"),
+                &JsValue::from_str(&focus.label),
+            )
+            .expect("set label");
+        }
+        Event::Key(key) => {
+            Reflect::set(
+                &object,
+                &JsValue::from_str("kind"),
+                &JsValue::from_str("key"),
+            )
+            .expect("set kind");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("key"),
+                &JsValue::from_str(control_key_to_str(key.key)),
+            )
+            .expect("set key");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("previous"),
+                &JsValue::from_bool(key.previous),
+            )
+            .expect("set previous");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("next"),
+                &JsValue::from_bool(key.next),
+            )
+            .expect("set next");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("disabled"),
+                &JsValue::from_bool(key.disabled),
+            )
+            .expect("set disabled");
+            push_optional_string(&object, "analyticsId", &key.analytics_id)
+                .expect("set analyticsId");
+            push_optional_string(&object, "automationId", &key.automation_id)
+                .expect("set automationId");
+            Reflect::set(
+                &object,
+                &JsValue::from_str("label"),
+                &JsValue::from_str(&key.label),
+            )
+            .expect("set label");
+        }
+    }
+
+    object.into()
+}
 #[cfg(feature = "react")]
 pub mod react {
     //! React adapter returning `Jsx` nodes via the WASM bridge.
     use super::*;
     use js_sys::{Array, Function, Object, Reflect};
-    use wasm_bindgen::{JsCast, JsValue};
+    use std::{cell::RefCell, rc::Rc};
+    use wasm_bindgen::{closure::Closure, JsCast};
 
     /// Type alias representing React nodes produced by the adapter.
     pub type Jsx = JsValue;
 
     /// Properties consumed by the React switch component.
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, Debug)]
     pub struct ReactSwitchProps {
         /// Presentation details for the switch label.
         pub switch: SwitchProps,
         /// Headless state driving ARIA metadata.
         pub state: SwitchState,
+        /// Optional React `onChange` handler bridging to enterprise orchestrators.
+        pub on_change: Option<Function>,
+        /// Optional React `onFocus` handler forwarding focus analytics payloads.
+        pub on_focus: Option<Function>,
+        /// Optional React `onBlur` handler forwarding blur analytics payloads.
+        pub on_blur: Option<Function>,
+        /// Optional React `onKeyDown` handler forwarding keyboard payloads.
+        pub on_key: Option<Function>,
+        /// Optional telemetry payload delegate invoked by surrounding shells.
+        pub telemetry_delegate: Option<Function>,
+    }
+
+    fn function_option_eq(lhs: &Option<Function>, rhs: &Option<Function>) -> bool {
+        match (lhs, rhs) {
+            (Some(a), Some(b)) => JsValue::from(a).strict_eq(&JsValue::from(b)),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    impl PartialEq for ReactSwitchProps {
+        fn eq(&self, other: &Self) -> bool {
+            self.switch == other.switch
+                && self.state == other.state
+                && function_option_eq(&self.on_change, &other.on_change)
+                && function_option_eq(&self.on_focus, &other.on_focus)
+                && function_option_eq(&self.on_blur, &other.on_blur)
+                && function_option_eq(&self.on_key, &other.on_key)
+                && function_option_eq(&self.telemetry_delegate, &other.telemetry_delegate)
+        }
     }
 
     fn create_element(tag: &str, props: Object, children: &[JsValue]) -> JsValue {
@@ -166,7 +698,14 @@ pub mod react {
             .expect("React.createElement invocation")
     }
 
-    fn build_props_object(pairs: Vec<(String, String)>) -> Object {
+    struct ReactHandlers {
+        on_change: Option<Function>,
+        on_focus: Option<Function>,
+        on_blur: Option<Function>,
+        on_key: Option<Function>,
+    }
+
+    fn build_props_object(pairs: Vec<(String, String)>, handlers: &ReactHandlers) -> Object {
         let object = Object::new();
         for (key, value) in pairs {
             Reflect::set(
@@ -176,23 +715,249 @@ pub mod react {
             )
             .expect("set React prop");
         }
+        if let Some(handler) = &handlers.on_change {
+            Reflect::set(&object, &JsValue::from_str("onChange"), handler)
+                .expect("set onChange handler");
+        }
+        if let Some(handler) = &handlers.on_focus {
+            Reflect::set(&object, &JsValue::from_str("onFocus"), handler)
+                .expect("set onFocus handler");
+        }
+        if let Some(handler) = &handlers.on_blur {
+            Reflect::set(&object, &JsValue::from_str("onBlur"), handler)
+                .expect("set onBlur handler");
+        }
+        if let Some(handler) = &handlers.on_key {
+            Reflect::set(&object, &JsValue::from_str("onKeyDown"), handler)
+                .expect("set onKeyDown handler");
+        }
         object
     }
 
+    fn change_handler(
+        props: &ReactSwitchProps,
+        state_handle: &Rc<RefCell<SwitchState>>,
+    ) -> Option<Function> {
+        if props.on_change.is_none() && props.telemetry_delegate.is_none() {
+            return None;
+        }
+
+        let telemetry = props.telemetry_delegate.clone();
+        let on_change = props.on_change.clone();
+        let switch_props = props.switch.clone();
+        let state = Rc::clone(state_handle);
+
+        let closure = Closure::wrap(Box::new(move |event: JsValue| {
+            let change = {
+                let state = state.borrow();
+                build_change_event(&switch_props, &state)
+            };
+            if let Some(delegate) = telemetry.as_ref() {
+                let payload = telemetry_event_to_js(SwitchTelemetryEvent::Change(change.clone()));
+                let _ = delegate.call1(&JsValue::NULL, &payload);
+            }
+            if let Some(handler) = on_change.as_ref() {
+                let _ = handler.call1(&JsValue::NULL, &event);
+            }
+            {
+                let mut state = state.borrow_mut();
+                state.toggle(|_| {});
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+
+        let function: Function = closure.as_ref().clone().unchecked_into();
+        closure.forget();
+        Some(function)
+    }
+
+    fn focus_handler(
+        props: &ReactSwitchProps,
+        state_handle: &Rc<RefCell<SwitchState>>,
+    ) -> Option<Function> {
+        if props.on_focus.is_none() && props.telemetry_delegate.is_none() {
+            return None;
+        }
+
+        let telemetry = props.telemetry_delegate.clone();
+        let on_focus = props.on_focus.clone();
+        let switch_props = props.switch.clone();
+        let state = Rc::clone(state_handle);
+
+        let closure = Closure::wrap(Box::new(move |event: JsValue| {
+            let focus = {
+                let state = state.borrow();
+                build_focus_event(&switch_props, &state, true)
+            };
+            if let Some(delegate) = telemetry.as_ref() {
+                let payload = telemetry_event_to_js(SwitchTelemetryEvent::Focus(focus.clone()));
+                let _ = delegate.call1(&JsValue::NULL, &payload);
+            }
+            if let Some(handler) = on_focus.as_ref() {
+                let _ = handler.call1(&JsValue::NULL, &event);
+            }
+            {
+                let mut state = state.borrow_mut();
+                state.focus();
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+
+        let function: Function = closure.as_ref().clone().unchecked_into();
+        closure.forget();
+        Some(function)
+    }
+
+    fn blur_handler(
+        props: &ReactSwitchProps,
+        state_handle: &Rc<RefCell<SwitchState>>,
+    ) -> Option<Function> {
+        if props.on_blur.is_none() && props.telemetry_delegate.is_none() {
+            return None;
+        }
+
+        let telemetry = props.telemetry_delegate.clone();
+        let on_blur = props.on_blur.clone();
+        let switch_props = props.switch.clone();
+        let state = Rc::clone(state_handle);
+
+        let closure = Closure::wrap(Box::new(move |event: JsValue| {
+            let blur = {
+                let state = state.borrow();
+                build_focus_event(&switch_props, &state, false)
+            };
+            if let Some(delegate) = telemetry.as_ref() {
+                let payload = telemetry_event_to_js(SwitchTelemetryEvent::Blur(blur.clone()));
+                let _ = delegate.call1(&JsValue::NULL, &payload);
+            }
+            if let Some(handler) = on_blur.as_ref() {
+                let _ = handler.call1(&JsValue::NULL, &event);
+            }
+            {
+                let mut state = state.borrow_mut();
+                state.blur();
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+
+        let function: Function = closure.as_ref().clone().unchecked_into();
+        closure.forget();
+        Some(function)
+    }
+
+    fn key_handler(
+        props: &ReactSwitchProps,
+        state_handle: &Rc<RefCell<SwitchState>>,
+    ) -> Option<Function> {
+        if props.on_key.is_none() && props.on_change.is_none() && props.telemetry_delegate.is_none()
+        {
+            return None;
+        }
+
+        let telemetry = props.telemetry_delegate.clone();
+        let on_key = props.on_key.clone();
+        let on_change = props.on_change.clone();
+        let switch_props = props.switch.clone();
+        let state = Rc::clone(state_handle);
+
+        let closure = Closure::wrap(Box::new(move |event: JsValue| {
+            let key_value = Reflect::get(&event, &JsValue::from_str("key"))
+                .ok()
+                .and_then(|value| value.as_string());
+            if let Some(key) = key_value.as_deref().and_then(control_key_from_str) {
+                if let Ok(prevent) = Reflect::get(&event, &JsValue::from_str("preventDefault")) {
+                    if let Ok(prevent) = prevent.dyn_into::<Function>() {
+                        let _ = prevent.call0(&event);
+                    }
+                }
+
+                let (key_event, change_event) = {
+                    let state = state.borrow();
+                    (
+                        build_key_event(&switch_props, &state, key),
+                        build_change_event(&switch_props, &state),
+                    )
+                };
+
+                if let Some(delegate) = telemetry.as_ref() {
+                    let key_payload =
+                        telemetry_event_to_js(SwitchTelemetryEvent::Key(key_event.clone()));
+                    let _ = delegate.call1(&JsValue::NULL, &key_payload);
+                    let change_payload =
+                        telemetry_event_to_js(SwitchTelemetryEvent::Change(change_event.clone()));
+                    let _ = delegate.call1(&JsValue::NULL, &change_payload);
+                }
+
+                if let Some(handler) = on_key.as_ref() {
+                    let _ = handler.call1(&JsValue::NULL, &event);
+                }
+
+                if let Some(handler) = on_change.as_ref() {
+                    let _ = handler.call1(&JsValue::NULL, &event);
+                }
+
+                {
+                    let mut state = state.borrow_mut();
+                    state.on_key(key, |_| {});
+                }
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+
+        let function: Function = closure.as_ref().clone().unchecked_into();
+        closure.forget();
+        Some(function)
+    }
+
+    fn handlers(props: &ReactSwitchProps, state_handle: Rc<RefCell<SwitchState>>) -> ReactHandlers {
+        ReactHandlers {
+            on_change: change_handler(props, &state_handle),
+            on_focus: focus_handler(props, &state_handle),
+            on_blur: blur_handler(props, &state_handle),
+            on_key: key_handler(props, &state_handle),
+        }
+    }
+
     /// React component rendering the Material switch.
+    ///
+    /// * A [`TelemetryContext`] seeded with the fully-qualified component path
+    ///   and decorated with descriptor metadata is constructed so downstream
+    ///   spans, analytics sinks, and error hooks can attribute metrics and
+    ///   attribute snapshots back to this adapter.
+    /// * [`instrument_render`] enters the context span, ensures success/error
+    ///   hooks run, and propagates analytics/automation identifiers extracted
+    ///   from [`SwitchProps::telemetry`].
+    /// * Prior to hydration, telemetry defaults are merged into the descriptor
+    ///   attributes so SSR and CSR renders emit identical `data-*` markers even
+    ///   when the caller omits explicit identifiers.
+    /// * Event handlers wrap consumer callbacks, delivering normalized
+    ///   [`SwitchTelemetryEvent`] payloads to the optional telemetry delegate
+    ///   **before** invoking user logic. This guarantees analytics capture
+    ///   precedes side effects, aligning with audit requirements in regulated
+    ///   environments.
+    /// * After telemetry delegates and consumer callbacks run, the captured
+    ///   [`SwitchState`] is mutated via [`SwitchState::toggle`],
+    ///   [`SwitchState::focus`], [`SwitchState::blur`], and
+    ///   [`SwitchState::on_key`] so UI transitions always flow through the
+    ///   shared headless state machine.
     pub fn ReactSwitch(props: &ReactSwitchProps) -> Jsx {
-        let descriptor = super::build_descriptor(&props.switch, &props.state);
-        let label = descriptor.label().to_string();
-        let attributes = descriptor.themed_attributes();
-        let props_object = build_props_object(attributes);
-        create_element("span", props_object, &[JsValue::from_str(&label)])
+        let (context, _descriptor, snapshot) = descriptor_with_context(
+            "rustic_ui_material::switch::react::ReactSwitch",
+            &props.switch,
+            &props.state,
+        );
+        let state_handle = Rc::new(RefCell::new(props.state.clone()));
+        instrument_render(&props.switch.telemetry, context, || {
+            let label = snapshot.label.clone();
+            let attributes = snapshot.themed_attributes.clone();
+            let handlers = handlers(props, Rc::clone(&state_handle));
+            let props_object = build_props_object(attributes, &handlers);
+            create_element("span", props_object, &[JsValue::from_str(&label)])
+        })
     }
 }
-
 #[cfg(feature = "yew")]
 pub mod yew {
     //! Yew adapter leveraging `#[function_component]` for idiomatic usage.
     use super::*;
+    use std::{cell::RefCell, rc::Rc};
+    use yew::events::{FocusEvent, KeyboardEvent, MouseEvent};
     use yew::prelude::*;
     use yew::virtual_dom::VNode;
 
@@ -203,30 +968,172 @@ pub mod yew {
         pub switch: SwitchProps,
         /// Headless state providing accessibility metadata.
         pub state: SwitchState,
+        /// Optional change callback invoked with [`SwitchChangeEvent`].
+        #[prop_or_default]
+        pub on_change: Option<Callback<SwitchChangeEvent>>,
+        /// Optional focus callback invoked when the switch gains focus.
+        #[prop_or_default]
+        pub on_focus: Option<Callback<SwitchFocusEvent>>,
+        /// Optional blur callback invoked when the switch loses focus.
+        #[prop_or_default]
+        pub on_blur: Option<Callback<SwitchFocusEvent>>,
+        /// Optional keyboard callback invoked with normalized control keys.
+        #[prop_or_default]
+        pub on_key: Option<Callback<SwitchKeyEvent>>,
+        /// Optional telemetry delegate invoked with structured payloads.
+        #[prop_or_default]
+        pub telemetry_delegate: Option<Callback<SwitchTelemetryEvent>>,
     }
 
     /// Switch rendered inside Yew applications.
     #[function_component(YewSwitch)]
     pub fn yew_switch(props: &YewSwitchProps) -> Html {
-        let descriptor = super::build_descriptor(&props.switch, &props.state);
-        let label = descriptor.label().to_string();
-        let attrs = descriptor.themed_attributes();
-        let mut node = html! { <span>{label}</span> };
-        if let VNode::VTag(ref mut tag) = node {
-            for (key, value) in attrs {
-                tag.add_attribute(key, value);
+        let (context, _descriptor, snapshot) = descriptor_with_context(
+            "rustic_ui_material::switch::yew::YewSwitch",
+            &props.switch,
+            &props.state,
+        );
+        let state_handle = Rc::new(RefCell::new(props.state.clone()));
+        instrument_render(&props.switch.telemetry, context, || {
+            let label = snapshot.label.clone();
+            let attrs = snapshot.themed_attributes.clone();
+            let change_handler = {
+                let on_change = props.on_change.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                Callback::from(move |_event: MouseEvent| {
+                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                        Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                            as Box<dyn FnMut(SwitchTelemetryEvent)>
+                    });
+                    let mut change_runner = on_change.clone().map(|callback| {
+                        Box::new(move |event: SwitchChangeEvent| callback.emit(event))
+                            as Box<dyn FnMut(SwitchChangeEvent)>
+                    });
+                    let telemetry_ref = telemetry_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                    let change_ref = change_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
+                    let mut state = state.borrow_mut();
+                    dispatch_change_event(&switch_props, &mut state, telemetry_ref, change_ref);
+                })
+            };
+            let focus_handler = {
+                let on_focus = props.on_focus.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                Callback::from(move |_event: FocusEvent| {
+                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                        Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                            as Box<dyn FnMut(SwitchTelemetryEvent)>
+                    });
+                    let mut focus_runner = on_focus.clone().map(|callback| {
+                        Box::new(move |event: SwitchFocusEvent| callback.emit(event))
+                            as Box<dyn FnMut(SwitchFocusEvent)>
+                    });
+                    let telemetry_ref = telemetry_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                    let focus_ref = focus_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
+                    let mut state = state.borrow_mut();
+                    dispatch_focus_event(&switch_props, &mut state, true, telemetry_ref, focus_ref);
+                })
+            };
+            let blur_handler = {
+                let on_blur = props.on_blur.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                Callback::from(move |_event: FocusEvent| {
+                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                        Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                            as Box<dyn FnMut(SwitchTelemetryEvent)>
+                    });
+                    let mut blur_runner = on_blur.clone().map(|callback| {
+                        Box::new(move |event: SwitchFocusEvent| callback.emit(event))
+                            as Box<dyn FnMut(SwitchFocusEvent)>
+                    });
+                    let telemetry_ref = telemetry_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                    let blur_ref = blur_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
+                    let mut state = state.borrow_mut();
+                    dispatch_focus_event(&switch_props, &mut state, false, telemetry_ref, blur_ref);
+                })
+            };
+            let key_handler = {
+                let on_key = props.on_key.clone();
+                let on_change = props.on_change.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                Callback::from(move |event: KeyboardEvent| {
+                    if let Some(control) = control_key_from_str(event.key().as_str()) {
+                        event.prevent_default();
+                        let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                            Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                                as Box<dyn FnMut(SwitchTelemetryEvent)>
+                        });
+                        let mut key_runner = on_key.clone().map(|callback| {
+                            Box::new(move |event: SwitchKeyEvent| callback.emit(event))
+                                as Box<dyn FnMut(SwitchKeyEvent)>
+                        });
+                        let mut change_runner = on_change.clone().map(|callback| {
+                            Box::new(move |event: SwitchChangeEvent| callback.emit(event))
+                                as Box<dyn FnMut(SwitchChangeEvent)>
+                        });
+                        let telemetry_ref = telemetry_runner
+                            .as_mut()
+                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                        let key_ref = key_runner
+                            .as_mut()
+                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchKeyEvent));
+                        let change_ref = change_runner
+                            .as_mut()
+                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
+                        let mut state = state.borrow_mut();
+                        dispatch_key_event(
+                            &switch_props,
+                            &mut state,
+                            control,
+                            telemetry_ref,
+                            key_ref,
+                            change_ref,
+                        );
+                    }
+                })
+            };
+
+            let mut node = html! { <span>{label}</span> };
+            if let VNode::VTag(ref mut tag) = node {
+                for (key, value) in attrs {
+                    tag.add_attribute(key, value);
+                }
+                tag.add_listener(change_handler);
+                tag.add_listener(focus_handler);
+                tag.add_listener(blur_handler);
+                tag.add_listener(key_handler);
             }
-        }
-        node
+            node
+        })
     }
 }
-
 #[cfg(feature = "leptos")]
 pub mod leptos {
     //! Leptos adapter returning a [`leptos::View`] that hydrates cleanly across
     //! server and client renders.
     use super::*;
+    use leptos::ev::{FocusEvent, KeyboardEvent, MouseEvent};
     use leptos::prelude::*;
+    use std::{cell::RefCell, rc::Rc};
 
     /// Properties accepted by [`LeptosSwitch`].
     #[derive(Clone)]
@@ -235,77 +1142,176 @@ pub mod leptos {
         pub switch: SwitchProps,
         /// Headless state providing ARIA metadata.
         pub state: SwitchState,
+        /// Optional change callback emitted when toggles occur.
+        pub on_change: Option<Rc<dyn Fn(SwitchChangeEvent)>>,
+        /// Optional focus callback emitted when focus is gained.
+        pub on_focus: Option<Rc<dyn Fn(SwitchFocusEvent)>>,
+        /// Optional blur callback emitted when focus is lost.
+        pub on_blur: Option<Rc<dyn Fn(SwitchFocusEvent)>>,
+        /// Optional key callback emitted with normalized control keys.
+        pub on_key: Option<Rc<dyn Fn(SwitchKeyEvent)>>,
+        /// Optional telemetry delegate invoked with structured payloads.
+        pub telemetry_delegate: Option<Rc<dyn Fn(SwitchTelemetryEvent)>>,
     }
 
     #[component]
     pub fn LeptosSwitch(props: LeptosSwitchProps) -> impl IntoView {
-        let descriptor = super::build_descriptor(&props.switch, &props.state);
-        let label = descriptor.label().to_string();
-        let mut element = leptos::html::span();
-        let mut role_present = false;
-        let mut aria_checked_present = false;
-        let mut tabindex_present = false;
-        let mut data_on_present = false;
-        let mut data_focus_visible_present = false;
+        let (context, _descriptor, snapshot) = descriptor_with_context(
+            "rustic_ui_material::switch::leptos::LeptosSwitch",
+            &props.switch,
+            &props.state,
+        );
+        let state_handle = Rc::new(RefCell::new(props.state.clone()));
+        instrument_render(&props.switch.telemetry, context, || {
+            let label = snapshot.label.clone();
+            let class = snapshot.class.clone();
+            let role = snapshot.role.clone();
+            let aria_checked = snapshot.aria_checked.clone();
+            let aria_disabled = snapshot.aria_disabled.clone();
+            let tabindex = snapshot.tabindex.clone();
+            let data_on = snapshot.data_on.clone();
+            let data_focus_visible = snapshot.data_focus_visible.clone();
+            let on_click = {
+                let on_change = props.on_change.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_event: MouseEvent| {
+                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                        Box::new(move |event: SwitchTelemetryEvent| delegate(event))
+                            as Box<dyn FnMut(SwitchTelemetryEvent)>
+                    });
+                    let mut change_runner = on_change.clone().map(|callback| {
+                        Box::new(move |event: SwitchChangeEvent| callback(event))
+                            as Box<dyn FnMut(SwitchChangeEvent)>
+                    });
+                    let telemetry_ref = telemetry_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                    let change_ref = change_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
+                    let mut state = state.borrow_mut();
+                    dispatch_change_event(&switch_props, &mut state, telemetry_ref, change_ref);
+                }
+            };
+            let on_focus = {
+                let on_focus = props.on_focus.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_event: FocusEvent| {
+                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                        Box::new(move |event: SwitchTelemetryEvent| delegate(event))
+                            as Box<dyn FnMut(SwitchTelemetryEvent)>
+                    });
+                    let mut focus_runner = on_focus.clone().map(|callback| {
+                        Box::new(move |event: SwitchFocusEvent| callback(event))
+                            as Box<dyn FnMut(SwitchFocusEvent)>
+                    });
+                    let telemetry_ref = telemetry_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                    let focus_ref = focus_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
+                    let mut state = state.borrow_mut();
+                    dispatch_focus_event(&switch_props, &mut state, true, telemetry_ref, focus_ref);
+                }
+            };
+            let on_blur = {
+                let on_blur = props.on_blur.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_event: FocusEvent| {
+                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                        Box::new(move |event: SwitchTelemetryEvent| delegate(event))
+                            as Box<dyn FnMut(SwitchTelemetryEvent)>
+                    });
+                    let mut blur_runner = on_blur.clone().map(|callback| {
+                        Box::new(move |event: SwitchFocusEvent| callback(event))
+                            as Box<dyn FnMut(SwitchFocusEvent)>
+                    });
+                    let telemetry_ref = telemetry_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                    let blur_ref = blur_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
+                    let mut state = state.borrow_mut();
+                    dispatch_focus_event(&switch_props, &mut state, false, telemetry_ref, blur_ref);
+                }
+            };
+            let on_key_down = {
+                let on_key = props.on_key.clone();
+                let on_change = props.on_change.clone();
+                let telemetry = props.telemetry_delegate.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |event: KeyboardEvent| {
+                    if let Some(control) = control_key_from_str(event.key().as_str()) {
+                        event.prevent_default();
+                        let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                            Box::new(move |event: SwitchTelemetryEvent| delegate(event))
+                                as Box<dyn FnMut(SwitchTelemetryEvent)>
+                        });
+                        let mut key_runner = on_key.clone().map(|callback| {
+                            Box::new(move |event: SwitchKeyEvent| callback(event))
+                                as Box<dyn FnMut(SwitchKeyEvent)>
+                        });
+                        let mut change_runner = on_change.clone().map(|callback| {
+                            Box::new(move |event: SwitchChangeEvent| callback(event))
+                                as Box<dyn FnMut(SwitchChangeEvent)>
+                        });
+                        let telemetry_ref = telemetry_runner
+                            .as_mut()
+                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                        let key_ref = key_runner
+                            .as_mut()
+                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchKeyEvent));
+                        let change_ref = change_runner
+                            .as_mut()
+                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
+                        let mut state = state.borrow_mut();
+                        dispatch_key_event(
+                            &switch_props,
+                            &mut state,
+                            control,
+                            telemetry_ref,
+                            key_ref,
+                            change_ref,
+                        );
+                    }
+                }
+            };
 
-        for (key, value) in descriptor.themed_attributes() {
-            match key.as_str() {
-                "class" => {
-                    // Preserve class ordering so Leptos hydration mirrors SSR output.
-                    element = element.class(value);
-                }
-                "role" => {
-                    role_present = true;
-                    element = element.attr(key, value);
-                }
-                "aria-checked" => {
-                    aria_checked_present = true;
-                    element = element.attr(key, value);
-                }
-                "tabindex" => {
-                    tabindex_present = true;
-                    element = element.attr(key, value);
-                }
-                "data-on" => {
-                    data_on_present = true;
-                    element = element.attr(key, value);
-                }
-                "data-focus-visible" => {
-                    data_focus_visible_present = true;
-                    element = element.attr(key, value);
-                }
-                _ => {
-                    element = element.attr(key, value);
-                }
+            leptos::view! {
+                leptos::html::span()
+                    .class(class)
+                    .attr("role", role)
+                    .attr("aria-checked", aria_checked)
+                    .attr("tabindex", tabindex)
+                    .attr("data-on", data_on)
+                    .attr("data-focus-visible", data_focus_visible)
+                    .attr_optional("aria-disabled", aria_disabled)
+                    .on(ev::click, on_click)
+                    .on(ev::focus, on_focus)
+                    .on(ev::blur, on_blur)
+                    .on(ev::keydown, on_key_down)
+                    .child(label)
             }
-        }
-
-        if !role_present {
-            element = element.attr("role", "switch");
-        }
-        if !aria_checked_present {
-            element = element.attr("aria-checked", "false");
-        }
-        if !tabindex_present {
-            element = element.attr("tabindex", "0");
-        }
-        if !data_on_present {
-            element = element.attr("data-on", "false");
-        }
-        if !data_focus_visible_present {
-            element = element.attr("data-focus-visible", "false");
-        }
-
-        element.child(label).into_view()
+        })
     }
 }
-
 #[cfg(feature = "dioxus")]
 pub mod dioxus {
     //! Dioxus adapter built with `rsx!` for idiomatic usage inside Dioxus
     //! applications.
     use super::*;
+    use dioxus::events::{FocusEvent, KeyboardEvent, MouseEvent};
     use dioxus::prelude::*;
+    use std::{cell::RefCell, rc::Rc};
 
     /// Properties accepted by [`DioxusSwitch`].
     #[derive(Props, Clone, PartialEq)]
@@ -314,59 +1320,173 @@ pub mod dioxus {
         pub switch: SwitchProps,
         /// Headless state providing ARIA metadata.
         pub state: SwitchState,
+        /// Optional change callback emitted when toggles occur.
+        #[props(default = None)]
+        pub on_change: Option<Rc<dyn Fn(SwitchChangeEvent)>>,
+        /// Optional focus callback emitted when focus is gained.
+        #[props(default = None)]
+        pub on_focus: Option<Rc<dyn Fn(SwitchFocusEvent)>>,
+        /// Optional blur callback emitted when focus is lost.
+        #[props(default = None)]
+        pub on_blur: Option<Rc<dyn Fn(SwitchFocusEvent)>>,
+        /// Optional key callback emitted with normalized control keys.
+        #[props(default = None)]
+        pub on_key: Option<Rc<dyn Fn(SwitchKeyEvent)>>,
+        /// Optional telemetry delegate invoked with structured payloads.
+        #[props(default = None)]
+        pub telemetry_delegate: Option<Rc<dyn Fn(SwitchTelemetryEvent)>>,
     }
 
     /// Switch rendered as a Dioxus component.
     pub fn DioxusSwitch(cx: Scope<DioxusSwitchProps>) -> Element {
-        let descriptor = super::build_descriptor(&cx.props().switch, &cx.props().state);
-        let label = descriptor.label().to_string();
-        let mut class = String::new();
-        let mut role = None;
-        let mut aria_checked = None;
-        let mut aria_disabled = None;
-        let mut tabindex = None;
-        let mut data_on = None;
-        let mut data_focus_visible = None;
+        let props = cx.props();
+        let (context, _descriptor, snapshot) = descriptor_with_context(
+            "rustic_ui_material::switch::dioxus::DioxusSwitch",
+            &props.switch,
+            &props.state,
+        );
+        let state_handle = Rc::new(RefCell::new(props.state.clone()));
+        instrument_render(&props.switch.telemetry, context, || {
+            let label = snapshot.label.clone();
+            let class = snapshot.class.clone();
+            let role = snapshot.role.clone();
+            let aria_checked = snapshot.aria_checked.clone();
+            let aria_disabled = snapshot.aria_disabled.clone();
+            let tabindex = snapshot.tabindex.clone();
+            let data_on = snapshot.data_on.clone();
+            let data_focus_visible = snapshot.data_focus_visible.clone();
+            let onclick = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_change = props.on_change.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_event: MouseEvent| {
+                    let change = {
+                        let state = state.borrow();
+                        build_change_event(&switch_props, &state)
+                    };
+                    if let Some(delegate) = &telemetry {
+                        delegate(SwitchTelemetryEvent::Change(change.clone()));
+                    }
+                    if let Some(cb) = &on_change {
+                        cb(change.clone());
+                    }
+                    {
+                        let mut state = state.borrow_mut();
+                        state.toggle(|_| {});
+                    }
+                }
+            };
+            let on_focus = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_focus = props.on_focus.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_event: FocusEvent| {
+                    let focus = {
+                        let state = state.borrow();
+                        build_focus_event(&switch_props, &state, true)
+                    };
+                    if let Some(delegate) = &telemetry {
+                        delegate(SwitchTelemetryEvent::Focus(focus.clone()));
+                    }
+                    if let Some(cb) = &on_focus {
+                        cb(focus.clone());
+                    }
+                    {
+                        let mut state = state.borrow_mut();
+                        state.focus();
+                    }
+                }
+            };
+            let on_blur = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_blur = props.on_blur.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_event: FocusEvent| {
+                    let blur = {
+                        let state = state.borrow();
+                        build_focus_event(&switch_props, &state, false)
+                    };
+                    if let Some(delegate) = &telemetry {
+                        delegate(SwitchTelemetryEvent::Blur(blur.clone()));
+                    }
+                    if let Some(cb) = &on_blur {
+                        cb(blur.clone());
+                    }
+                    {
+                        let mut state = state.borrow_mut();
+                        state.blur();
+                    }
+                }
+            };
+            let on_key = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_key = props.on_key.clone();
+                let on_change = props.on_change.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |event: KeyboardEvent| {
+                    let key = match event.data.key() {
+                        Key::Space | Key::Character(ref ch) if ch == " " => Some(" ".to_string()),
+                        Key::Enter => Some("Enter".to_string()),
+                        _ => None,
+                    };
+                    if let Some(name) = key.as_deref() {
+                        if let Some(control) = control_key_from_str(name) {
+                            let (key_event, change) = {
+                                let state = state.borrow();
+                                (
+                                    build_key_event(&switch_props, &state, control),
+                                    build_change_event(&switch_props, &state),
+                                )
+                            };
+                            if let Some(delegate) = &telemetry {
+                                delegate(SwitchTelemetryEvent::Key(key_event.clone()));
+                                delegate(SwitchTelemetryEvent::Change(change.clone()));
+                            }
+                            if let Some(cb) = &on_key {
+                                cb(key_event.clone());
+                            }
+                            if let Some(change_cb) = &on_change {
+                                change_cb(change.clone());
+                            }
+                            {
+                                let mut state = state.borrow_mut();
+                                state.on_key(control, |_| {});
+                            }
+                        }
+                    }
+                }
+            };
 
-        for (key, value) in descriptor.themed_attributes() {
-            match key.as_str() {
-                "class" => class = value,
-                "role" => role = Some(value),
-                "aria-checked" => aria_checked = Some(value),
-                "aria-disabled" => aria_disabled = Some(value),
-                "tabindex" => tabindex = Some(value),
-                "data-on" => data_on = Some(value),
-                "data-focus-visible" => data_focus_visible = Some(value),
-                _ => {}
-            }
-        }
-
-        let role = role.unwrap_or_default();
-        let aria_checked = aria_checked.unwrap_or_else(|| String::from("false"));
-        let tabindex = tabindex.unwrap_or_else(|| String::from("0"));
-        let data_on = data_on.unwrap_or_else(|| String::from("false"));
-        let data_focus_visible = data_focus_visible.unwrap_or_else(|| String::from("false"));
-
-        cx.render(rsx! {
-            span {
-                class: class,
-                role: role,
-                aria_checked: aria_checked,
-                aria_disabled: aria_disabled,
-                tabindex: tabindex,
-                data_on: data_on,
-                data_focus_visible: data_focus_visible,
-                {label}
-            }
+            cx.render(rsx! {
+                span {
+                    class: class,
+                    role: role,
+                    aria_checked: aria_checked,
+                    aria_disabled: aria_disabled,
+                    tabindex: tabindex,
+                    data_on: data_on,
+                    data_focus_visible: data_focus_visible,
+                    onclick: onclick,
+                    onfocus: on_focus,
+                    onblur: on_blur,
+                    onkeydown: on_key,
+                    {label}
+                }
+            })
         })
     }
 }
-
 #[cfg(feature = "sycamore")]
 pub mod sycamore {
     //! Sycamore adapter yielding a [`Template`] for reactive dashboards.
     use super::*;
+    use std::{cell::RefCell, rc::Rc};
     use sycamore::prelude::*;
+    use sycamore::web::html::event::KeyboardEvent;
 
     /// Alias mirroring Sycamore's view representation.
     pub type Template<G> = View<G>;
@@ -378,65 +1498,237 @@ pub mod sycamore {
         pub switch: SwitchProps,
         /// Headless state providing ARIA metadata.
         pub state: SwitchState,
+        /// Optional change callback emitted when toggles occur.
+        pub on_change: Option<Rc<dyn Fn(SwitchChangeEvent)>>,
+        /// Optional focus callback emitted when focus is gained.
+        pub on_focus: Option<Rc<dyn Fn(SwitchFocusEvent)>>,
+        /// Optional blur callback emitted when focus is lost.
+        pub on_blur: Option<Rc<dyn Fn(SwitchFocusEvent)>>,
+        /// Optional key callback emitted with normalized control keys.
+        pub on_key: Option<Rc<dyn Fn(SwitchKeyEvent)>>,
+        /// Optional telemetry delegate invoked with structured payloads.
+        pub telemetry_delegate: Option<Rc<dyn Fn(SwitchTelemetryEvent)>>,
     }
 
     /// Switch rendered within a Sycamore reactive scope.
     #[component]
     pub fn SycamoreSwitch<G: Html>(cx: Scope, props: SycamoreSwitchProps) -> Template<G> {
-        let descriptor = super::build_descriptor(&props.switch, &props.state);
-        let label = descriptor.label().to_string();
-        let mut class = String::new();
-        let mut role = None;
-        let mut aria_checked = None;
-        let mut aria_disabled = None;
-        let mut tabindex = None;
-        let mut data_on = None;
-        let mut data_focus_visible = None;
+        let (context, _descriptor, snapshot) = descriptor_with_context(
+            "rustic_ui_material::switch::sycamore::SycamoreSwitch",
+            &props.switch,
+            &props.state,
+        );
+        let state_handle = Rc::new(RefCell::new(props.state.clone()));
+        instrument_render(&props.switch.telemetry, context, || {
+            let label = snapshot.label.clone();
+            let class = snapshot.class.clone();
+            let role = snapshot.role.clone();
+            let aria_checked = snapshot.aria_checked.clone();
+            let aria_disabled = snapshot.aria_disabled.clone();
+            let tabindex = snapshot.tabindex.clone();
+            let data_on = snapshot.data_on.clone();
+            let data_focus_visible = snapshot.data_focus_visible.clone();
+            let on_click = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_change = props.on_change.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_| {
+                    let change = {
+                        let state = state.borrow();
+                        build_change_event(&switch_props, &state)
+                    };
+                    if let Some(delegate) = &telemetry {
+                        delegate(SwitchTelemetryEvent::Change(change.clone()));
+                    }
+                    if let Some(cb) = &on_change {
+                        cb(change.clone());
+                    }
+                    {
+                        let mut state = state.borrow_mut();
+                        state.toggle(|_| {});
+                    }
+                }
+            };
+            let on_focus = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_focus = props.on_focus.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_| {
+                    let focus = {
+                        let state = state.borrow();
+                        build_focus_event(&switch_props, &state, true)
+                    };
+                    if let Some(delegate) = &telemetry {
+                        delegate(SwitchTelemetryEvent::Focus(focus.clone()));
+                    }
+                    if let Some(cb) = &on_focus {
+                        cb(focus.clone());
+                    }
+                    {
+                        let mut state = state.borrow_mut();
+                        state.focus();
+                    }
+                }
+            };
+            let on_blur = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_blur = props.on_blur.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |_| {
+                    let blur = {
+                        let state = state.borrow();
+                        build_focus_event(&switch_props, &state, false)
+                    };
+                    if let Some(delegate) = &telemetry {
+                        delegate(SwitchTelemetryEvent::Blur(blur.clone()));
+                    }
+                    if let Some(cb) = &on_blur {
+                        cb(blur.clone());
+                    }
+                    {
+                        let mut state = state.borrow_mut();
+                        state.blur();
+                    }
+                }
+            };
+            let on_key = {
+                let telemetry = props.telemetry_delegate.clone();
+                let on_key = props.on_key.clone();
+                let on_change = props.on_change.clone();
+                let switch_props = props.switch.clone();
+                let state = Rc::clone(&state_handle);
+                move |event: KeyboardEvent| {
+                    let key = event.key();
+                    if let Some(control) = control_key_from_str(&key) {
+                        let (key_event, change) = {
+                            let state = state.borrow();
+                            (
+                                build_key_event(&switch_props, &state, control),
+                                build_change_event(&switch_props, &state),
+                            )
+                        };
+                        if let Some(delegate) = &telemetry {
+                            delegate(SwitchTelemetryEvent::Key(key_event.clone()));
+                            delegate(SwitchTelemetryEvent::Change(change.clone()));
+                        }
+                        if let Some(cb) = &on_key {
+                            cb(key_event.clone());
+                        }
+                        if let Some(change_cb) = &on_change {
+                            change_cb(change.clone());
+                        }
+                        {
+                            let mut state = state.borrow_mut();
+                            state.on_key(control, |_| {});
+                        }
+                    }
+                }
+            };
 
-        for (key, value) in descriptor.themed_attributes() {
-            match key.as_str() {
-                "class" => class = value,
-                "role" => role = Some(value),
-                "aria-checked" => aria_checked = Some(value),
-                "aria-disabled" => aria_disabled = Some(value),
-                "tabindex" => tabindex = Some(value),
-                "data-on" => data_on = Some(value),
-                "data-focus-visible" => data_focus_visible = Some(value),
-                _ => {}
+            view! { cx,
+                span(
+                    class=class,
+                    role=role,
+                    aria_checked=aria_checked,
+                    aria_disabled=aria_disabled,
+                    tabindex=tabindex,
+                    data_on=data_on,
+                    data_focus_visible=data_focus_visible,
+                    on:click=on_click,
+                    on:focus=on_focus,
+                    on:blur=on_blur,
+                    on:keydown=on_key,
+                ) { (label) }
             }
-        }
-
-        let role = role.unwrap_or_default();
-        let aria_checked = aria_checked.unwrap_or_else(|| String::from("false"));
-        let tabindex = tabindex.unwrap_or_else(|| String::from("0"));
-        let data_on = data_on.unwrap_or_else(|| String::from("false"));
-        let data_focus_visible = data_focus_visible.unwrap_or_else(|| String::from("false"));
-
-        view! { cx,
-            span(
-                class=class,
-                role=role,
-                aria_checked=aria_checked,
-                aria_disabled=aria_disabled,
-                tabindex=tabindex,
-                data_on=data_on,
-                data_focus_visible=data_focus_visible,
-            ) { (label) }
-        }
+        })
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn themed_attributes_include_role() {
-        let state = SwitchState::uncontrolled(false, true);
-        let descriptor = build_descriptor(&SwitchProps::new("Notifications"), &state);
-        assert!(descriptor
-            .aria_attributes()
-            .any(|(k, v)| k == "role" && v == "switch"));
+    fn dispatch_change_updates_state_and_telemetry() {
+        let mut props = SwitchProps::new("Notifications");
+        props.telemetry.analytics_id = Some("switch.analytics".into());
+        let mut state = SwitchState::uncontrolled(false, false);
+        let mut telemetry_events = Vec::new();
+        let mut change_events = Vec::new();
+        {
+            let mut telemetry = |event: SwitchTelemetryEvent| telemetry_events.push(event);
+            let mut change = |event: SwitchChangeEvent| change_events.push(event);
+            dispatch_change_event(&props, &mut state, Some(&mut telemetry), Some(&mut change));
+        }
+        assert!(state.on());
+        assert_eq!(telemetry_events.len(), 1);
+        match &telemetry_events[0] {
+            SwitchTelemetryEvent::Change(change) => {
+                assert!(!change.previous);
+                assert!(change.next);
+                assert_eq!(change.analytics_id.as_deref(), Some("switch.analytics"));
+            }
+            other => panic!("unexpected telemetry event: {other:?}"),
+        }
+        assert_eq!(change_events.len(), 1);
+        assert!(change_events[0].next);
+    }
+
+    #[test]
+    fn dispatch_focus_tracks_focus_visibility_and_telemetry() {
+        let props = SwitchProps::new("Notifications");
+        let mut state = SwitchState::uncontrolled(false, false);
+        let mut telemetry_events = Vec::new();
+        let mut focus_events = Vec::new();
+        {
+            let mut telemetry = |event: SwitchTelemetryEvent| telemetry_events.push(event);
+            let mut focus = |event: SwitchFocusEvent| focus_events.push(event);
+            dispatch_focus_event(
+                &props,
+                &mut state,
+                true,
+                Some(&mut telemetry),
+                Some(&mut focus),
+            );
+        }
+        assert!(state.focus_visible());
+        assert_eq!(telemetry_events.len(), 1);
+        matches!(telemetry_events[0], SwitchTelemetryEvent::Focus(_));
+        assert_eq!(focus_events.len(), 1);
+        assert!(focus_events[0].focused);
+    }
+
+    #[test]
+    fn dispatch_key_emits_key_and_change_telemetry() {
+        let mut props = SwitchProps::new("Notifications");
+        let mut state = SwitchState::uncontrolled(false, false);
+        let mut telemetry_events = Vec::new();
+        let mut key_events = Vec::new();
+        let mut change_events = Vec::new();
+        {
+            let mut telemetry = |event: SwitchTelemetryEvent| telemetry_events.push(event);
+            let mut key = |event: SwitchKeyEvent| key_events.push(event);
+            let mut change = |event: SwitchChangeEvent| change_events.push(event);
+            dispatch_key_event(
+                &props,
+                &mut state,
+                ControlKey::Space,
+                Some(&mut telemetry),
+                Some(&mut key),
+                Some(&mut change),
+            );
+        }
+        assert!(state.on());
+        assert_eq!(telemetry_events.len(), 2);
+        assert!(matches!(telemetry_events[0], SwitchTelemetryEvent::Key(_)));
+        assert!(matches!(
+            telemetry_events[1],
+            SwitchTelemetryEvent::Change(_)
+        ));
+        assert_eq!(key_events.len(), 1);
+        assert_eq!(change_events.len(), 1);
     }
 
     #[test]

--- a/docs/src/pages/examples/selection-controls-telemetry.md
+++ b/docs/src/pages/examples/selection-controls-telemetry.md
@@ -1,10 +1,11 @@
 # Selection control telemetry walkthrough
 
 Enterprise dashboards can now treat RusticUI selection controls as rich telemetry
-producers. Every checkbox adapter shares the same render instrumentation: the
-adapter enters `instrument_render`, emits a `TelemetryContext` describing the
-component, analytics, automation identifiers, and descriptor snapshot, and only
-then renders the DOM node.【F:crates/rustic-ui-material/src/checkbox.rs†L928-L1012】【F:crates/rustic-ui-material/src/checkbox.rs†L1126-L1228】【F:crates/rustic-ui-material/src/telemetry.rs†L22-L78】【F:crates/rustic-ui-material/src/telemetry.rs†L132-L189】
+producers. Every checkbox **and switch** adapter shares the same render
+instrumentation: the adapter enters `instrument_render`, emits a
+`TelemetryContext` describing the component, analytics, automation identifiers,
+and descriptor snapshot, and only then renders the DOM
+node.【F:crates/rustic-ui-material/src/checkbox.rs†L928-L1012】【F:crates/rustic-ui-material/src/checkbox.rs†L1126-L1228】【F:crates/rustic-ui-material/src/switch.rs†L1031-L1150】【F:crates/rustic-ui-material/src/switch.rs†L1325-L1420】【F:crates/rustic-ui-material/src/telemetry.rs†L22-L78】【F:crates/rustic-ui-material/src/telemetry.rs†L132-L189】
 
 The sections below demonstrate how to seed shared hooks, attach adapter-specific
 telemetry delegates, and decode the resulting payloads across frameworks.
@@ -58,48 +59,80 @@ adapters.【F:crates/rustic-ui-material/src/telemetry.rs†L132-L189】
 ## Yew example: register a telemetry delegate
 
 Yew adapters accept idiomatic `Callback<T>` handlers and forward
-`CheckboxTelemetryEvent` payloads to the telemetry delegate **before** invoking
-user callbacks, guaranteeing deterministic analytics ordering.【F:crates/rustic-ui-material/src/checkbox.rs†L928-L1120】【F:crates/rustic-ui-material/tests/checkbox_adapters.rs†L17-L74】【F:crates/rustic-ui-material/tests/checkbox_adapters.rs†L210-L299】
+`CheckboxTelemetryEvent` and `SwitchTelemetryEvent` payloads to the telemetry
+delegate **before** invoking user callbacks, guaranteeing deterministic
+analytics ordering.【F:crates/rustic-ui-material/src/checkbox.rs†L928-L1120】【F:crates/rustic-ui-material/src/switch.rs†L883-L1042】【F:crates/rustic-ui-material/tests/checkbox_adapters.rs†L17-L74】【F:crates/rustic-ui-material/tests/switch_adapters.rs†L1-L38】
 
 ```rust
-use rustic_ui_headless::checkbox::CheckboxState;
-use rustic_ui_material::checkbox::{
-    CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
-    yew::{YewCheckbox, YewCheckboxProps},
+use rustic_ui_headless::{checkbox::CheckboxState, switch::SwitchState};
+use rustic_ui_material::{
+    checkbox::{
+        CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
+        yew::{YewCheckbox, YewCheckboxProps},
+    },
+    switch::{
+        SwitchProps, SwitchTelemetryEvent,
+        yew::{YewSwitch, YewSwitchProps},
+    },
 };
 use yew::prelude::*;
 
 #[function_component(MarketingOptIn)]
 fn marketing_opt_in() -> Html {
     let state = CheckboxState::uncontrolled(false, false);
-    let telemetry_log = use_state(|| Vec::new());
+    let telemetry_log = use_state(|| Vec::<String>::new());
 
-    let delegate = {
+    let checkbox_delegate = {
         let telemetry_log = telemetry_log.clone();
         Callback::from(move |event: CheckboxTelemetryEvent| {
             telemetry_log.set({
                 let mut next = (*telemetry_log).clone();
-                next.push(event);
+                next.push(format!("checkbox::{event:?}"));
+                next
+            });
+        })
+    };
+
+    let switch_delegate = {
+        let telemetry_log = telemetry_log.clone();
+        Callback::from(move |event: SwitchTelemetryEvent| {
+            telemetry_log.set({
+                let mut next = (*telemetry_log).clone();
+                next.push(format!("switch::{event:?}"));
                 next
             });
         })
     };
 
     html! {
-        <YewCheckbox
-            checkbox={CheckboxProps {
-                label: "Email updates".into(),
-                telemetry: analytics_hooks("marketing.opt_in"),
-            }}
-            state={state}
-            telemetry_delegate={Some(delegate)}
-            on_change={Some(Callback::from(|event: CheckboxChangeEvent| {
-                metrics::increment!("marketing.opt_in.change", "state" => format!("{:?}", event.next));
-            }))}
-            on_focus={None}
-            on_blur={None}
-            on_key={None}
-        />
+        <>
+            <YewCheckbox
+                checkbox={CheckboxProps {
+                    label: "Email updates".into(),
+                    telemetry: analytics_hooks("marketing.opt_in"),
+                }}
+                state={state.clone()}
+                telemetry_delegate={Some(checkbox_delegate.clone())}
+                on_change={Some(Callback::from(|event: CheckboxChangeEvent| {
+                    metrics::increment!("marketing.opt_in.change", "state" => format!("{:?}", event.next));
+                }))}
+                on_focus={None}
+                on_blur={None}
+                on_key={None}
+            />
+            <YewSwitch
+                switch={SwitchProps {
+                    label: "Push alerts".into(),
+                    telemetry: analytics_hooks("marketing.opt_in.switch"),
+                }}
+                state={SwitchState::uncontrolled(false, false)}
+                telemetry_delegate={Some(switch_delegate)}
+                on_change={None}
+                on_focus={None}
+                on_blur={None}
+                on_key={None}
+            />
+        </>
     }
 }
 ```
@@ -112,19 +145,26 @@ internal ordering.
 
 Leptos, Dioxus, and Sycamore share the same lifecycle: each closure emits the
 telemetry payload, then the consumer callback, and finally mutates the headless
-state machine. Pass an `Rc<dyn Fn(CheckboxTelemetryEvent)>` delegate to receive
-that stream.【F:crates/rustic-ui-material/src/checkbox.rs†L1126-L1228】【F:crates/rustic-ui-material/src/checkbox.rs†L1333-L1463】【F:crates/rustic-ui-material/src/checkbox.rs†L1548-L1662】
+state machine. Pass an `Rc<dyn Fn(CheckboxTelemetryEvent)>` or
+`Rc<dyn Fn(SwitchTelemetryEvent)>` delegate to receive that
+stream.【F:crates/rustic-ui-material/src/checkbox.rs†L1126-L1228】【F:crates/rustic-ui-material/src/checkbox.rs†L1333-L1463】【F:crates/rustic-ui-material/src/checkbox.rs†L1548-L1662】【F:crates/rustic-ui-material/src/switch.rs†L1044-L1323】
 
 ```rust
 use std::rc::Rc;
-use rustic_ui_headless::checkbox::CheckboxState;
-use rustic_ui_material::checkbox::{
-    CheckboxProps, CheckboxTelemetryEvent,
-    leptos::{LeptosCheckbox, LeptosCheckboxProps},
+use rustic_ui_headless::{checkbox::CheckboxState, switch::SwitchState};
+use rustic_ui_material::{
+    checkbox::{
+        CheckboxProps, CheckboxTelemetryEvent,
+        leptos::{LeptosCheckbox, LeptosCheckboxProps},
+    },
+    switch::{
+        SwitchProps, SwitchTelemetryEvent,
+        leptos::{LeptosSwitch, LeptosSwitchProps},
+    },
 };
 
 fn leptos_checkbox_view() -> impl leptos::IntoView {
-    let delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = Rc::new(|event| {
+    let checkbox_delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = Rc::new(|event| {
         match event {
             CheckboxTelemetryEvent::Change(change) => {
                 analytics::record("selection.change", change.analytics_id.clone());
@@ -135,7 +175,24 @@ fn leptos_checkbox_view() -> impl leptos::IntoView {
         }
     });
 
-    LeptosCheckbox(LeptosCheckboxProps {
+    let switch_delegate: Rc<dyn Fn(SwitchTelemetryEvent)> = Rc::new(|event| {
+        match event {
+            SwitchTelemetryEvent::Change(change) => {
+                analytics::record("selection.switch.change", change.analytics_id.clone());
+            }
+            SwitchTelemetryEvent::Focus(focus) => {
+                analytics::record("selection.switch.focus", focus.analytics_id.clone())
+            }
+            SwitchTelemetryEvent::Blur(blur) => {
+                analytics::record("selection.switch.blur", blur.analytics_id.clone())
+            }
+            SwitchTelemetryEvent::Key(key) => {
+                analytics::record("selection.switch.key", Some(format!("{:?}", key.key)))
+            }
+        }
+    });
+
+    let checkbox = LeptosCheckbox(LeptosCheckboxProps {
         checkbox: CheckboxProps {
             label: "SMS updates".into(),
             telemetry: analytics_hooks("marketing.opt_in"),
@@ -145,24 +202,42 @@ fn leptos_checkbox_view() -> impl leptos::IntoView {
         on_focus: None,
         on_blur: None,
         on_key: None,
-        telemetry_delegate: Some(delegate),
-    })
+        telemetry_delegate: Some(checkbox_delegate),
+    });
+
+    let switch = LeptosSwitch(LeptosSwitchProps {
+        switch: SwitchProps {
+            label: "Geo-fencing".into(),
+            telemetry: analytics_hooks("marketing.opt_in"),
+        },
+        state: SwitchState::uncontrolled(false, false),
+        on_change: None,
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(switch_delegate),
+    });
+
+    (checkbox, switch)
 }
 ```
 
-This pattern applies unchanged to `DioxusCheckboxProps` and
-`SycamoreCheckboxProps`, which both consume `Rc<dyn Fn(CheckboxTelemetryEvent)>`
-telemetry delegates.【F:crates/rustic-ui-material/src/checkbox.rs†L1333-L1463】【F:crates/rustic-ui-material/src/checkbox.rs†L1548-L1662】
+This pattern applies unchanged to `DioxusCheckboxProps`, `DioxusSwitchProps`,
+`SycamoreCheckboxProps`, and `SycamoreSwitchProps`, which all consume
+`Rc<dyn Fn(_TelemetryEvent)>` delegates with identical ordering
+guarantees.【F:crates/rustic-ui-material/src/checkbox.rs†L1333-L1463】【F:crates/rustic-ui-material/src/checkbox.rs†L1548-L1662】【F:crates/rustic-ui-material/src/switch.rs†L1152-L1323】
 
 ## React adapter integration
 
 React consumers receive a JavaScript object describing each telemetry payload.
 `kind` identifies the event (`"change"`, `"focus"`, `"blur"`, or `"key"`), and
 subsequent fields mirror the Rust structs. Register a single delegate to forward
-those events into your analytics provider.
+those events into your analytics provider for both checkboxes and
+switches.【F:crates/rustic-ui-material/src/checkbox.rs†L600-L831】【F:crates/rustic-ui-material/src/switch.rs†L697-L882】
 
 ```tsx
 import { ReactCheckbox } from 'rustic-ui-material/checkbox';
+import { ReactSwitch } from 'rustic-ui-material/switch';
 
 const telemetryDelegate = (event: any) => {
   switch (event.kind) {
@@ -186,16 +261,23 @@ const telemetryDelegate = (event: any) => {
   }
 };
 
-<ReactCheckbox
-  checkbox={checkboxPropsFromWasm}
-  state={checkboxStateFromWasm}
-  telemetry_delegate={telemetryDelegate}
-/>;
+<>
+  <ReactCheckbox
+    checkbox={checkboxPropsFromWasm}
+    state={checkboxStateFromWasm}
+    telemetry_delegate={telemetryDelegate}
+  />
+  <ReactSwitch
+    switch={switchPropsFromWasm}
+    state={switchStateFromWasm}
+    telemetry_delegate={telemetryDelegate}
+  />
+</>;
 ```
 
 The delegate signature matches the `Function` stored in
-`ReactCheckboxProps::telemetry_delegate`, and events are emitted before any user
-handlers run.【F:crates/rustic-ui-material/src/checkbox.rs†L600-L831】
+`ReactCheckboxProps::telemetry_delegate` and `ReactSwitchProps::telemetry_delegate`,
+and events are emitted before any user handlers run.【F:crates/rustic-ui-material/src/checkbox.rs†L600-L831】【F:crates/rustic-ui-material/src/switch.rs†L697-L882】
 
 `checkboxPropsFromWasm` and `checkboxStateFromWasm` represent the `CheckboxProps`
 and `CheckboxState` values exported by the wasm bundle; the React adapter expects


### PR DESCRIPTION
## Summary
- wire TelemetryHooks, structured change/focus/blur/key payloads, and external callbacks through every switch adapter while reusing descriptor metadata for hydration parity
- introduce reusable dispatch helpers that drive SwitchState mutations and validate them with unit tests to ensure telemetry delegates fire before consumer handlers
- refresh the selection control telemetry guide with switch-specific examples spanning Yew, Leptos, and React integrations

## Testing
- cargo test switch::tests --lib *(fails: leptos dependency expects `DynBindings` trait without enabling downstream feature support)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9c542d7c832e8eb3ef1b4c836ef6