### PR TITLE
Guard checkbox adapters against controlled mutations

### DIFF
--- a/crates/rustic-ui-material/src/checkbox.rs
+++ b/crates/rustic-ui-material/src/checkbox.rs
@@ -738,7 +738,9 @@ pub mod react {
             }
             {
                 let mut state = state.borrow_mut();
-                state.toggle(|_| {});
+                if !state.is_controlled() {
+                    state.toggle(|_| {});
+                }
             }
         }) as Box<dyn FnMut(JsValue)>);
 
@@ -872,7 +874,9 @@ pub mod react {
 
                 {
                     let mut state = state.borrow_mut();
-                    state.on_key(key, |_| {});
+                    if !state.is_controlled() {
+                        state.on_key(key, |_| {});
+                    }
                 }
             }
         }) as Box<dyn FnMut(JsValue)>);
@@ -916,10 +920,12 @@ pub mod react {
     ///   precedes side effects, aligning with audit requirements in regulated
     ///   environments.
     /// * After telemetry delegates and consumer callbacks run, the captured
-    ///   [`CheckboxState`] is mutated via [`CheckboxState::toggle`],
+    ///   [`CheckboxState`] mutates via [`CheckboxState::toggle`],
     ///   [`CheckboxState::focus`], [`CheckboxState::blur`], and
-    ///   [`CheckboxState::on_key`] so UI transitions always flow through the
-    ///   shared headless state machine.
+    ///   [`CheckboxState::on_key`] whenever it owns its value. Controlled
+    ///   integrations trigger the same telemetry/change notifications but the
+    ///   bridge guards the mutation with [`CheckboxState::is_controlled`] so
+    ///   local snapshots stay in sync with external sources of truth.
     pub fn ReactCheckbox(props: &ReactCheckboxProps) -> Jsx {
         let (context, _descriptor, snapshot) = descriptor_with_context(
             "rustic_ui_material::checkbox::react::ReactCheckbox",
@@ -991,8 +997,10 @@ pub mod yew {
     ///   analytics capture consistently precedes consumer side effects.
     /// * After telemetry flows, the shared [`CheckboxState`] transitions via
     ///   [`CheckboxState::toggle`], [`CheckboxState::focus`],
-    ///   [`CheckboxState::blur`], and [`CheckboxState::on_key`] ensuring the UI
-    ///   always reflects the canonical headless state.
+    ///   [`CheckboxState::blur`], and [`CheckboxState::on_key`] whenever it owns
+    ///   its value. Controlled parents still receive telemetry/change
+    ///   callbacks, yet the bridge checks [`CheckboxState::is_controlled`] so
+    ///   the local snapshot stays untouched until the external owner syncs it.
     #[function_component(YewCheckbox)]
     pub fn yew_checkbox(props: &YewCheckboxProps) -> Html {
         let (context, _descriptor, snapshot) = descriptor_with_context(
@@ -1022,7 +1030,9 @@ pub mod yew {
                     }
                     {
                         let mut state = state.borrow_mut();
-                        state.toggle(|_| {});
+                        if !state.is_controlled() {
+                            state.toggle(|_| {});
+                        }
                     }
                 })
             };
@@ -1098,7 +1108,9 @@ pub mod yew {
                         }
                         {
                             let mut state = state.borrow_mut();
-                            state.on_key(control, |_| {});
+                            if !state.is_controlled() {
+                                state.on_key(control, |_| {});
+                            }
                         }
                     }
                 })
@@ -1160,8 +1172,11 @@ pub mod leptos {
     ///   telemetry delegate **before** executing user callbacks, keeping
     ///   analytics capture deterministic.
     /// * [`CheckboxState`] transitions (`toggle`/`focus`/`blur`/`on_key`) execute
-    ///   after telemetry delegates fire so the UI mutates through the shared
-    ///   headless state machine while preserving analytics ordering.
+    ///   after telemetry delegates fire whenever the checkbox owns its value, so
+    ///   the UI mutates through the shared headless state machine while
+    ///   preserving analytics ordering. Controlled flows emit the same telemetry
+    ///   yet skip the mutation because the bridge checks
+    ///   [`CheckboxState::is_controlled`], keeping host-owned truth authoritative.
     pub fn LeptosCheckbox(props: LeptosCheckboxProps) -> impl IntoView {
         let (context, _descriptor, snapshot) = descriptor_with_context(
             "rustic_ui_material::checkbox::leptos::LeptosCheckbox",
@@ -1197,7 +1212,9 @@ pub mod leptos {
                     }
                     {
                         let mut state = state.borrow_mut();
-                        state.toggle(|_| {});
+                        if !state.is_controlled() {
+                            state.toggle(|_| {});
+                        }
                     }
                 }
             };
@@ -1273,7 +1290,9 @@ pub mod leptos {
                         }
                         {
                             let mut state = state.borrow_mut();
-                            state.on_key(control, |_| {});
+                            if !state.is_controlled() {
+                                state.on_key(control, |_| {});
+                            }
                         }
                     }
                 }
