### PR TITLE
Ensure Leptos radios record controlled focus telemetry

### DIFF
--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -2410,19 +2410,32 @@ pub mod leptos {
                     )
                 };
 
-                let next_index = if controlled {
-                    let state_ref = state.borrow();
-                    preview_keyboard_target(&state_ref, control)
-                } else {
-                    let selected_after = Rc::new(RefCell::new(None));
-                    {
-                        let mut state_mut = state.borrow_mut();
-                        let recorder = Rc::clone(&selected_after);
-                        state_mut.on_key(control, move |selected| {
-                            recorder.borrow_mut().replace(selected);
-                        });
+                let selected_after = Rc::new(RefCell::new(None));
+                {
+                    // Governance-grade focus audit trail: even in controlled mode we
+                    // forward the key press into the headless state machine so the
+                    // canonical roving focus algorithm records which option would be
+                    // highlighted.  Framework adapters only own the commit step; by
+                    // sourcing the focus intent from `on_key` we ensure telemetry is
+                    // anchored to the same index the core engine calculated, keeping
+                    // accessibility reviewers and SOC teams in sync.
+                    let mut state_mut = state.borrow_mut();
+                    let recorder = Rc::clone(&selected_after);
+                    state_mut.on_key(control, move |selected| {
+                        recorder.borrow_mut().replace(selected);
+                    });
+                }
+
+                let next_index = {
+                    let resolved = selected_after.borrow().copied();
+                    if resolved.is_some() {
+                        resolved
+                    } else if controlled {
+                        let state_ref = state.borrow();
+                        preview_keyboard_target(&state_ref, control)
+                    } else {
+                        None
                     }
-                    *selected_after.borrow()
                 };
 
                 refresh();

--- a/crates/rustic-ui-material/tests/radio_adapters.rs
+++ b/crates/rustic-ui-material/tests/radio_adapters.rs
@@ -482,16 +482,53 @@ where
     assert_eq!(key_event.next, Some(2));
     assert_eq!(harness.state.selected_index(), initial_selected);
 
-    if framework == "yew" {
-        // Enterprise governance expects controlled Yew integrations to advance the
-        // roving focus index even though the caller owns the commit.  Asserting the
-        // focus telemetry immediately after the keyboard step documents the order:
-        // pointer intent → commit audit → keyboard intent → focus audit.
+    if matches!(framework, "yew" | "leptos") {
+        // Enterprise governance expects controlled adapters to advance the roving
+        // focus index even though the caller owns the commit.  Auditors review
+        // this assertion to confirm pointer intent → commit audit → keyboard intent
+        // → focus audit remains intact across frameworks before production rollout.
         assert_eq!(
             harness.state.focus_visible_index(),
             key_event.next,
-            "Yew controlled radio groups must expose focus movement for audit logs",
+            "{} controlled radio groups must expose focus movement for audit logs",
+            framework,
         );
+
+        // Telemetry due diligence: validate the key payload forwarded to SOC
+        // tooling points at the same option index recorded by the roving focus
+        // machinery.  This keeps enterprise monitoring in lockstep with the core
+        // interaction contract regardless of rendering surface.
+        let key_telemetry = harness
+            .telemetry_events
+            .iter()
+            .find_map(|event| match event {
+                RadioTelemetryEvent::Key(evt) => Some(evt.clone()),
+                _ => None,
+            })
+            .expect("key telemetry");
+        assert_eq!(key_telemetry.next, key_event.next);
+
+        let focus_telemetry = harness
+            .telemetry_events
+            .iter()
+            .find_map(|event| match event {
+                RadioTelemetryEvent::Focus(evt) => Some(evt.clone()),
+                _ => None,
+            })
+            .expect("focus telemetry");
+        assert!(focus_telemetry.focused);
+        assert_eq!(focus_telemetry.index, key_event.next.unwrap());
+
+        let blur_telemetry = harness
+            .telemetry_events
+            .iter()
+            .find_map(|event| match event {
+                RadioTelemetryEvent::Blur(evt) => Some(evt.clone()),
+                _ => None,
+            })
+            .expect("blur telemetry");
+        assert!(!blur_telemetry.focused);
+        assert_eq!(blur_telemetry.index, pointer_change.next);
     }
 
     let key_commit = harness


### PR DESCRIPTION
## Summary
- route Leptos radio keyboard handling through the headless state machine in both controlled and uncontrolled modes to capture focus intent for telemetry
- expand controlled radio adapter tests to assert Leptos propagates roving focus updates and associated telemetry payloads alongside enterprise commentary

## Testing
- cargo fmt
- cargo test -p rustic-ui-material --features "leptos" --tests *(fails: dependency `leptos` missing `DynBindings` trait when compiled with the requested feature set)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfbb1be70832e9879e6d421c80251