### PR TITLE
Add Yew radio telemetry handlers and interaction tests

### DIFF
--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -96,6 +96,25 @@ pub struct RadioCommitEvent {
     pub label: String,
 }
 
+/// Canonical payload emitted for keyboard interactions across adapters.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RadioKeyEvent {
+    /// Normalised control key derived from the browser event.
+    pub key: ControlKey,
+    /// Previously selected index prior to the key interaction.
+    pub previous: Option<usize>,
+    /// Next index requested by the interaction (if any).
+    pub next: Option<usize>,
+    /// Whether the group was disabled while the event fired.
+    pub disabled: bool,
+    /// Analytics identifier mirrored from the descriptor, if present.
+    pub analytics_id: Option<String>,
+    /// Automation identifier mirrored from the descriptor, if present.
+    pub automation_id: Option<String>,
+    /// Human friendly label rendered beside the originating option.
+    pub label: String,
+}
+
 /// Unified telemetry event surfaced to React consumers.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RadioTelemetryEvent {
@@ -169,6 +188,38 @@ fn build_commit_event(
         analytics_id: option.analytics_id.clone(),
         automation_id: option.automation_id.clone(),
         label: option.label.clone(),
+    }
+}
+
+fn build_key_event(
+    option: &RadioOptionSnapshot,
+    key: ControlKey,
+    previous: Option<usize>,
+    next: Option<usize>,
+    disabled: bool,
+) -> RadioKeyEvent {
+    RadioKeyEvent {
+        key,
+        previous,
+        next,
+        disabled,
+        analytics_id: option.analytics_id.clone(),
+        automation_id: option.automation_id.clone(),
+        label: option.label.clone(),
+    }
+}
+
+fn control_key_from_str(key: &str) -> Option<ControlKey> {
+    match key {
+        " " | "Space" | "Spacebar" => Some(ControlKey::Space),
+        "Enter" => Some(ControlKey::Enter),
+        "ArrowUp" => Some(ControlKey::ArrowUp),
+        "ArrowDown" => Some(ControlKey::ArrowDown),
+        "ArrowLeft" => Some(ControlKey::ArrowLeft),
+        "ArrowRight" => Some(ControlKey::ArrowRight),
+        "Home" => Some(ControlKey::Home),
+        "End" => Some(ControlKey::End),
+        _ => None,
     }
 }
 
@@ -622,20 +673,6 @@ pub mod react {
                 && function_option_eq(&self.on_blur, &other.on_blur)
                 && function_option_eq(&self.on_key_down, &other.on_key_down)
                 && function_option_eq(&self.telemetry_delegate, &other.telemetry_delegate)
-        }
-    }
-
-    fn control_key_from_str(key: &str) -> Option<ControlKey> {
-        match key {
-            " " | "Space" | "Spacebar" => Some(ControlKey::Space),
-            "Enter" => Some(ControlKey::Enter),
-            "ArrowUp" => Some(ControlKey::ArrowUp),
-            "ArrowDown" => Some(ControlKey::ArrowDown),
-            "ArrowLeft" => Some(ControlKey::ArrowLeft),
-            "ArrowRight" => Some(ControlKey::ArrowRight),
-            "Home" => Some(ControlKey::Home),
-            "End" => Some(ControlKey::End),
-            _ => None,
         }
     }
 
