### PR TITLE
feat(radio): emit key telemetry across adapters

### DIFF
--- a/crates/rustic-ui-material/README.md
+++ b/crates/rustic-ui-material/README.md
@@ -146,6 +146,22 @@ Leptos, Dioxus, and Sycamore renders all include the disabled metadata. When
 augmenting the component ensure any additional markup preserves these hooks so
 end-to-end automation continues to function.
 
+## Radio group telemetry orchestration
+
+Material radio groups now expose a telemetry contract that mirrors the
+checkbox and switch integrations. `RadioTelemetryEvent` includes analytics,
+key, focus, blur, change, and commit variants so enterprise dashboards can trace
+every interaction across SSR and hydration renders. Adapters emit telemetry in
+the deterministic order `analytics → key → focus/blur → change → commit` before
+invoking consumer callbacks, ensuring QA suites observe the exact state the user
+experienced.【F:crates/rustic-ui-material/src/radio.rs†L95-L214】【F:crates/rustic-ui-material/src/radio.rs†L930-L1110】【F:crates/rustic-ui-material/src/radio.rs†L2620-L2798】【F:crates/rustic-ui-material/tests/radio_adapters.rs†L188-L272】
+
+Keyboard flows now forward a dedicated `RadioKeyEvent` to telemetry delegates in
+addition to the existing change payloads. Regression tests cover pointer
+selection, focus transitions, and keyboard commits across Yew, Leptos, Dioxus,
+and Sycamore adapters to guarantee analytics ordering remains stable as new
+frameworks or descriptors are added.【F:crates/rustic-ui-material/src/radio.rs†L2700-L2798】【F:crates/rustic-ui-material/src/radio.rs†L3460-L3568】【F:crates/rustic-ui-material/src/radio.rs†L4580-L4662】【F:crates/rustic-ui-material/tests/radio_adapters.rs†L188-L272】
+
 ## Dialog, popover, and text field adapters
 
 The Material adapters for `Dialog`, `Popover`, and `TextField` lean directly on

--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -120,6 +120,8 @@ pub struct RadioKeyEvent {
 pub enum RadioTelemetryEvent {
     /// Analytics metadata observed prior to any other telemetry.
     Analytics(RadioAnalyticsEvent),
+    /// Keyboard interaction payload captured before focus or selection updates.
+    Key(RadioKeyEvent),
     /// Focus gained for a specific option.
     Focus(RadioFocusEvent),
     /// Focus lost for a specific option.
@@ -976,7 +978,7 @@ pub mod react {
                         )
                     };
 
-                    let mut events = Vec::with_capacity(5);
+                    let mut events = Vec::with_capacity(6);
                     events.push(analytics_event);
 
                     let selected_after = Rc::new(RefCell::new(None));
@@ -988,7 +990,12 @@ pub mod react {
                         });
                     }
 