@@ -1371,8 +1390,11 @@ pub mod dioxus {
     ///   analytics capture precedes business logic.
     /// * After telemetry dispatch, the shared [`CheckboxState`] transitions via
     ///   [`CheckboxState::toggle`], [`CheckboxState::focus`],
-    ///   [`CheckboxState::blur`], and [`CheckboxState::on_key`], guaranteeing all
-    ///   UI updates flow through the headless state machine.
+    ///   [`CheckboxState::blur`], and [`CheckboxState::on_key`] whenever it owns
+    ///   its value, guaranteeing UI updates flow through the headless state
+    ///   machine. Controlled consumers still receive telemetry/change payloads
+    ///   while the guard around [`CheckboxState::is_controlled`] prevents local
+    ///   mutation until hosts sync external truth.
     pub fn DioxusCheckbox(cx: Scope<DioxusCheckboxProps>) -> Element {
         let props = cx.props();
         let (context, _descriptor, snapshot) = descriptor_with_context(
@@ -1409,7 +1431,9 @@ pub mod dioxus {
                     }
                     {
                         let mut state = state.borrow_mut();
-                        state.toggle(|_| {});
+                        if !state.is_controlled() {
+                            state.toggle(|_| {});
+                        }
                     }
                 }
             };
@@ -1490,7 +1514,9 @@ pub mod dioxus {
                             }
                             {
                                 let mut state = state.borrow_mut();
-                                state.on_key(control, |_| {});
+                                if !state.is_controlled() {
+                                    state.on_key(control, |_| {});
+                                }
                             }
                         }
                     }
@@ -1555,8 +1581,11 @@ pub mod sycamore {
     /// with attribute metadata scopes the render span, telemetry delegates fire
     /// before consumer callbacks, and [`CheckboxState`] transitions occur via
     /// [`CheckboxState::toggle`], [`CheckboxState::focus`],
-    /// [`CheckboxState::blur`], and [`CheckboxState::on_key`] after analytics
-    /// capture so UI updates funnel through the shared headless state machine.
+    /// [`CheckboxState::blur`], and [`CheckboxState::on_key`] once analytics
+    /// capture completes **and** the state machine owns its value. Controlled
+    /// flows still emit telemetry/change callbacks, yet the guard around
+    /// [`CheckboxState::is_controlled`] keeps the local snapshot pristine until
+    /// hosts reconcile external truth.
     #[component]
     pub fn SycamoreCheckbox<G: Html>(cx: Scope, props: SycamoreCheckboxProps) -> Template<G> {
         let (context, _descriptor, snapshot) = descriptor_with_context(
@@ -1593,7 +1622,9 @@ pub mod sycamore {
                     }
                     {
                         let mut state = state.borrow_mut();
-                        state.toggle(|_| {});
+                        if !state.is_controlled() {
+                            state.toggle(|_| {});
+                        }
                     }
                 }
             };
@@ -1669,7 +1700,9 @@ pub mod sycamore {
                         }
                         {
                             let mut state = state.borrow_mut();
-                            state.on_key(control, |_| {});
+                            if !state.is_controlled() {
+                                state.on_key(control, |_| {});
+                            }
                         }
                     }
                 }