@@ -1443,8 +1480,11 @@ pub mod react {
 pub mod yew {
     //! Yew adapter implemented with `#[function_component]` for idiomatic usage.
     use super::*;
+    use std::{cell::RefCell, rc::Rc};
+    use yew::events::{Event, FocusEvent, KeyboardEvent, MouseEvent};
+    use yew::html::{onblur, onchange, onclick, onfocus, onkeydown};
     use yew::prelude::*;
-    use yew::virtual_dom::VNode;
+    use yew::virtual_dom::{Listener, VNode};
 
     /// Properties accepted by [`YewRadioGroup`].
     #[derive(Properties, Clone, PartialEq)]
@@ -1456,9 +1496,358 @@ pub mod yew {
         /// Telemetry hooks applied around the Yew render lifecycle.
         #[prop_or_default]
         pub telemetry: TelemetryHooks,
+        /// Optional change callback invoked with [`RadioChangeEvent`].
+        #[prop_or_default]
+        pub on_change: Option<Callback<RadioChangeEvent>>,
+        /// Optional focus callback invoked when an option gains focus.
+        #[prop_or_default]
+        pub on_focus: Option<Callback<RadioFocusEvent>>,
+        /// Optional blur callback invoked when an option loses focus.
+        #[prop_or_default]
+        pub on_blur: Option<Callback<RadioFocusEvent>>,
+        /// Optional keyboard callback invoked with normalized key payloads.
+        #[prop_or_default]
+        pub on_key: Option<Callback<RadioKeyEvent>>,
+        /// Optional telemetry delegate receiving structured payloads.
+        #[prop_or_default]
+        pub telemetry_delegate: Option<Callback<RadioTelemetryEvent>>,
+    }
+
+    fn emit_telemetry(
+        delegate: &Option<Callback<RadioTelemetryEvent>>,
+        events: &[RadioTelemetryEvent],
+    ) {
+        if let Some(callback) = delegate {
+            for event in events {
+                callback.emit(event.clone());
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct YewOptionHandlers {
+        onclick: Rc<dyn Listener>,
+        onchange: Rc<dyn Listener>,
+        onfocus: Rc<dyn Listener>,
+        onblur: Rc<dyn Listener>,
+        onkeydown: Rc<dyn Listener>,
+    }
+
+    #[derive(Clone)]
+    struct YewOptionHandlerBuilder {
+        state: Rc<RefCell<RadioGroupState>>,
+        options: Rc<Vec<RadioOptionSnapshot>>,
+        on_change: Option<Callback<RadioChangeEvent>>,
+        on_focus: Option<Callback<RadioFocusEvent>>,
+        on_blur: Option<Callback<RadioFocusEvent>>,
+        on_key: Option<Callback<RadioKeyEvent>>,
+        telemetry_delegate: Option<Callback<RadioTelemetryEvent>>,
+    }
+
+    impl YewOptionHandlerBuilder {
+        fn new(
+            state: Rc<RefCell<RadioGroupState>>,
+            options: Rc<Vec<RadioOptionSnapshot>>,
+            on_change: Option<Callback<RadioChangeEvent>>,
+            on_focus: Option<Callback<RadioFocusEvent>>,
+            on_blur: Option<Callback<RadioFocusEvent>>,
+            on_key: Option<Callback<RadioKeyEvent>>,
+            telemetry_delegate: Option<Callback<RadioTelemetryEvent>>,
+        ) -> Self {
+            Self {
+                state,
+                options,
+                on_change,
+                on_focus,
+                on_blur,
+                on_key,
+                telemetry_delegate,
+            }
+        }
+
+        fn build(&self, index: usize) -> YewOptionHandlers {
+            let (onclick, onchange) = self.build_select_handlers(index);
+            let onfocus = self.build_focus_handler(index);
+            let onblur = self.build_blur_handler(index);
+            let onkeydown = self.build_key_handler(index);
+            YewOptionHandlers {
+                onclick,
+                onchange,
+                onfocus,
+                onblur,
+                onkeydown,
+            }
+        }
+
+        fn build_select_handlers(&self, index: usize) -> (Rc<dyn Listener>, Rc<dyn Listener>) {
+            let state = Rc::clone(&self.state);
+            let option = self.options[index].clone();
+            let telemetry = self.telemetry_delegate.clone();
+            let on_change = self.on_change.clone();
+
+            // Wrap the choreography in a single runner so both `onclick` and `onchange`
+            // listeners can delegate to the same logic without duplicating telemetry
+            // ordering. Automation pipelines rely on this deterministic sequence:
+            // 1. Capture analytics metadata before mutating any state.
+            // 2. Emit the `RadioChangeEvent` snapshot requested by the interaction.
+            // 3. Drive the shared [`RadioGroupState`] via [`RadioGroupState::select`].
+            // 4. Emit the post-mutation `RadioCommitEvent` snapshot.
+            // 5. Finally invoke user callbacks, ensuring analytics is always emitted
+            //    before consumer side effects run.
+            let runner: Rc<RefCell<Box<dyn FnMut()>>> = Rc::new(RefCell::new(Box::new({
+                move || {
+                    let (analytics_event, previous, controlled, disabled) = {
+                        let state_ref = state.borrow();
+                        (
+                            RadioTelemetryEvent::Analytics(build_analytics_event(
+                                &option, &state_ref, index,
+                            )),
+                            state_ref.selected_index(),
+                            state_ref.is_controlled(),
+                            state_ref.disabled(),
+                        )
+                    };
+
+                    let change_event = build_change_event(&option, previous, index, disabled);
+                    let mut telemetry_events = Vec::with_capacity(3);
+                    telemetry_events.push(analytics_event);
+                    telemetry_events.push(RadioTelemetryEvent::Change(change_event.clone()));
+
+                    {
+                        let mut state_mut = state.borrow_mut();
+                        state_mut.select(index, |_| {});
+                        state_mut.focus(index);
+                    }
+
+                    let selected_after = {
+                        let state_ref = state.borrow();
+                        state_ref.selected_index().or(Some(index))
+                    };
+                    let commit_event = build_commit_event(&option, selected_after, controlled);
+                    telemetry_events.push(RadioTelemetryEvent::Commit(commit_event));
+
+                    emit_telemetry(&telemetry, &telemetry_events);
+
+                    if let Some(callback) = &on_change {
+                        callback.emit(change_event);
+                    }
+                }
+            })));
+
+            let click_runner = Rc::clone(&runner);
+            let onclick_callback = Callback::from(move |_event: MouseEvent| {
+                (click_runner.borrow_mut())();
+            });
+            let onchange_runner = Rc::clone(&runner);
+            let onchange_callback = Callback::from(move |_event: Event| {
+                (onchange_runner.borrow_mut())();
+            });
+
+            let onclick_listener: Rc<dyn Listener> =
+                Rc::new(onclick::Wrapper::new(onclick_callback));
+            let onchange_listener: Rc<dyn Listener> =
+                Rc::new(onchange::Wrapper::new(onchange_callback));
+
+            (onclick_listener, onchange_listener)
+        }
+
+        fn build_focus_handler(&self, index: usize) -> Rc<dyn Listener> {
+            let state = Rc::clone(&self.state);
+            let option = self.options[index].clone();
+            let telemetry = self.telemetry_delegate.clone();
+            let on_focus = self.on_focus.clone();
+
+            let callback = Callback::from(move |_event: FocusEvent| {
+                let (analytics_event, focus_payload) = {
+                    let state_ref = state.borrow();
+                    (
+                        RadioTelemetryEvent::Analytics(build_analytics_event(
+                            &option, &state_ref, index,
+                        )),
+                        build_focus_event(&option, &state_ref, index, true),
+                    )
+                };
+
+                let telemetry_events = vec![
+                    analytics_event,
+                    RadioTelemetryEvent::Focus(focus_payload.clone()),
+                ];
+                emit_telemetry(&telemetry, &telemetry_events);
+
+                {
+                    let mut state_mut = state.borrow_mut();
+                    state_mut.focus(index);
+                }
+
+                if let Some(callback) = &on_focus {
+                    callback.emit(focus_payload);
+                }
+            });
+
+            Rc::new(onfocus::Wrapper::new(callback))
+        }
+
+        fn build_blur_handler(&self, index: usize) -> Rc<dyn Listener> {
+            let state = Rc::clone(&self.state);
+            let option = self.options[index].clone();
+            let telemetry = self.telemetry_delegate.clone();
+            let on_blur = self.on_blur.clone();
+
+            let callback = Callback::from(move |_event: FocusEvent| {
+                let (analytics_event, blur_payload) = {
+                    let state_ref = state.borrow();
+                    (
+                        RadioTelemetryEvent::Analytics(build_analytics_event(
+                            &option, &state_ref, index,
+                        )),
+                        build_focus_event(&option, &state_ref, index, false),
+                    )
+                };
+
+                let telemetry_events = vec![
+                    analytics_event,
+                    RadioTelemetryEvent::Blur(blur_payload.clone()),
+                ];
+                emit_telemetry(&telemetry, &telemetry_events);
+
+                {
+                    let mut state_mut = state.borrow_mut();
+                    state_mut.blur();
+                }
+
+                if let Some(callback) = &on_blur {
+                    callback.emit(blur_payload);
+                }
+            });
+
+            Rc::new(onblur::Wrapper::new(callback))
+        }
+
+        fn build_key_handler(&self, index: usize) -> Rc<dyn Listener> {
+            let state = Rc::clone(&self.state);
+            let options = Rc::clone(&self.options);
+            let telemetry = self.telemetry_delegate.clone();
+            let on_key = self.on_key.clone();
+            let on_change = self.on_change.clone();
+            let origin_option = self.options[index].clone();
+
+            let callback = Callback::from(move |event: KeyboardEvent| {
+                if let Some(control) = control_key_from_str(event.key().as_str()) {
+                    event.prevent_default();
+
+                    let (analytics_event, previous, controlled, disabled) = {
+                        let state_ref = state.borrow();
+                        (
+                            RadioTelemetryEvent::Analytics(build_analytics_event(
+                                &origin_option,
+                                &state_ref,
+                                index,
+                            )),
+                            state_ref.selected_index(),
+                            state_ref.is_controlled(),
+                            state_ref.disabled(),
+                        )
+                    };
+
+                    let selected_after = Rc::new(RefCell::new(None));
+                    {
+                        let mut state_mut = state.borrow_mut();
+                        let recorder = Rc::clone(&selected_after);
+                        state_mut.on_key(control, move |selected| {
+                            recorder.borrow_mut().replace(selected);
+                        });
+                    }
+
+                    let mut telemetry_events = Vec::with_capacity(5);
+                    telemetry_events.push(analytics_event);
+
+                    let next_index = *selected_after.borrow();
+                    let mut change_payload = None;
+                    let mut key_payload =
+                        build_key_event(&origin_option, control, previous, next_index, disabled);
+
+                    if let Some(next_index) = next_index {
+                        let focused_option = options[next_index].clone();
+                        let focus_event = {
+                            let state_ref = state.borrow();
+                            RadioTelemetryEvent::Focus(build_focus_event(
+                                &focused_option,
+                                &state_ref,
+                                next_index,
+                                true,
+                            ))
+                        };
+                        telemetry_events.push(focus_event);
+
+                        if next_index != index {
+                            let blur_event = {
+                                let state_ref = state.borrow();
+                                RadioTelemetryEvent::Blur(build_focus_event(
+                                    &origin_option,
+                                    &state_ref,
+                                    index,
+                                    false,
+                                ))
+                            };
+                            telemetry_events.push(blur_event);
+                        }
+
+                        let change_event =
+                            build_change_event(&focused_option, previous, next_index, disabled);
+                        telemetry_events.push(RadioTelemetryEvent::Change(change_event.clone()));
+
+                        let committed = {
+                            let state_ref = state.borrow();
+                            state_ref.selected_index().or(Some(next_index))
+                        };
+                        telemetry_events.push(RadioTelemetryEvent::Commit(build_commit_event(
+                            &focused_option,
+                            committed,
+                            controlled,
+                        )));
+
+                        change_payload = Some(change_event);
+                    }
+
+                    emit_telemetry(&telemetry, &telemetry_events);
+
+                    if let Some(callback) = &on_key {
+                        callback.emit(key_payload);
+                    }
+
+                    if let (Some(callback), Some(change_event)) =
+                        (on_change.as_ref(), change_payload)
+                    {
+                        callback.emit(change_event);
+                    }
+                }
+            });
+
+            Rc::new(onkeydown::Wrapper::new(callback))
+        }
     }
 
     /// Radio group rendered via Yew.
+    ///
+    /// The implementation mirrors the enterprise telemetry choreography used by
+    /// the React adapter to keep analytics, automation and state transitions in
+    /// lockstep:
+    ///
+    /// * [`TelemetryHooks`] from the props and [`RadioGroupProps`] are merged so
+    ///   analytics identifiers flow consistently regardless of where they are
+    ///   configured.
+    /// * [`descriptor_with_context`] seeds a [`TelemetryContext`] that captures
+    ///   the fully-qualified component path and descriptor metadata.
+    /// * Event handler factories centralise wiring per option, guaranteeing each
+    ///   closure emits telemetry **before** invoking consumer callbacks while
+    ///   also funnelling mutations through the shared [`RadioGroupState`].
+    /// * Pointer and keyboard interactions emit analytics → change → commit in
+    ///   order, focus transitions emit analytics → focus/blur, and keyboard
+    ///   flows optionally append change/commit snapshots when selection changes.
+    ///
+    /// Extensive inline documentation exists so governance teams can audit the
+    /// behaviour and so future contributors can extend the logic without
+    /// repeating boilerplate across options.
     #[function_component(YewRadioGroup)]
     pub fn yew_radio_group(props: &YewRadioGroupProps) -> Html {
         let telemetry = super::merged_telemetry(&props.telemetry, &props.group.telemetry);
@@ -1469,20 +1858,39 @@ pub mod yew {
             &props.state,
         );
         instrument_render(&telemetry, context, move || {
-            let mut node = html! {
-                <div>
-                    { for snapshot.options.iter().map(|option| {
-                        let option_attrs = option.themed_attributes.clone();
-                        let mut child = html! { <span>{option.label.clone()}</span> };
-                        if let VNode::VTag(ref mut tag) = child {
-                            for (key, value) in option_attrs {
-                                tag.add_attribute(key, value);
-                            }
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let options = Rc::new(snapshot.options.clone());
+            let handler_builder = Rc::new(YewOptionHandlerBuilder::new(
+                Rc::clone(&state_handle),
+                Rc::clone(&options),
+                props.on_change.clone(),
+                props.on_focus.clone(),
+                props.on_blur.clone(),
+                props.on_key.clone(),
+                props.telemetry_delegate.clone(),
+            ));
+
+            let option_nodes = options.iter().enumerate().map({
+                let builder = Rc::clone(&handler_builder);
+                move |(index, option)| {
+                    let option_snapshot = option.clone();
+                    let handlers = builder.build(index);
+                    let mut child = html! { <span>{option_snapshot.label.clone()}</span> };
+                    if let VNode::VTag(ref mut tag) = child {
+                        for (key, value) in option_snapshot.themed_attributes.clone() {
+                            tag.add_attribute(key, value);
                         }
-                        child
-                    }) }
-                </div>
-            };
+                        tag.add_listener(Rc::clone(&handlers.onclick));
+                        tag.add_listener(Rc::clone(&handlers.onchange));
+                        tag.add_listener(Rc::clone(&handlers.onfocus));
+                        tag.add_listener(Rc::clone(&handlers.onblur));
+                        tag.add_listener(Rc::clone(&handlers.onkeydown));
+                    }
+                    child
+                }
+            });
+
+            let mut node = html! { <div>{ for option_nodes }</div> };
 
             if let VNode::VTag(ref mut tag) = node {
                 for (key, value) in snapshot.group_thematic_attributes.clone() {

--- a/crates/rustic-ui-material/tests/wasm.rs
+++ b/crates/rustic-ui-material/tests/wasm.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "yew")]
 
+use gloo_timers::future::TimeoutFuture;
 use rustic_ui_headless::checkbox::CheckboxState;
 use rustic_ui_headless::chip::{ChipConfig, ChipState};
 use rustic_ui_headless::click_away::ClickAwayState;
@@ -22,7 +23,9 @@ use rustic_ui_material::dialog::{self as dialog_adapter, DialogSurfaceOptions};
 use rustic_ui_material::drawer::{self, DrawerLayoutOptions, DrawerProps};
 use rustic_ui_material::focus_trap::{self, FocusTrapSentinelKind, FocusTrapSentinelOptions};
 use rustic_ui_material::menu::{self, MenuItem, MenuProps};
-use rustic_ui_material::radio::{self, RadioGroupProps};
+use rustic_ui_material::radio::{
+    self, RadioChangeEvent, RadioFocusEvent, RadioGroupProps, RadioKeyEvent, RadioTelemetryEvent,
+};
 use rustic_ui_material::switch::{self, SwitchProps};
 use rustic_ui_material::tab_panel;
 use rustic_ui_material::table::{self, TableColumn, TableProps, TableRow};
@@ -31,6 +34,7 @@ use rustic_ui_material::text_field::TextFieldStateHandle;
 use rustic_ui_material::tooltip::{self, TooltipProps};
 use rustic_ui_material::{AppBar, Button, Snackbar, TextField};
 use rustic_ui_styled_engine::{Theme, ThemeProvider};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 use wasm_bindgen::{prelude::*, JsCast};
@@ -338,6 +342,184 @@ async fn radio_accessibility_audit() {
     let radios = mount.query_selector_all("[role='radio']").unwrap();
     assert_eq!(radios.length(), 3);
     axe_check(&mount).await;
+}
+
+/// Exercise pointer, focus and keyboard interactions to guarantee telemetry and
+/// ARIA state stay in sync with the headless state machine.
+#[wasm_bindgen_test(async)]
+async fn radio_group_interactions_emit_telemetry() {
+    use rustic_ui_material::radio::yew::YewRadioGroup;
+
+    let document = gloo_utils::document();
+    let mount = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&mount).unwrap();
+
+    let telemetry_log = Rc::new(RefCell::new(Vec::new()));
+    let change_log = Rc::new(RefCell::new(Vec::new()));
+    let focus_log = Rc::new(RefCell::new(Vec::new()));
+    let blur_log = Rc::new(RefCell::new(Vec::new()));
+    let key_log = Rc::new(RefCell::new(Vec::new()));
+
+    let telemetry_cb = {
+        let log = Rc::clone(&telemetry_log);
+        Callback::from(move |event: RadioTelemetryEvent| {
+            log.borrow_mut().push(event);
+        })
+    };
+    let change_cb = {
+        let log = Rc::clone(&change_log);
+        Callback::from(move |event: RadioChangeEvent| {
+            log.borrow_mut().push(event);
+        })
+    };
+    let focus_cb = {
+        let log = Rc::clone(&focus_log);
+        Callback::from(move |event: RadioFocusEvent| {
+            log.borrow_mut().push(event);
+        })
+    };
+    let blur_cb = {
+        let log = Rc::clone(&blur_log);
+        Callback::from(move |event: RadioFocusEvent| {
+            log.borrow_mut().push(event);
+        })
+    };
+    let key_cb = {
+        let log = Rc::clone(&key_log);
+        Callback::from(move |event: RadioKeyEvent| {
+            log.borrow_mut().push(event);
+        })
+    };
+
+    let state = RadioGroupState::uncontrolled(
+        vec!["Alpha".into(), "Beta".into(), "Gamma".into()],
+        false,
+        RadioOrientation::Horizontal,
+        Some(0),
+    );
+    let mut group = RadioGroupProps::from_state(&state);
+    group.telemetry.analytics_id = Some("yew-radio-group".into());
+    group.telemetry.automation_id = Some("yew-radio-automation".into());
+
+    #[derive(Properties, Clone, PartialEq)]
+    struct RadioHarnessProps {
+        group: RadioGroupProps,
+        state: RadioGroupState,
+        on_change: Callback<RadioChangeEvent>,
+        on_focus: Callback<RadioFocusEvent>,
+        on_blur: Callback<RadioFocusEvent>,
+        on_key: Callback<RadioKeyEvent>,
+        telemetry: Callback<RadioTelemetryEvent>,
+    }
+
+    #[function_component(RadioHarness)]
+    fn radio_harness(props: &RadioHarnessProps) -> Html {
+        html! {
+            <ThemeProvider theme={Theme::default()}>
+                <YewRadioGroup
+                    group={props.group.clone()}
+                    state={props.state.clone()}
+                    on_change={Some(props.on_change.clone())}
+                    on_focus={Some(props.on_focus.clone())}
+                    on_blur={Some(props.on_blur.clone())}
+                    on_key={Some(props.on_key.clone())}
+                    telemetry_delegate={Some(props.telemetry.clone())}
+                />
+            </ThemeProvider>
+        }
+    }
+
+    let props = RadioHarnessProps {
+        group,
+        state: state.clone(),
+        on_change: change_cb,
+        on_focus: focus_cb,
+        on_blur: blur_cb,
+        on_key: key_cb,
+        telemetry: telemetry_cb,
+    };
+
+    Renderer::<RadioHarness>::with_root_and_props(mount.clone(), props).render();
+
+    // Pointer selection updates telemetry and aria attributes.
+    let second = mount
+        .query_selector("[data-index='1']")
+        .unwrap()
+        .expect("second radio option");
+    let second_element: web_sys::HtmlElement = second.clone().dyn_into().unwrap();
+    second_element.click();
+    TimeoutFuture::new(0).await;
+
+    let change_events = change_log.borrow();
+    assert_eq!(change_events.len(), 1);
+    assert_eq!(change_events[0].next, 1);
+    drop(change_events);
+
+    let telemetry_events = telemetry_log.borrow();
+    assert!(matches!(
+        telemetry_events[0],
+        RadioTelemetryEvent::Analytics(_)
+    ));
+    assert!(matches!(telemetry_events[1], RadioTelemetryEvent::Change(ref evt) if evt.next == 1));
+    assert!(
+        matches!(telemetry_events[2], RadioTelemetryEvent::Commit(ref evt) if evt.selected == Some(1))
+    );
+    drop(telemetry_events);
+
+    assert_eq!(
+        second
+            .get_attribute("aria-checked")
+            .expect("aria-checked attribute"),
+        "true"
+    );
+
+    // Focus and blur events bubble telemetry before consumer callbacks.
+    let focus_event = web_sys::FocusEvent::new("focus").unwrap();
+    second_element.dispatch_event(&focus_event).unwrap();
+    TimeoutFuture::new(0).await;
+    let blur_event = web_sys::FocusEvent::new("blur").unwrap();
+    second_element.dispatch_event(&blur_event).unwrap();
+    TimeoutFuture::new(0).await;
+
+    assert_eq!(focus_log.borrow().len(), 1);
+    assert_eq!(blur_log.borrow().len(), 1);
+
+    // Keyboard navigation advances selection and surfaces telemetry in order.
+    let mut keyboard_init = web_sys::KeyboardEventInit::new();
+    keyboard_init.set_key("ArrowRight");
+    keyboard_init.set_bubbles(true);
+    keyboard_init.set_cancelable(true);
+    let key_event =
+        web_sys::KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &keyboard_init)
+            .unwrap();
+    second_element.dispatch_event(&key_event).unwrap();
+    TimeoutFuture::new(0).await;
+
+    let key_events = key_log.borrow();
+    assert_eq!(key_events.len(), 1);
+    assert_eq!(key_events[0].next, Some(2));
+    drop(key_events);
+
+    let telemetry_events = telemetry_log.borrow();
+    assert!(telemetry_events.len() >= 7);
+    let tail = &telemetry_events[telemetry_events.len() - 5..];
+    assert!(matches!(tail[0], RadioTelemetryEvent::Analytics(_)));
+    assert!(matches!(tail[1], RadioTelemetryEvent::Focus(_)));
+    assert!(matches!(tail[2], RadioTelemetryEvent::Blur(_)));
+    assert!(matches!(tail[3], RadioTelemetryEvent::Change(ref evt) if evt.next == 2));
+    assert!(matches!(tail[4], RadioTelemetryEvent::Commit(ref evt) if evt.selected == Some(2)));
+    drop(telemetry_events);
+
+    let third = mount
+        .query_selector("[data-index='2']")
+        .unwrap()
+        .expect("third radio option");
+    assert_eq!(
+        third
+            .get_attribute("data-checked")
+            .expect("data-checked attribute"),
+        "true"
+    );
 }
 
 /// Validate the switch renders and passes accessibility audit.

--- a/examples/selection-controls-yew/README.md
+++ b/examples/selection-controls-yew/README.md
@@ -6,9 +6,11 @@ from `rustic_ui_material`.
 
 ```rust
 use rustic_ui_headless::checkbox::CheckboxState;
+use gloo_console::log;
 use rustic_ui_material::checkbox::{self, CheckboxProps};
 use rustic_ui_material::switch::{self, SwitchProps};
-use rustic_ui_material::radio::{self, RadioGroupProps};
+use rustic_ui_material::radio::{self, RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent};
+use rustic_ui_material::radio::yew::YewRadioGroup;
 use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
 use yew::prelude::*;
 
@@ -23,22 +25,32 @@ fn selection_controls() -> Html {
         Some(0),
     );
 
-    let checkbox = Html::from_html_unchecked(AttrValue::from(
-        checkbox::yew::render(&CheckboxProps::new("Receive updates"), &checkbox_state),
-    ));
-    let switch = Html::from_html_unchecked(AttrValue::from(
-        switch::yew::render(&SwitchProps::new("Enable notifications"), &switch_state),
-    ));
-    let radio = Html::from_html_unchecked(AttrValue::from(
-        radio::yew::render(&RadioGroupProps::from_state(&radio_state), &radio_state),
-    ));
+    let on_radio_change = Callback::from(|event: RadioChangeEvent| {
+        log!(format!("selected index: {}", event.next));
+    });
+    let on_radio_telemetry = Callback::from(|event: RadioTelemetryEvent| {
+        log!(format!("telemetry: {:?}", event));
+    });
 
     html! {
         <>
-            {checkbox}
-            {switch}
-            {radio}
+            { Html::from_html_unchecked(AttrValue::from(
+                checkbox::yew::render(&CheckboxProps::new("Receive updates"), &checkbox_state),
+            )) }
+            { Html::from_html_unchecked(AttrValue::from(
+                switch::yew::render(&SwitchProps::new("Enable notifications"), &switch_state),
+            )) }
+            <YewRadioGroup
+                group={RadioGroupProps::from_state(&radio_state)}
+                state={radio_state}
+                on_change={Some(on_radio_change)}
+                telemetry_delegate={Some(on_radio_telemetry)}
+            />
         </>
     }
 }
 ```
+
+The radio group now emits structured telemetry before any consumer callbacks
+execute, ensuring analytics capture remains deterministic even as the UI mutates
+through `RadioGroupState`.


### PR DESCRIPTION
## Summary
- add a dedicated `RadioKeyEvent` payload and shared control-key parsing for the radio adapters
- rework the Yew radio group component to centralise listener construction, emit telemetry ahead of user callbacks, and expose new callbacks/telemetry delegate hooks
- extend the wasm-based Yew adapter tests to cover pointer, focus, and keyboard flows while updating the Yew example to describe the richer telemetry surface

## Testing
- `cargo fmt`
- `cargo test -p rustic-ui-material --features yew` *(fails: upstream build errors around unrelated modules such as checkbox/switch/snackbar when compiling with the yew feature)*

------
https://chatgpt.com/codex/tasks/task_e_68dd40308974832ea53871c5c11a29f4