-                    if let Some(next_index) = *selected_after.borrow() {
+                    let next_index = *selected_after.borrow();
+                    let key_payload =
+                        build_key_event(&origin_option, control, previous, next_index, disabled);
+                    events.push(RadioTelemetryEvent::Key(key_payload));
+
+                    if let Some(next_index) = next_index {
                         let focused_option = options[next_index].clone();
                         let focus_event = {
                             let state_ref = state.borrow();
@@ -1189,6 +1196,47 @@ pub mod react {
                     &object,
                     &JsValue::from_str("label"),
                     &JsValue::from_str(&analytics.label),
+                )
+                .expect("set label");
+            }
+            Event::Key(key) => {
+                Reflect::set(
+                    &object,
+                    &JsValue::from_str("kind"),
+                    &JsValue::from_str("key"),
+                )
+                .expect("set kind");
+                Reflect::set(
+                    &object,
+                    &JsValue::from_str("key"),
+                    &JsValue::from_str(match key.key {
+                        ControlKey::Space => "Space",
+                        ControlKey::Enter => "Enter",
+                        ControlKey::ArrowUp => "ArrowUp",
+                        ControlKey::ArrowDown => "ArrowDown",
+                        ControlKey::ArrowLeft => "ArrowLeft",
+                        ControlKey::ArrowRight => "ArrowRight",
+                        ControlKey::Home => "Home",
+                        ControlKey::End => "End",
+                    }),
+                )
+                .expect("set key");
+                push_optional_usize(&object, "previous", key.previous).expect("set previous");
+                push_optional_usize(&object, "next", key.next).expect("set next");
+                Reflect::set(
+                    &object,
+                    &JsValue::from_str("disabled"),
+                    &JsValue::from_bool(key.disabled),
+                )
+                .expect("set disabled");
+                push_optional_string(&object, "analyticsId", &key.analytics_id)
+                    .expect("set analyticsId");
+                push_optional_string(&object, "automationId", &key.automation_id)
+                    .expect("set automationId");
+                Reflect::set(
+                    &object,
+                    &JsValue::from_str("label"),
+                    &JsValue::from_str(&key.label),
                 )
                 .expect("set label");
             }
@@ -1397,11 +1445,29 @@ pub mod react {
         }
 
         fn call_handler(props: &Object, key: &str) {
+            call_handler_with_event(props, key, JsValue::UNDEFINED);
+        }
+
+        fn call_handler_with_event(props: &Object, key: &str, event: JsValue) {
             if let Ok(handler) = Reflect::get(props, &JsValue::from_str(key)) {
                 if let Ok(function) = handler.dyn_into::<Function>() {
-                    let _ = function.call1(&JsValue::NULL, &JsValue::UNDEFINED);
+                    let _ = function.call1(&JsValue::NULL, &event);
                 }
             }
+        }
+
+        fn keyboard_event(key: &str) -> JsValue {
+            let event = Object::new();
+            Reflect::set(&event, &JsValue::from_str("key"), &JsValue::from_str(key))
+                .expect("set key");
+
+            let prevent = Closure::wrap(Box::new(|| {}) as Box<dyn FnMut()>);
+            let function = prevent.as_ref().clone();
+            Reflect::set(&event, &JsValue::from_str("preventDefault"), &function)
+                .expect("set preventDefault");
+            prevent.forget();
+
+            event.into()
         }
 
         fn event_kinds(events: &js_sys::Array) -> Vec<String> {
@@ -1485,6 +1551,24 @@ pub mod react {
             assert_eq!(role, "radio");
             assert_eq!(aria_checked, "true");
             assert_eq!(data_index, "0");
+        }
+
+        #[wasm_bindgen_test]
+        fn keydown_emits_key_focus_and_commit_sequence() {
+            let state = Rc::new(RefCell::new(sample_state_uncontrolled()));
+            let snapshot = build_snapshot(&state.borrow());
+            let (delegate, events) = telemetry_collector();
+            let (props, state_handle) =
+                build_option_props(Rc::clone(&state), &snapshot, Some(delegate), 0);
+
+            call_handler_with_event(&props, "onKeyDown", keyboard_event("ArrowRight"));
+
+            let kinds = event_kinds(&events);
+            assert_eq!(
+                kinds,
+                vec!["analytics", "key", "focus", "blur", "change", "commit"]
+            );
+            assert_eq!(state_handle.borrow().selected_index(), Some(1));
         }
     }
 
@@ -1807,13 +1891,14 @@ pub mod yew {
                         });
                     }
 
-                    let mut telemetry_events = Vec::with_capacity(5);
+                    let mut telemetry_events = Vec::with_capacity(6);
                     telemetry_events.push(analytics_event);
 
                     let next_index = *selected_after.borrow();
-                    let mut change_payload = None;
-                    let mut key_payload =
+                    let key_payload =
                         build_key_event(&origin_option, control, previous, next_index, disabled);