--- a/crates/rustic-ui-material/tests/checkbox_adapters.rs
+++ b/crates/rustic-ui-material/tests/checkbox_adapters.rs
@@ -121,6 +121,14 @@ mod yew_tests {
 
     impl YewHarness {
         fn new() -> Self {
+            Self::new_with_state(CheckboxState::uncontrolled(false, false))
+        }
+
+        fn new_controlled() -> Self {
+            Self::new_with_state(CheckboxState::controlled(false, false))
+        }
+
+        fn new_with_state(state: CheckboxState) -> Self {
             let contexts = Arc::new(Mutex::new(Vec::new()));
             let mut props = CheckboxProps::new("Marketing opt-in");
             props.telemetry = instrumented_hooks(
@@ -128,8 +136,6 @@ mod yew_tests {
                 "automation::checkbox::yew",
                 &contexts,
             );
-            let state = CheckboxState::uncontrolled(false, false);
-
             let telemetry_events = Rc::new(RefCell::new(Vec::new()));
             let telemetry_delegate = {
                 let events = Rc::clone(&telemetry_events);
@@ -209,7 +215,9 @@ mod yew_tests {
             self.telemetry_delegate
                 .emit(CheckboxTelemetryEvent::Change(payload.clone()));
             self.on_change.emit(payload.clone());
-            self.state.toggle(|_| {});
+            if !self.state.is_controlled() {
+                self.state.toggle(|_| {});
+            }
             payload
         }
 
@@ -240,7 +248,9 @@ mod yew_tests {
                 .emit(CheckboxTelemetryEvent::Change(change_payload.clone()));
             self.on_key.emit(key_payload.clone());
             self.on_change.emit(change_payload.clone());
-            self.state.on_key(key, |_| {});
+            if !self.state.is_controlled() {
+                self.state.on_key(key, |_| {});
+            }
             (key_payload, change_payload)
         }
     }
@@ -318,6 +328,41 @@ mod yew_tests {
         assert_eq!(key_events.len(), 1);
         assert_eq!(key_events[0], expected_key);
     }
+
+    #[test]
+    fn controlled_state_still_emits_events_without_mutating_local_snapshot() {
+        let mut harness = YewHarness::new_controlled();
+        let initial_value = harness.state.checked();
+
+        let expected_change = expected_change(&harness.props, &harness.state);
+        let change = harness.simulate_change();
+        assert_eq!(change, expected_change);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let (expected_key, expected_key_change) = harness.simulate_key(ControlKey::Space);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let telemetry = harness.telemetry_events.borrow();
+        assert_eq!(telemetry.len(), 3);
+        assert_eq!(
+            telemetry[0],
+            CheckboxTelemetryEvent::Change(expected_change.clone())
+        );
+        assert_eq!(
+            telemetry[1],
+            CheckboxTelemetryEvent::Key(expected_key.clone())
+        );
+        assert_eq!(
+            telemetry[2],
+            CheckboxTelemetryEvent::Change(expected_key_change.clone())
+        );
+        drop(telemetry);
+
+        let changes = harness.change_events.borrow();
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0], expected_change);
+        assert_eq!(changes[1], expected_key_change);
+    }
 }
 
 #[cfg(feature = "leptos")]
@@ -343,6 +388,14 @@ mod leptos_tests {
 
     impl LeptosHarness {
         fn new() -> Self {
+            Self::new_with_state(CheckboxState::uncontrolled(false, false))
+        }
+
+        fn new_controlled() -> Self {
+            Self::new_with_state(CheckboxState::controlled(false, false))
+        }
+
+        fn new_with_state(state: CheckboxState) -> Self {
             let contexts = Arc::new(Mutex::new(Vec::new()));
             let mut props = CheckboxProps::new("Release automation");
             props.telemetry = instrumented_hooks(
@@ -350,8 +403,6 @@ mod leptos_tests {
                 "automation::checkbox::leptos",
                 &contexts,
             );
-            let state = CheckboxState::uncontrolled(false, false);
-
             let telemetry_events = Rc::new(RefCell::new(Vec::new()));
             let telemetry_delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = {
                 let events = Rc::clone(&telemetry_events);
@@ -433,7 +484,9 @@ mod leptos_tests {
             let payload = expected_change(&self.props, &self.state);
             (self.telemetry_delegate)(CheckboxTelemetryEvent::Change(payload.clone()));
             (self.on_change)(payload.clone());
-            self.state.toggle(|_| {});
+            if !self.state.is_controlled() {
+                self.state.toggle(|_| {});
+            }
             payload
         }
 
@@ -460,7 +513,9 @@ mod leptos_tests {
             (self.telemetry_delegate)(CheckboxTelemetryEvent::Change(change_payload.clone()));
             (self.on_key)(key_payload.clone());
             (self.on_change)(change_payload.clone());
-            self.state.on_key(key, |_| {});
+            if !self.state.is_controlled() {
+                self.state.on_key(key, |_| {});
+            }
             (key_payload, change_payload)
         }
     }
@@ -538,6 +593,41 @@ mod leptos_tests {
         assert_eq!(key_events.len(), 1);
         assert_eq!(key_events[0], expected_key);
     }
+
+    #[test]
+    fn controlled_state_still_emits_events_without_mutating_local_snapshot() {
+        let mut harness = LeptosHarness::new_controlled();
+        let initial_value = harness.state.checked();
+
+        let expected_change = expected_change(&harness.props, &harness.state);
+        let change = harness.simulate_change();
+        assert_eq!(change, expected_change);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let (expected_key, expected_key_change) = harness.simulate_key(ControlKey::Space);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let telemetry = harness.telemetry_events.borrow();
+        assert_eq!(telemetry.len(), 3);
+        assert_eq!(
+            telemetry[0],
+            CheckboxTelemetryEvent::Change(expected_change.clone())
+        );
+        assert_eq!(
+            telemetry[1],
+            CheckboxTelemetryEvent::Key(expected_key.clone())
+        );
+        assert_eq!(
+            telemetry[2],
+            CheckboxTelemetryEvent::Change(expected_key_change.clone())
+        );
+        drop(telemetry);
+
+        let changes = harness.change_events.borrow();
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0], expected_change);
+        assert_eq!(changes[1], expected_key_change);
+    }
 }
 
 #[cfg(feature = "dioxus")]
@@ -564,6 +654,14 @@ mod dioxus_tests {
 
     impl DioxusHarness {
         fn new() -> Self {
+            Self::new_with_state(CheckboxState::uncontrolled(false, false))
+        }
+
+        fn new_controlled() -> Self {
+            Self::new_with_state(CheckboxState::controlled(false, false))
+        }
+
+        fn new_with_state(state: CheckboxState) -> Self {
             let contexts = Arc::new(Mutex::new(Vec::new()));
             let mut props = CheckboxProps::new("Nightly deployments");
             props.telemetry = instrumented_hooks(
@@ -571,7 +669,6 @@ mod dioxus_tests {
                 "automation::checkbox::dioxus",
                 &contexts,
             );
-            let state = CheckboxState::uncontrolled(false, false);
 
             let telemetry_events = Rc::new(RefCell::new(Vec::new()));
             let telemetry_delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = {
@@ -648,7 +745,9 @@ mod dioxus_tests {
             let payload = expected_change(&self.props, &self.state);
             (self.telemetry_delegate)(CheckboxTelemetryEvent::Change(payload.clone()));
             (self.on_change)(payload.clone());
-            self.state.toggle(|_| {});
+            if !self.state.is_controlled() {
+                self.state.toggle(|_| {});
+            }
             payload
         }
 
@@ -675,7 +774,9 @@ mod dioxus_tests {
             (self.telemetry_delegate)(CheckboxTelemetryEvent::Change(change_payload.clone()));
             (self.on_key)(key_payload.clone());
             (self.on_change)(change_payload.clone());
-            self.state.on_key(key, |_| {});
+            if !self.state.is_controlled() {
+                self.state.on_key(key, |_| {});
+            }
             (key_payload, change_payload)
         }
     }
@@ -753,6 +854,41 @@ mod dioxus_tests {
         assert_eq!(key_events.len(), 1);
         assert_eq!(key_events[0], expected_key);
     }
+
+    #[test]
+    fn controlled_state_still_emits_events_without_mutating_local_snapshot() {
+        let mut harness = DioxusHarness::new_controlled();
+        let initial_value = harness.state.checked();
+
+        let expected_change = expected_change(&harness.props, &harness.state);
+        let change = harness.simulate_change();
+        assert_eq!(change, expected_change);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let (expected_key, expected_key_change) = harness.simulate_key(ControlKey::Space);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let telemetry = harness.telemetry_events.borrow();
+        assert_eq!(telemetry.len(), 3);
+        assert_eq!(
+            telemetry[0],
+            CheckboxTelemetryEvent::Change(expected_change.clone())
+        );
+        assert_eq!(
+            telemetry[1],
+            CheckboxTelemetryEvent::Key(expected_key.clone())
+        );
+        assert_eq!(
+            telemetry[2],
+            CheckboxTelemetryEvent::Change(expected_key_change.clone())
+        );
+        drop(telemetry);
+
+        let changes = harness.change_events.borrow();
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0], expected_change);
+        assert_eq!(changes[1], expected_key_change);
+    }
 }
 
 #[cfg(feature = "sycamore")]
@@ -779,6 +915,14 @@ mod sycamore_tests {
 
     impl SycamoreHarness {
         fn new() -> Self {
+            Self::new_with_state(CheckboxState::uncontrolled(false, false))
+        }
+
+        fn new_controlled() -> Self {
+            Self::new_with_state(CheckboxState::controlled(false, false))
+        }
+
+        fn new_with_state(state: CheckboxState) -> Self {
             let contexts = Arc::new(Mutex::new(Vec::new()));
             let mut props = CheckboxProps::new("Finance approvals");
             props.telemetry = instrumented_hooks(
@@ -786,7 +930,6 @@ mod sycamore_tests {
                 "automation::checkbox::sycamore",
                 &contexts,
             );
-            let state = CheckboxState::uncontrolled(false, false);
 
             let telemetry_events = Rc::new(RefCell::new(Vec::new()));
             let telemetry_delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = {
@@ -867,7 +1010,9 @@ mod sycamore_tests {
             let payload = expected_change(&self.props, &self.state);
             (self.telemetry_delegate)(CheckboxTelemetryEvent::Change(payload.clone()));
             (self.on_change)(payload.clone());
-            self.state.toggle(|_| {});
+            if !self.state.is_controlled() {
+                self.state.toggle(|_| {});
+            }
             payload
         }
 
@@ -894,7 +1039,9 @@ mod sycamore_tests {
             (self.telemetry_delegate)(CheckboxTelemetryEvent::Change(change_payload.clone()));
             (self.on_key)(key_payload.clone());
             (self.on_change)(change_payload.clone());
-            self.state.on_key(key, |_| {});
+            if !self.state.is_controlled() {
+                self.state.on_key(key, |_| {});
+            }
             (key_payload, change_payload)
         }
     }
@@ -971,5 +1118,40 @@ mod sycamore_tests {
         let key_events = harness.key_events.borrow();
         assert_eq!(key_events.len(), 1);
         assert_eq!(key_events[0], expected_key);
+    }
+
+    #[test]
+    fn controlled_state_still_emits_events_without_mutating_local_snapshot() {
+        let mut harness = SycamoreHarness::new_controlled();
+        let initial_value = harness.state.checked();
+
+        let expected_change = expected_change(&harness.props, &harness.state);
+        let change = harness.simulate_change();
+        assert_eq!(change, expected_change);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let (expected_key, expected_key_change) = harness.simulate_key(ControlKey::Space);
+        assert_eq!(harness.state.checked(), initial_value);
+
+        let telemetry = harness.telemetry_events.borrow();
+        assert_eq!(telemetry.len(), 3);
+        assert_eq!(
+            telemetry[0],
+            CheckboxTelemetryEvent::Change(expected_change.clone())
+        );
+        assert_eq!(
+            telemetry[1],
+            CheckboxTelemetryEvent::Key(expected_key.clone())
+        );
+        assert_eq!(
+            telemetry[2],
+            CheckboxTelemetryEvent::Change(expected_key_change.clone())
+        );
+        drop(telemetry);
+
+        let changes = harness.change_events.borrow();
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0], expected_change);
+        assert_eq!(changes[1], expected_key_change);
     }
 }


### PR DESCRIPTION
## Summary
- wrap toggle and key transitions across the material checkbox adapters with controlled-state guards so UI state is only mutated when the headless machine owns it
- document the controlled guard in each adapter lifecycle description for audit clarity
- expand checkbox adapter tests with controlled harness coverage to assert telemetry/change flows without mutating local state

## Testing
- cargo test -p rustic-ui-material --test checkbox_adapters --all-features *(fails: leptos dependency missing DynBindings trait when compiling with all features)*
- cargo test -p rustic-ui-material --test checkbox_adapters --features yew *(fails: existing macro issues in unrelated modules prevent compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68dde0648c1c832e92881a38645b5395