### PR TITLE
Ensure Dioxus controlled radios advance focus

### DIFF
--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -3412,19 +3412,46 @@ pub mod dioxus {
                     )
                 };
 
-                let next_index = if controlled {
-                    let state_ref = state.borrow();
-                    preview_keyboard_target(&state_ref, control)
-                } else {
-                    let selected_after = Rc::new(RefCell::new(None));
-                    {
-                        let mut state_mut = state.borrow_mut();
-                        let recorder = Rc::clone(&selected_after);
-                        state_mut.on_key(control, move |selected| {
-                            recorder.borrow_mut().replace(selected);
-                        });
+                // Regulatory audit requirement: the headless state machine must
+                // always observe the keyboard control flow so the roving focus
+                // cursor advances identically for controlled and uncontrolled
+                // inputs.  We therefore invoke `on_key` unconditionally and
+                // capture the resulting index in a scoped cell.  Controlled
+                // callers ignore the commit produced by the state machine, but
+                // the focus mutation remains authoritative for accessibility
+                // attestations and SOC reviewers.
+                let selected_after = Rc::new(RefCell::new(None));
+                {
+                    // Compliance note: this guard intentionally borrows the
+                    // state mutably even when the group is controlled.  The
+                    // inner callback records the computed target so telemetry
+                    // can cite the same index as the roving focus algorithm,
+                    // while the controlled contract keeps the commit owner in
+                    // the host application.  This mirrors the sequencing used
+                    // by the React/Yew adapters and keeps our analytics trace
+                    // consistent across renderers.
+                    let mut state_mut = state.borrow_mut();
+                    let recorder = Rc::clone(&selected_after);
+                    state_mut.on_key(control, move |selected| {
+                        recorder.borrow_mut().replace(selected);
+                    });
+                }
+
+                let next_index = {
+                    let resolved = selected_after.borrow().copied();
+                    if resolved.is_some() {
+                        resolved
+                    } else if controlled {
+                        // Fallback for defensive parity: if the controlled flow
+                        // short-circuited selection we still synthesize the
+                        // focus target using the deterministic preview helper so
+                        // auditors see a stable trajectory in the telemetry
+                        // payloads.
+                        let state_ref = state.borrow();
+                        preview_keyboard_target(&state_ref, control)
+                    } else {
+                        None
                     }
-                    *selected_after.borrow()
                 };
 
                 refresh();

--- a/crates/rustic-ui-material/tests/radio_adapters.rs
+++ b/crates/rustic-ui-material/tests/radio_adapters.rs
@@ -482,11 +482,15 @@ where
     assert_eq!(key_event.next, Some(2));
     assert_eq!(harness.state.selected_index(), initial_selected);
 
-    if matches!(framework, "yew" | "leptos") {
+    let requires_focus_audit = matches!(framework, "yew" | "leptos" | "dioxus");
+    if requires_focus_audit {
         // Enterprise governance expects controlled adapters to advance the roving
         // focus index even though the caller owns the commit.  Auditors review
         // this assertion to confirm pointer intent → commit audit → keyboard intent
         // → focus audit remains intact across frameworks before production rollout.
+        // Dioxus recently joined the focus parity guarantee, hence the explicit
+        // guard instead of an `else` branch so compliance logs capture which
+        // renderer was under evaluation when the navigation handshake executed.
         assert_eq!(
             harness.state.focus_visible_index(),
             key_event.next,
@@ -497,7 +501,10 @@ where
         // Telemetry due diligence: validate the key payload forwarded to SOC
         // tooling points at the same option index recorded by the roving focus
         // machinery.  This keeps enterprise monitoring in lockstep with the core
-        // interaction contract regardless of rendering surface.
+        // interaction contract regardless of rendering surface.  The Dioxus
+        // adapter previously skipped the headless `on_key` path when controlled;
+        // these checks ensure the regression cannot reappear without immediately
+        // tripping our compliance dashboards.
         let key_telemetry = harness
             .telemetry_events
             .iter()
@@ -603,6 +610,10 @@ mod dioxus_tests {
 
     #[test]
     fn controlled_mode_emits_telemetry_without_mutating_state() {
+        // Compliance visibility: Dioxus' controlled execution path now mirrors
+        // the React/Yew focus choreography.  We re-use the shared harness so the
+        // newly enforced keyboard telemetry assertions execute during every CI
+        // cycle, keeping the enterprise audit story consistent across adapters.
         exercise_controlled_adapter("dioxus", radio::dioxus::render);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the Dioxus radio keyboard handler always routes through the headless state so controlled inputs advance focus, with governance notes documenting the guard
- extend the shared controlled-mode adapter harness to enforce Dioxus focus and telemetry rotation, including auditor-facing commentary in the dioxus test module

## Testing
- cargo fmt
- cargo test -p rustic-ui-material --features "dioxus" --tests *(fails: existing dioxus feature compilation errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ddfdd8fa7c832e85afcfaedf6d3ff0