+                    telemetry_events.push(RadioTelemetryEvent::Key(key_payload.clone()));
+                    let mut change_payload = None;
 
                     if let Some(next_index) = next_index {
                         let focused_option = options[next_index].clone();
@@ -1890,9 +1975,10 @@ pub mod yew {
     /// * Event handler factories centralise wiring per option, guaranteeing each
     ///   closure emits telemetry **before** invoking consumer callbacks while
     ///   also funnelling mutations through the shared [`RadioGroupState`].
-    /// * Pointer and keyboard interactions emit analytics → change → commit in
-    ///   order, focus transitions emit analytics → focus/blur, and keyboard
-    ///   flows optionally append change/commit snapshots when selection changes.
+    /// * Pointer interactions emit analytics → change → commit in order, focus
+    ///   transitions emit analytics → focus/blur, and keyboard flows emit
+    ///   analytics → key → focus/blur → change → commit so automation suites can
+    ///   validate navigation intent separately from the resulting selection.
     ///
     /// Extensive inline documentation exists so governance teams can audit the
     /// behaviour and so future contributors can extend the logic without
@@ -2202,14 +2288,14 @@ pub mod leptos {
 
                 refresh();
 
-                let mut telemetry_events = Vec::with_capacity(5);
+                let mut telemetry_events = Vec::with_capacity(6);
                 telemetry_events.push(analytics_event);
 
                 let next_index = *selected_after.borrow();
-                let mut change_payload = None;
-
                 let key_payload =
                     build_key_event(&origin_option, control, previous, next_index, disabled);
+                telemetry_events.push(RadioTelemetryEvent::Key(key_payload.clone()));
+                let mut change_payload = None;
 
                 if let Some(next_index) = next_index {
                     let focused_option = options[next_index].clone();
@@ -2764,11 +2850,13 @@ pub mod leptos {
             assert_eq!(harness.state.borrow().selected_index(), Some(1));
 
             let telemetry = harness.telemetry_events.borrow();
+            assert_eq!(telemetry.len(), 6);
             assert!(matches!(telemetry[0], RadioTelemetryEvent::Analytics(_)));
-            assert!(matches!(telemetry[1], RadioTelemetryEvent::Focus(_)));
-            assert!(matches!(telemetry[2], RadioTelemetryEvent::Blur(_)));
-            assert!(matches!(telemetry[3], RadioTelemetryEvent::Change(_)));
-            assert!(matches!(telemetry[4], RadioTelemetryEvent::Commit(_)));
+            assert!(matches!(telemetry[1], RadioTelemetryEvent::Key(_)));
+            assert!(matches!(telemetry[2], RadioTelemetryEvent::Focus(_)));
+            assert!(matches!(telemetry[3], RadioTelemetryEvent::Blur(_)));
+            assert!(matches!(telemetry[4], RadioTelemetryEvent::Change(_)));
+            assert!(matches!(telemetry[5], RadioTelemetryEvent::Commit(_)));
             drop(telemetry);
 
             let keys = harness.key_events.borrow();
@@ -2782,14 +2870,15 @@ pub mod leptos {
             drop(changes);
 
             let order = harness.order.borrow();
-            assert_eq!(order.len(), 7);
+            assert_eq!(order.len(), 8);
             assert!(order[0].starts_with("telemetry::Analytics"));
-            assert!(order[1].starts_with("telemetry::Focus"));
-            assert!(order[2].starts_with("telemetry::Blur"));
-            assert!(order[3].starts_with("telemetry::Change"));
-            assert!(order[4].starts_with("telemetry::Commit"));
-            assert_eq!(order[5], "callback::key");
-            assert_eq!(order[6], "callback::change");
+            assert!(order[1].starts_with("telemetry::Key"));
+            assert!(order[2].starts_with("telemetry::Focus"));
+            assert!(order[3].starts_with("telemetry::Blur"));
+            assert!(order[4].starts_with("telemetry::Change"));
+            assert!(order[5].starts_with("telemetry::Commit"));
+            assert_eq!(order[6], "callback::key");
+            assert_eq!(order[7], "callback::change");
             drop(order);
 
             assert_eq!(*harness.refresh_counter.borrow(), 1);
@@ -3178,14 +3267,14 @@ pub mod dioxus {
 
                 refresh();
 
-                let mut telemetry_events = Vec::with_capacity(5);
+                let mut telemetry_events = Vec::with_capacity(6);
                 telemetry_events.push(analytics_event);
 
                 let next_index = *selected_after.borrow();
-                let mut change_payload = None;
-
                 let key_payload =
                     build_key_event(&origin_option, control, previous, next_index, disabled);
+                telemetry_events.push(RadioTelemetryEvent::Key(key_payload.clone()));
+                let mut change_payload = None;
 
                 if let Some(next_index) = next_index {
                     let focused_option = options[next_index].clone();
@@ -3741,11 +3830,13 @@ pub mod dioxus {
             assert_eq!(harness.state.borrow().selected_index(), Some(1));
 
             let telemetry = harness.telemetry_events.borrow();
+            assert_eq!(telemetry.len(), 6);
             assert!(matches!(telemetry[0], RadioTelemetryEvent::Analytics(_)));
-            assert!(matches!(telemetry[1], RadioTelemetryEvent::Focus(_)));
-            assert!(matches!(telemetry[2], RadioTelemetryEvent::Blur(_)));
-            assert!(matches!(telemetry[3], RadioTelemetryEvent::Change(_)));
-            assert!(matches!(telemetry[4], RadioTelemetryEvent::Commit(_)));
+            assert!(matches!(telemetry[1], RadioTelemetryEvent::Key(_)));
+            assert!(matches!(telemetry[2], RadioTelemetryEvent::Focus(_)));
+            assert!(matches!(telemetry[3], RadioTelemetryEvent::Blur(_)));
+            assert!(matches!(telemetry[4], RadioTelemetryEvent::Change(_)));
+            assert!(matches!(telemetry[5], RadioTelemetryEvent::Commit(_)));
             drop(telemetry);
 
             let keys = harness.key_events.borrow();
@@ -3759,14 +3850,15 @@ pub mod dioxus {
             drop(changes);
 
             let order = harness.order.borrow();
-            assert_eq!(order.len(), 7);
+            assert_eq!(order.len(), 8);
             assert!(order[0].starts_with("telemetry::Analytics"));
-            assert!(order[1].starts_with("telemetry::Focus"));
-            assert!(order[2].starts_with("telemetry::Blur"));
-            assert!(order[3].starts_with("telemetry::Change"));
-            assert!(order[4].starts_with("telemetry::Commit"));
-            assert_eq!(order[5], "callback::key");
-            assert_eq!(order[6], "callback::change");
+            assert!(order[1].starts_with("telemetry::Key"));
+            assert!(order[2].starts_with("telemetry::Focus"));
+            assert!(order[3].starts_with("telemetry::Blur"));
+            assert!(order[4].starts_with("telemetry::Change"));
+            assert!(order[5].starts_with("telemetry::Commit"));
+            assert_eq!(order[6], "callback::key");
+            assert_eq!(order[7], "callback::change");
             drop(order);
 
             assert_eq!(*harness.refresh_counter.borrow(), 1);
@@ -4095,14 +4187,14 @@ pub mod sycamore {
                     });
                 }
 
-                let mut telemetry_events = Vec::with_capacity(5);
+                let mut telemetry_events = Vec::with_capacity(6);
                 telemetry_events.push(analytics_event);
 
                 let next_index = *selected_after.borrow();
-                let mut change_payload = None;
-
                 let key_payload =
                     build_key_event(&origin_option, control, previous, next_index, disabled);
+                telemetry_events.push(RadioTelemetryEvent::Key(key_payload.clone()));
+                let mut change_payload = None;
 
                 if let Some(next_index) = next_index {
                     let focused_option = options[next_index].clone();
@@ -4535,11 +4627,13 @@ pub mod sycamore {
             assert_eq!(harness.state.borrow().selected_index(), Some(1));
 
             let telemetry = harness.telemetry_events.borrow();
+            assert_eq!(telemetry.len(), 6);
             assert!(matches!(telemetry[0], RadioTelemetryEvent::Analytics(_)));
-            assert!(matches!(telemetry[1], RadioTelemetryEvent::Focus(_)));
-            assert!(matches!(telemetry[2], RadioTelemetryEvent::Blur(_)));
-            assert!(matches!(telemetry[3], RadioTelemetryEvent::Change(_)));
-            assert!(matches!(telemetry[4], RadioTelemetryEvent::Commit(_)));
+            assert!(matches!(telemetry[1], RadioTelemetryEvent::Key(_)));
+            assert!(matches!(telemetry[2], RadioTelemetryEvent::Focus(_)));
+            assert!(matches!(telemetry[3], RadioTelemetryEvent::Blur(_)));
+            assert!(matches!(telemetry[4], RadioTelemetryEvent::Change(_)));
+            assert!(matches!(telemetry[5], RadioTelemetryEvent::Commit(_)));
             drop(telemetry);
 
             let keys = harness.key_events.borrow();
@@ -4547,14 +4641,15 @@ pub mod sycamore {
             assert_eq!(keys[0].key, ControlKey::ArrowRight);
 
             let order = harness.order.borrow();
-            assert_eq!(order.len(), 7);
+            assert_eq!(order.len(), 8);
             assert!(order[0].starts_with("telemetry::Analytics"));
-            assert!(order[1].starts_with("telemetry::Focus"));
-            assert!(order[2].starts_with("telemetry::Blur"));
-            assert!(order[3].starts_with("telemetry::Change"));
-            assert!(order[4].starts_with("telemetry::Commit"));
-            assert_eq!(order[5], "callback::key");
-            assert_eq!(order[6], "callback::change");
+            assert!(order[1].starts_with("telemetry::Key"));
+            assert!(order[2].starts_with("telemetry::Focus"));
+            assert!(order[3].starts_with("telemetry::Blur"));
+            assert!(order[4].starts_with("telemetry::Change"));
+            assert!(order[5].starts_with("telemetry::Commit"));
+            assert_eq!(order[6], "callback::key");
+            assert_eq!(order[7], "callback::change");
         }
 
         #[test]

--- a/crates/rustic-ui-material/tests/radio_adapters.rs
+++ b/crates/rustic-ui-material/tests/radio_adapters.rs
@@ -174,11 +174,9 @@ impl RadioHarness {
     fn focus_option(&mut self, index: usize) -> RadioFocusEvent {
         let analytics = self.analytics_event(index, self.state.selected_index());
         let payload = self.focus_payload(index, true);
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Analytics(analytics));
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Focus(payload.clone()));
         self.focus_events.push(payload.clone());
         self.state.focus(index);
@@ -188,11 +186,9 @@ impl RadioHarness {
     fn blur_option(&mut self, index: usize) -> RadioFocusEvent {
         let analytics = self.analytics_event(index, self.state.selected_index());
         let payload = self.focus_payload(index, false);
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Analytics(analytics));
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Blur(payload.clone()));
         self.blur_events.push(payload.clone());
         self.state.blur();
@@ -203,17 +199,14 @@ impl RadioHarness {
         let previous = self.state.selected_index();
         let analytics = self.analytics_event(index, previous);
         let change = self.change_payload(previous, index);
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Analytics(analytics));
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Change(change.clone()));
         self.state.select(index, |_| {});
         self.state.focus(index);
         let commit = self.commit_payload(self.state.selected_index(), index);
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Commit(commit));
         self.change_events.push(change.clone());
         change
@@ -222,8 +215,7 @@ impl RadioHarness {
     fn key_from(&mut self, origin: usize, key: ControlKey) -> RadioKeyEvent {
         let previous = self.state.selected_index();
         let analytics = self.analytics_event(origin, previous);
-        self
-            .telemetry_events
+        self.telemetry_events
             .push(RadioTelemetryEvent::Analytics(analytics));
 
         let mut selected_after = None;
@@ -233,27 +225,25 @@ impl RadioHarness {
 
         let payload = self.key_payload(origin, key, previous, selected_after);
         self.key_events.push(payload.clone());
+        self.telemetry_events
+            .push(RadioTelemetryEvent::Key(payload.clone()));
 
         if let Some(next_index) = selected_after {
             let focus_event = self.focus_payload(next_index, true);
-            self
-                .telemetry_events
+            self.telemetry_events
                 .push(RadioTelemetryEvent::Focus(focus_event));
 
             if next_index != origin {
                 let blur_event = self.focus_payload(origin, false);
-                self
-                    .telemetry_events
+                self.telemetry_events
                     .push(RadioTelemetryEvent::Blur(blur_event));
             }
 
             let change = self.change_payload(previous, next_index);
-            self
-                .telemetry_events
+            self.telemetry_events
                 .push(RadioTelemetryEvent::Change(change.clone()));
             let commit = self.commit_payload(self.state.selected_index(), next_index);
-            self
-                .telemetry_events
+            self.telemetry_events
                 .push(RadioTelemetryEvent::Commit(commit));
             self.change_events.push(change);
         }
@@ -274,12 +264,8 @@ where
     assert!(initial_markup.contains("role=\"radiogroup\""));
     assert!(initial_markup.contains("aria-orientation=\"horizontal\""));
     assert!(initial_markup.contains("data-orientation=\"horizontal\""));
-    assert!(initial_markup.contains(&format!(
-        "data-rustic-analytics-id=\"{analytics_id}\""
-    )));
-    assert!(initial_markup.contains(&format!(
-        "data-automation-id=\"{automation_id}\""
-    )));
+    assert!(initial_markup.contains(&format!("data-rustic-analytics-id=\"{analytics_id}\"")));
+    assert!(initial_markup.contains(&format!("data-automation-id=\"{automation_id}\"")));
     assert!(initial_markup.contains("data-e2e=\"radio-group-under-test\""));
     assert!(initial_markup.contains("data-option-flag=\"alpha\""));
     assert!(initial_markup.contains("style=\"position: relative;\""));
@@ -342,7 +328,7 @@ where
     assert_eq!(contexts.len(), 5);
     drop(contexts);
 
-    assert_eq!(harness.telemetry_events.len(), 12);
+    assert_eq!(harness.telemetry_events.len(), 13);
     let telemetry = &harness.telemetry_events;
     assert!(matches!(
         telemetry[0],
@@ -388,21 +374,29 @@ where
     ));
     assert!(matches!(
         telemetry[8],
+        RadioTelemetryEvent::Key(ref evt)
+            if evt.key == ControlKey::ArrowRight
+                && evt.previous == Some(1)
+                && evt.next == Some(2)
+                && evt.label == "Beta"
+    ));
+    assert!(matches!(
+        telemetry[9],
         RadioTelemetryEvent::Focus(ref evt)
             if evt.focused && evt.index == 2 && evt.label == "Gamma"
     ));
     assert!(matches!(
-        telemetry[9],
+        telemetry[10],
         RadioTelemetryEvent::Blur(ref evt)
             if !evt.focused && evt.index == 1 && evt.label == "Beta"
     ));
     assert!(matches!(
-        telemetry[10],
+        telemetry[11],
         RadioTelemetryEvent::Change(ref evt)
             if evt.previous == Some(1) && evt.next == 2 && evt.label == "Gamma"
     ));
     assert!(matches!(
-        telemetry[11],
+        telemetry[12],
         RadioTelemetryEvent::Commit(ref evt)
             if evt.selected == Some(2) && evt.label == "Gamma"
     ));

--- a/docs/src/pages/examples/selection-controls-telemetry.md
+++ b/docs/src/pages/examples/selection-controls-telemetry.md
@@ -88,11 +88,11 @@ the rendered DOM.
 | `Commit` | Post-mutation selection snapshot, including controlled state. | `selected`, `controlled`, `analytics_id`, `automation_id`, `label` |
 | `Key` | Keyboard interaction metadata. | `key`, `previous`, `next`, `disabled`, `analytics_id`, `automation_id`, `label` |
 
-All adapters emit events in the deterministic order `Analytics → Focus/Blur →
-Change → Commit → callback`, with optional `Key` payloads inserted before
-`Change` when the interaction is keyboard-driven. Tests across every framework
-validate that telemetry fires before user callbacks and that commits capture the
-final selection snapshot—even in controlled radio groups.【F:crates/rustic-ui-material/src/radio.rs†L120-L212】【F:crates/rustic-ui-material/src/radio.rs†L2633-L2709】【F:crates/rustic-ui-material/src/radio.rs†L2709-L2793】【F:crates/rustic-ui-material/tests/radio_adapters.rs†L188-L260】
+All adapters emit events in the deterministic order `Analytics → Key →
+Focus/Blur → Change → Commit → callback`, with pointer interactions simply
+skipping the keyboard payload. Tests across every framework validate that
+telemetry fires before user callbacks and that commits capture the final
+selection snapshot—even in controlled radio groups.【F:crates/rustic-ui-material/src/radio.rs†L118-L213】【F:crates/rustic-ui-material/src/radio.rs†L2620-L2798】【F:crates/rustic-ui-material/src/radio.rs†L3190-L3286】【F:crates/rustic-ui-material/tests/radio_adapters.rs†L188-L272】
 
 ## Yew example: register a telemetry delegate
 


### PR DESCRIPTION
## Summary
- add the `RadioTelemetryEvent::Key` variant and feed keyboard telemetry through the React, Yew, Leptos, Dioxus, and Sycamore radio handlers before state commits
- expose the key payload to React consumers, tighten the per-adapter unit tests, and extend the shared radio adapter harness to expect the expanded telemetry stream
- document the telemetry ordering and keyboard semantics in the Material README and the selection control telemetry guide

## Testing
- `cargo test -p rustic-ui-material --features "yew leptos dioxus sycamore" radio_adapters` *(fails: upstream `leptos` crate requires missing `DynBindings` trait when compiled in this environment)*
- `cargo test -p rustic-ui-material --no-default-features --features yew radio_adapters` *(fails: yew-only build expects macro re-exports from other feature gates in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68ddafb0df1c832e80f429478eac3181