### PR TITLE
Align Sycamore controlled radio focus telemetry

### DIFF
--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -2002,14 +2002,15 @@ pub mod yew {
 
                     let selected_after = Rc::new(RefCell::new(None));
                     {
-                        // Focus guard: borrow the state mutably only long enough to
-                        // delegate to the headless state machine.  Enterprise
-                        // governance teams audit this hand-off to confirm roving
-                        // focus is always updated by the canonical logic, even when
-                        // React/Yew consumers operate the component in controlled
-                        // mode.  By funnelling the key into `on_key` we capture the
-                        // callback-selected index for telemetry without taking over
-                        // ownership of the eventual commit.
+                        // Focus guard: we only hold the mutable borrow long enough
+                        // to stream the keystroke through the headless
+                        // [`RadioGroupState::on_key`].  Enterprise reviewers lean on
+                        // this choreography to prove that every renderer – Sycamore
+                        // included – sources its roving focus progression from the
+                        // canonical state machine.  The callback supplied to
+                        // `on_key` records the index requested by the headless
+                        // logic, ensuring telemetry mirrors the same navigation
+                        // contract auditors inspect during readiness reviews.
                         let mut state_mut = state.borrow_mut();
                         let recorder = Rc::clone(&selected_after);
                         state_mut.on_key(control, move |selected| {
@@ -2018,6 +2019,21 @@ pub mod yew {
                     }
 
                     let next_index = selected_after.borrow().copied();
+
+                    if controlled {
+                        if let Some(next_index) = next_index {
+                            // Controlled safeguard: the external owner remains in
+                            // charge of committing selection state, yet governance
+                            // requires the roving focus index to advance so SOC
+                            // dashboards can trace intent across renders.  We
+                            // re-enter the state machine momentarily to align the
+                            // visible focus with the callback supplied by
+                            // `on_key`, without mutating the caller owned
+                            // selection snapshot.
+                            let mut state_mut = state.borrow_mut();
+                            state_mut.focus(next_index);
+                        }
+                    }
 
                     let mut telemetry_events = Vec::with_capacity(6);
                     telemetry_events.push(analytics_event);

--- a/crates/rustic-ui-material/tests/radio_adapters.rs
+++ b/crates/rustic-ui-material/tests/radio_adapters.rs
@@ -482,7 +482,7 @@ where
     assert_eq!(key_event.next, Some(2));
     assert_eq!(harness.state.selected_index(), initial_selected);
 
-    let requires_focus_audit = matches!(framework, "yew" | "leptos" | "dioxus");
+    let requires_focus_audit = matches!(framework, "yew" | "leptos" | "dioxus" | "sycamore");
     if requires_focus_audit {
         // Enterprise governance expects controlled adapters to advance the roving
         // focus index even though the caller owns the commit.  Auditors review
@@ -629,6 +629,13 @@ mod sycamore_tests {
 
     #[test]
     fn controlled_mode_emits_telemetry_without_mutating_state() {
+        // Lifecycle contract: the harness first stages a pointer interaction to
+        // capture the read-only commit snapshot.  Arrow navigation follows so we
+        // can assert Sycamore relays the callback supplied by
+        // `RadioGroupState::on_key` into both the roving focus index and the
+        // emitted telemetry payloads.  Enterprise operations uses these checks to
+        // validate focus advancement, `focus_visible_index()` parity and SOC
+        // analytics wiring prior to production rollout.
         exercise_controlled_adapter("sycamore", radio::sycamore::render);
     }
 }


### PR DESCRIPTION
## Summary
- keep Sycamore radio key handling on the headless `on_key` path, capturing the callback index for telemetry while separately guarding controlled commit payloads
- document the controlled focus progression contract and include Sycamore in the shared controlled adapter focus audits

## Testing
- `cargo fmt`
- `cargo test -p rustic-ui-material --features "sycamore" --tests` *(fails: sycamore adapters currently missing `component`/`view` macro imports and css macro terminators in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ddffeb4768832e837a572b40f66c6e