### PR TITLE
Add wasm telemetry tests for React toggle controls

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 xtask = "run --package xtask --"
+wasm-react-test = "test --package rustic-ui-material --target wasm32-unknown-unknown --features react"

--- a/crates/rustic-ui-material/Cargo.toml
+++ b/crates/rustic-ui-material/Cargo.toml
@@ -52,3 +52,4 @@ forms = ["rustic-ui-headless/forms"]
 feedback = ["rustic-ui-headless/feedback"]
 progress = ["rustic-ui-headless/progress"]
 unstable = ["rustic-ui-headless/unstable"]
+

--- a/crates/rustic-ui-material/README.md
+++ b/crates/rustic-ui-material/README.md
@@ -49,6 +49,27 @@ disabled by default so applications opt in explicitly:
 See the [Cargo feature guide](../../docs/cargo-features.md) for examples of
 disabling defaults and enabling only the framework your application requires.
 
+## WebAssembly test harness
+
+Enterprise teams frequently validate React bindings inside the WebAssembly
+target to guarantee the `wasm_bindgen` bridges and telemetry delegates behave as
+expected. The crate ships a convenience alias so there is no bespoke scripting
+required to exercise the suite:
+
+```bash
+# one-time toolchain setup
+rustup target add wasm32-unknown-unknown
+
+# execute every React adapter test (including the new telemetry assertions)
+cargo wasm-react-test
+```
+
+The alias expands to `cargo test --target wasm32-unknown-unknown --features
+react`, keeping CI and local workflows aligned without copy/pasting the verbose
+command. The tests depend on [`wasm-bindgen-test`], so running them in a browser
+enabled environment (headless or via `wasm_bindgen_test_configure!(run_in_browser)`) is
+fully supported.
+
 ## Feedback primitives (Tooltip & Chip)
 
 Enterprise telemetry, accessibility, and automation pipelines lean heavily on

--- a/crates/rustic-ui-material/src/checkbox.rs
+++ b/crates/rustic-ui-material/src/checkbox.rs
@@ -609,7 +609,6 @@ pub mod react {
     use super::*;
     use js_sys::{Array, Function, Object, Reflect};
     use std::{cell::RefCell, rc::Rc};
-    use std::{cell::RefCell, rc::Rc};
     use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 
     /// Type alias representing React elements returned through the WASM bridge.
@@ -895,6 +894,265 @@ pub mod react {
             on_focus: focus_handler(props, &state_handle),
             on_blur: blur_handler(props, &state_handle),
             on_key: key_handler(props, &state_handle),
+        }
+    }
+
+    #[cfg(all(test, feature = "react"))]
+    mod tests {
+        use super::*;
+        use js_sys::{Function, Object, Reflect};
+        use wasm_bindgen::closure::Closure;
+        use wasm_bindgen_test::*;
+
+        wasm_bindgen_test_configure!(run_in_browser);
+
+        fn parse_checkbox_value(value: &JsValue) -> CheckboxValue {
+            match value
+                .as_string()
+                .expect("checkbox telemetry should encode strings")
+                .as_str()
+            {
+                "on" => CheckboxValue::On,
+                "off" => CheckboxValue::Off,
+                "indeterminate" => CheckboxValue::Indeterminate,
+                other => panic!("unexpected checkbox value {other}"),
+            }
+        }
+
+        fn parse_control_key(value: &JsValue) -> ControlKey {
+            match value
+                .as_string()
+                .expect("key telemetry should encode the control key")
+                .as_str()
+            {
+                "space" => ControlKey::Space,
+                "enter" => ControlKey::Enter,
+                other => panic!("unexpected control key {other}"),
+            }
+        }
+
+        fn optional_string(object: &JsValue, key: &str) -> Option<String> {
+            Reflect::get(object, &JsValue::from_str(key))
+                .ok()
+                .and_then(|value| value.as_string())
+        }
+
+        fn decode_checkbox_event(value: &JsValue) -> CheckboxTelemetryEvent {
+            let kind = Reflect::get(value, &JsValue::from_str("kind"))
+                .expect("telemetry payload exposes kind metadata")
+                .as_string()
+                .expect("telemetry kind should be a string");
+            match kind.as_str() {
+                "change" => CheckboxTelemetryEvent::Change(CheckboxChangeEvent {
+                    previous: parse_checkbox_value(
+                        &Reflect::get(value, &JsValue::from_str("previous"))
+                            .expect("previous should be set"),
+                    ),
+                    next: parse_checkbox_value(
+                        &Reflect::get(value, &JsValue::from_str("next"))
+                            .expect("next should be set"),
+                    ),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a boolean"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "focus" => CheckboxTelemetryEvent::Focus(CheckboxFocusEvent {
+                    focused: Reflect::get(value, &JsValue::from_str("focused"))
+                        .expect("focused should be set")
+                        .as_bool()
+                        .expect("focused encodes a boolean"),
+                    checked: parse_checkbox_value(
+                        &Reflect::get(value, &JsValue::from_str("checked"))
+                            .expect("checked should be set"),
+                    ),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a boolean"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "blur" => CheckboxTelemetryEvent::Blur(CheckboxFocusEvent {
+                    focused: Reflect::get(value, &JsValue::from_str("focused"))
+                        .expect("focused should be set")
+                        .as_bool()
+                        .expect("focused encodes a boolean"),
+                    checked: parse_checkbox_value(
+                        &Reflect::get(value, &JsValue::from_str("checked"))
+                            .expect("checked should be set"),
+                    ),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a boolean"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "key" => CheckboxTelemetryEvent::Key(CheckboxKeyEvent {
+                    key: parse_control_key(
+                        &Reflect::get(value, &JsValue::from_str("key")).expect("key should be set"),
+                    ),
+                    previous: parse_checkbox_value(
+                        &Reflect::get(value, &JsValue::from_str("previous"))
+                            .expect("previous should be set"),
+                    ),
+                    next: parse_checkbox_value(
+                        &Reflect::get(value, &JsValue::from_str("next"))
+                            .expect("next should be set"),
+                    ),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a boolean"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                other => panic!("unexpected telemetry kind {other}"),
+            }
+        }
+
+        fn telemetry_recorder() -> (
+            Function,
+            Rc<RefCell<Vec<CheckboxTelemetryEvent>>>,
+            Closure<dyn FnMut(JsValue)>,
+        ) {
+            let events = Rc::new(RefCell::new(Vec::new()));
+            let stored = Rc::clone(&events);
+            let closure = Closure::wrap(Box::new(move |value: JsValue| {
+                let event = decode_checkbox_event(&value);
+                stored.borrow_mut().push(event);
+            }) as Box<dyn FnMut(JsValue)>);
+            let function: Function = closure.as_ref().clone().unchecked_into();
+            (function, events, closure)
+        }
+
+        fn event_kinds(events: &[CheckboxTelemetryEvent]) -> Vec<&'static str> {
+            events
+                .iter()
+                .map(|event| match event {
+                    CheckboxTelemetryEvent::Change(_) => "change",
+                    CheckboxTelemetryEvent::Focus(_) => "focus",
+                    CheckboxTelemetryEvent::Blur(_) => "blur",
+                    CheckboxTelemetryEvent::Key(_) => "key",
+                })
+                .collect()
+        }
+
+        fn invoke(handler: &Option<Function>, event: JsValue) {
+            if let Some(function) = handler {
+                let _ = function.call1(&JsValue::NULL, &event);
+            }
+        }
+
+        fn keyboard_event(key: &str) -> JsValue {
+            let event = Object::new();
+            Reflect::set(&event, &JsValue::from_str("key"), &JsValue::from_str(key))
+                .expect("set key");
+            let prevent = Closure::wrap(Box::new(|| {}) as Box<dyn FnMut()>);
+            Reflect::set(
+                &event,
+                &JsValue::from_str("preventDefault"),
+                prevent.as_ref(),
+            )
+            .expect("set preventDefault");
+            prevent.forget();
+            event.into()
+        }
+
+        fn build_props(state: CheckboxState, telemetry: Option<Function>) -> ReactCheckboxProps {
+            ReactCheckboxProps {
+                checkbox: CheckboxProps::new("Terms of use"),
+                state,
+                on_change: None,
+                on_focus: None,
+                on_blur: None,
+                on_key: None,
+                telemetry_delegate: telemetry,
+            }
+        }
+
+        #[wasm_bindgen_test]
+        fn uncontrolled_handlers_emit_ordered_telemetry() {
+            let (delegate, events, closure) = telemetry_recorder();
+            let props = build_props(
+                CheckboxState::uncontrolled(false, CheckboxValue::Off),
+                Some(delegate),
+            );
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let handlers = handlers(&props, Rc::clone(&state_handle));
+
+            // Focus metadata must land before any mutation attempts so analytics can
+            // observe the untouched state. We therefore expect the focus event to be
+            // the first entry in the telemetry log.
+            invoke(&handlers.on_focus, JsValue::UNDEFINED);
+            invoke(&handlers.on_blur, JsValue::UNDEFINED);
+
+            // Keyboard flows should emit their key payload *before* the change event
+            // to honour the analytics → key/focus → change sequencing.
+            invoke(&handlers.on_key, keyboard_event(" "));
+
+            // Pointer toggles only emit the change payload; this still runs after the
+            // keyboard telemetry so mutation commits happen last.
+            invoke(&handlers.on_change, JsValue::UNDEFINED);
+
+            let kinds = event_kinds(&events.borrow());
+            assert_eq!(kinds, vec!["focus", "blur", "key", "change", "change"]);
+            assert_eq!(state_handle.borrow().checked(), CheckboxValue::Off);
+
+            // The first change toggled the uncontrolled state to `On`, while the
+            // pointer interaction toggled it back to `Off`. Verifying the round-trip
+            // ensures commit semantics occur after telemetry dispatch.
+            let events_ref = events.borrow();
+            let mut iter = events_ref.iter();
+            assert!(matches!(
+                iter.find(|event| matches!(event, CheckboxTelemetryEvent::Key(_))),
+                Some(_)
+            ));
+            drop(events_ref);
+            drop(closure);
+        }
+
+        #[wasm_bindgen_test]
+        fn controlled_handlers_preserve_state() {
+            let (delegate, events, closure) = telemetry_recorder();
+            let props = build_props(
+                CheckboxState::controlled(false, CheckboxValue::Off),
+                Some(delegate),
+            );
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let handlers = handlers(&props, Rc::clone(&state_handle));
+
+            invoke(&handlers.on_key, keyboard_event("Enter"));
+            invoke(&handlers.on_change, JsValue::UNDEFINED);
+
+            // Controlled flows must emit telemetry but keep their state untouched,
+            // reinforcing analytics → key → change → commit ordering without
+            // mutating local caches.
+            assert_eq!(
+                event_kinds(&events.borrow()),
+                vec!["key", "change", "change"]
+            );
+            assert_eq!(state_handle.borrow().checked(), CheckboxValue::Off);
+            drop(closure);
         }
     }
 

--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -1430,10 +1430,11 @@ pub mod react {
         object.into()
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "react"))]
     mod tests {
         use super::*;
-        use std::{cell::RefCell, rc::Rc};
+        use js_sys::{Function, Object, Reflect};
+        use wasm_bindgen::closure::Closure;
         use wasm_bindgen::JsValue;
         use wasm_bindgen_test::*;
 
@@ -1469,15 +1470,175 @@ pub mod react {
             snapshot
         }
 
-        fn telemetry_collector() -> (Function, js_sys::Array) {
-            let events = js_sys::Array::new();
-            let stored = events.clone();
-            let closure = Closure::wrap(Box::new(move |event: JsValue| {
-                stored.push(&event);
+        fn optional_string(object: &JsValue, key: &str) -> Option<String> {
+            Reflect::get(object, &JsValue::from_str(key))
+                .ok()
+                .and_then(|value| value.as_string())
+        }
+
+        fn optional_usize(object: &JsValue, key: &str) -> Option<usize> {
+            Reflect::get(object, &JsValue::from_str(key))
+                .ok()
+                .and_then(|value| {
+                    if value.is_undefined() || value.is_null() {
+                        None
+                    } else {
+                        value.as_f64().map(|value| value as usize)
+                    }
+                })
+        }
+
+        fn required_usize(object: &JsValue, key: &str) -> usize {
+            optional_usize(object, key).expect("telemetry payload should include the field")
+        }
+
+        fn parse_control_key(key: &str) -> ControlKey {
+            match key {
+                "Space" => ControlKey::Space,
+                "Enter" => ControlKey::Enter,
+                "ArrowUp" => ControlKey::ArrowUp,
+                "ArrowDown" => ControlKey::ArrowDown,
+                "ArrowLeft" => ControlKey::ArrowLeft,
+                "ArrowRight" => ControlKey::ArrowRight,
+                "Home" => ControlKey::Home,
+                "End" => ControlKey::End,
+                other => panic!("unexpected control key {other}"),
+            }
+        }
+
+        fn decode_radio_event(value: &JsValue) -> RadioTelemetryEvent {
+            let kind = Reflect::get(value, &JsValue::from_str("kind"))
+                .expect("telemetry payload exposes kind metadata")
+                .as_string()
+                .expect("telemetry kind should be a string");
+            match kind.as_str() {
+                "analytics" => RadioTelemetryEvent::Analytics(RadioAnalyticsEvent {
+                    index: required_usize(value, "index"),
+                    selected: optional_usize(value, "selected"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "key" => RadioTelemetryEvent::Key(RadioKeyEvent {
+                    key: parse_control_key(
+                        Reflect::get(value, &JsValue::from_str("key"))
+                            .expect("key should be set")
+                            .as_string()
+                            .expect("key encodes a string")
+                            .as_str(),
+                    ),
+                    previous: optional_usize(value, "previous"),
+                    next: optional_usize(value, "next"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "focus" => RadioTelemetryEvent::Focus(RadioFocusEvent {
+                    index: required_usize(value, "index"),
+                    focused: Reflect::get(value, &JsValue::from_str("focused"))
+                        .expect("focused should be set")
+                        .as_bool()
+                        .expect("focused encodes a bool"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "blur" => RadioTelemetryEvent::Blur(RadioFocusEvent {
+                    index: required_usize(value, "index"),
+                    focused: Reflect::get(value, &JsValue::from_str("focused"))
+                        .expect("focused should be set")
+                        .as_bool()
+                        .expect("focused encodes a bool"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "change" => RadioTelemetryEvent::Change(RadioChangeEvent {
+                    previous: optional_usize(value, "previous"),
+                    next: required_usize(value, "next"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "commit" => RadioTelemetryEvent::Commit(RadioCommitEvent {
+                    selected: optional_usize(value, "selected"),
+                    controlled: Reflect::get(value, &JsValue::from_str("controlled"))
+                        .expect("controlled should be set")
+                        .as_bool()
+                        .expect("controlled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                other => panic!("unexpected telemetry kind {other}"),
+            }
+        }
+
+        fn telemetry_recorder() -> (
+            Function,
+            Rc<RefCell<Vec<RadioTelemetryEvent>>>,
+            Closure<dyn FnMut(JsValue)>,
+        ) {
+            let events = Rc::new(RefCell::new(Vec::new()));
+            let stored = Rc::clone(&events);
+            let closure = Closure::wrap(Box::new(move |value: JsValue| {
+                let event = decode_radio_event(&value);
+                stored.borrow_mut().push(event);
             }) as Box<dyn FnMut(JsValue)>);
             let function: Function = closure.as_ref().clone().unchecked_into();
-            closure.forget();
-            (function, events)
+            (function, events, closure)
+        }
+
+        fn event_kinds(events: &[RadioTelemetryEvent]) -> Vec<&'static str> {
+            events
+                .iter()
+                .map(|event| match event {
+                    RadioTelemetryEvent::Analytics(_) => "analytics",
+                    RadioTelemetryEvent::Key(_) => "key",
+                    RadioTelemetryEvent::Focus(_) => "focus",
+                    RadioTelemetryEvent::Blur(_) => "blur",
+                    RadioTelemetryEvent::Change(_) => "change",
+                    RadioTelemetryEvent::Commit(_) => "commit",
+                })
+                .collect()
         }
 
         fn build_option_props(
@@ -1501,78 +1662,73 @@ pub mod react {
             (props, state)
         }
 
-        fn call_handler(props: &Object, key: &str) {
-            call_handler_with_event(props, key, JsValue::UNDEFINED);
-        }
-
-        fn call_handler_with_event(props: &Object, key: &str, event: JsValue) {
-            if let Ok(handler) = Reflect::get(props, &JsValue::from_str(key)) {
-                if let Ok(function) = handler.dyn_into::<Function>() {
-                    let _ = function.call1(&JsValue::NULL, &event);
-                }
-            }
-        }
-
         fn keyboard_event(key: &str) -> JsValue {
             let event = Object::new();
             Reflect::set(&event, &JsValue::from_str("key"), &JsValue::from_str(key))
                 .expect("set key");
-
             let prevent = Closure::wrap(Box::new(|| {}) as Box<dyn FnMut()>);
-            let function = prevent.as_ref().clone();
-            Reflect::set(&event, &JsValue::from_str("preventDefault"), &function)
-                .expect("set preventDefault");
+            Reflect::set(
+                &event,
+                &JsValue::from_str("preventDefault"),
+                prevent.as_ref(),
+            )
+            .expect("set preventDefault");
             prevent.forget();
-
             event.into()
         }
 
-        fn event_kinds(events: &js_sys::Array) -> Vec<String> {
-            events
-                .iter()
-                .map(|value| {
-                    Reflect::get(&value, &JsValue::from_str("kind"))
-                        .ok()
-                        .and_then(|kind| kind.as_string())
-                        .unwrap_or_default()
-                })
-                .collect()
-        }
-
         #[wasm_bindgen_test]
-        fn uncontrolled_click_emits_change_commit_sequence() {
+        fn uncontrolled_click_emits_ordered_telemetry() {
             let state = Rc::new(RefCell::new(sample_state_uncontrolled()));
             let snapshot = build_snapshot(&state.borrow());
-            let (delegate, events) = telemetry_collector();
+            let (delegate, events, closure) = telemetry_recorder();
             let (props, state_handle) =
                 build_option_props(Rc::clone(&state), &snapshot, Some(delegate), 1);
 
-            call_handler(&props, "onClick");
+            // Analytics always fires first so downstream dashboards capture the raw
+            // context before mutation. A pointer click should therefore emit
+            // analytics → change → commit in that exact order.
+            if let Ok(handler) = Reflect::get(&props, &JsValue::from_str("onClick")) {
+                if let Ok(function) = handler.dyn_into::<Function>() {
+                    let _ = function.call0(&JsValue::NULL);
+                }
+            }
 
-            let kinds = event_kinds(&events);
+            let kinds = event_kinds(&events.borrow());
             assert_eq!(kinds, vec!["analytics", "change", "commit"]);
             assert_eq!(state_handle.borrow().selected_index(), Some(1));
+            drop(closure);
         }
 
         #[wasm_bindgen_test]
         fn controlled_click_reports_commit_without_mutating_state() {
             let state = Rc::new(RefCell::new(sample_state_controlled()));
             let snapshot = build_snapshot(&state.borrow());
-            let (delegate, events) = telemetry_collector();
+            let (delegate, events, closure) = telemetry_recorder();
             let (props, state_handle) =
                 build_option_props(Rc::clone(&state), &snapshot, Some(delegate), 2);
 
-            call_handler(&props, "onClick");
+            if let Ok(handler) = Reflect::get(&props, &JsValue::from_str("onClick")) {
+                if let Ok(function) = handler.dyn_into::<Function>() {
+                    let _ = function.call0(&JsValue::NULL);
+                }
+            }
 
+            // Even controlled flows honour analytics → change → commit ordering while
+            // preserving the previous selection.
+            assert_eq!(
+                event_kinds(&events.borrow()),
+                vec!["analytics", "change", "commit"]
+            );
             assert_eq!(state_handle.borrow().selected_index(), Some(1));
-            let last_event = events.get(events.length() - 1);
-            let selected = Reflect::get(&last_event, &JsValue::from_str("selected"))
-                .unwrap()
-                .as_f64()
-                .map(|value| value as usize);
-            assert_eq!(selected, Some(2));
-            let kinds = event_kinds(&events);
-            assert_eq!(kinds, vec!["analytics", "change", "commit"]);
+            let commit = events.borrow().last().cloned().expect("commit event");
+            if let RadioTelemetryEvent::Commit(commit) = commit {
+                assert_eq!(commit.selected, Some(2));
+                assert!(commit.controlled);
+            } else {
+                panic!("expected commit event");
+            }
+            drop(closure);
         }
 
         #[wasm_bindgen_test]
@@ -1611,71 +1767,73 @@ pub mod react {
         }
 
         #[wasm_bindgen_test]
-        fn keydown_emits_key_focus_and_commit_sequence() {
+        fn keydown_emits_full_sequence() {
             let state = Rc::new(RefCell::new(sample_state_uncontrolled()));
             let snapshot = build_snapshot(&state.borrow());
-            let (delegate, events) = telemetry_collector();
+            let (delegate, events, closure) = telemetry_recorder();
             let (props, state_handle) =
                 build_option_props(Rc::clone(&state), &snapshot, Some(delegate), 0);
 
-            call_handler_with_event(&props, "onKeyDown", keyboard_event("ArrowRight"));
+            if let Ok(handler) = Reflect::get(&props, &JsValue::from_str("onKeyDown")) {
+                if let Ok(function) = handler.dyn_into::<Function>() {
+                    let _ = function.call1(&JsValue::NULL, &keyboard_event("ArrowRight"));
+                }
+            }
 
-            let kinds = event_kinds(&events);
+            // Keyboard interactions must emit analytics → key → focus/blur → change →
+            // commit so observers can replay the exact user journey.
             assert_eq!(
-                kinds,
-                vec!["analytics", "key", "focus", "blur", "change", "commit"]
+                event_kinds(&events.borrow()),
+                vec!["analytics", "key", "focus", "blur", "change", "commit"],
             );
             assert_eq!(state_handle.borrow().selected_index(), Some(1));
+            drop(closure);
         }
 
         #[wasm_bindgen_test]
         fn controlled_keydown_advances_focus_and_reports_next_index() {
             let state = Rc::new(RefCell::new(sample_state_controlled()));
             let snapshot = build_snapshot(&state.borrow());
-            let (delegate, events) = telemetry_collector();
+            let (delegate, events, closure) = telemetry_recorder();
             let (props, state_handle) =
                 build_option_props(Rc::clone(&state), &snapshot, Some(delegate), 1);
 
-            call_handler_with_event(&props, "onKeyDown", keyboard_event("ArrowRight"));
+            if let Ok(handler) = Reflect::get(&props, &JsValue::from_str("onKeyDown")) {
+                if let Ok(function) = handler.dyn_into::<Function>() {
+                    let _ = function.call1(&JsValue::NULL, &keyboard_event("ArrowRight"));
+                }
+            }
 
             let handle = state_handle.borrow();
             assert_eq!(handle.selected_index(), Some(1));
             assert_eq!(handle.focus_visible_index(), Some(2));
             drop(handle);
 
-            let kinds = event_kinds(&events);
             assert_eq!(
-                kinds,
-                vec!["analytics", "key", "focus", "blur", "change", "commit"]
+                event_kinds(&events.borrow()),
+                vec!["analytics", "key", "focus", "blur", "change", "commit"],
             );
 
-            let key_event = events.get(1);
-            let key_next = Reflect::get(&key_event, &JsValue::from_str("next"))
-                .ok()
-                .and_then(|value| value.as_f64())
-                .map(|value| value as usize);
-            assert_eq!(key_next, Some(2));
+            let events_ref = events.borrow();
+            let key_event = events_ref
+                .iter()
+                .find_map(|event| match event {
+                    RadioTelemetryEvent::Key(event) => Some(event.clone()),
+                    _ => None,
+                })
+                .expect("key event");
+            assert_eq!(key_event.next, Some(2));
 
-            let focus_event = events.get(2);
-            let focus_index = Reflect::get(&focus_event, &JsValue::from_str("index"))
-                .ok()
-                .and_then(|value| value.as_f64())
-                .map(|value| value as usize);
-            assert_eq!(focus_index, Some(2));
-
-            let blur_event = events.get(3);
-            let blur_index = Reflect::get(&blur_event, &JsValue::from_str("index"))
-                .ok()
-                .and_then(|value| value.as_f64())
-                .map(|value| value as usize);
-            assert_eq!(blur_index, Some(1));
-
-            let commit_event = events.get(5);
-            let commit_selected = Reflect::get(&commit_event, &JsValue::from_str("selected"))
-                .ok()
-                .and_then(|value| value.as_f64())
-                .map(|value| value as usize);
-            assert_eq!(commit_selected, Some(1));
+            let commit = events_ref
+                .iter()
+                .find_map(|event| match event {
+                    RadioTelemetryEvent::Commit(event) => Some(event.clone()),
+                    _ => None,
+                })
+                .expect("commit event");
+            assert_eq!(commit.selected, Some(1));
+            assert!(commit.controlled);
+            drop(closure);
         }
     }
 

--- a/crates/rustic-ui-material/src/switch.rs
+++ b/crates/rustic-ui-material/src/switch.rs
@@ -928,6 +928,233 @@ pub mod react {
         }
     }
 
+    #[cfg(all(test, feature = "react"))]
+    mod tests {
+        use super::*;
+        use js_sys::{Function, Object, Reflect};
+        use wasm_bindgen::closure::Closure;
+        use wasm_bindgen_test::*;
+
+        wasm_bindgen_test_configure!(run_in_browser);
+
+        fn parse_control_key(value: &JsValue) -> ControlKey {
+            match value
+                .as_string()
+                .expect("key telemetry should encode control keys")
+                .as_str()
+            {
+                "space" => ControlKey::Space,
+                "enter" => ControlKey::Enter,
+                other => panic!("unexpected control key {other}"),
+            }
+        }
+
+        fn optional_string(object: &JsValue, key: &str) -> Option<String> {
+            Reflect::get(object, &JsValue::from_str(key))
+                .ok()
+                .and_then(|value| value.as_string())
+        }
+
+        fn decode_switch_event(value: &JsValue) -> SwitchTelemetryEvent {
+            let kind = Reflect::get(value, &JsValue::from_str("kind"))
+                .expect("telemetry payload exposes kind metadata")
+                .as_string()
+                .expect("telemetry kind should be a string");
+            match kind.as_str() {
+                "change" => SwitchTelemetryEvent::Change(SwitchChangeEvent {
+                    previous: Reflect::get(value, &JsValue::from_str("previous"))
+                        .expect("previous should be set")
+                        .as_bool()
+                        .expect("previous encodes a bool"),
+                    next: Reflect::get(value, &JsValue::from_str("next"))
+                        .expect("next should be set")
+                        .as_bool()
+                        .expect("next encodes a bool"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "focus" => SwitchTelemetryEvent::Focus(SwitchFocusEvent {
+                    focused: Reflect::get(value, &JsValue::from_str("focused"))
+                        .expect("focused should be set")
+                        .as_bool()
+                        .expect("focused encodes a bool"),
+                    on: Reflect::get(value, &JsValue::from_str("on"))
+                        .expect("on should be set")
+                        .as_bool()
+                        .expect("on encodes a bool"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "blur" => SwitchTelemetryEvent::Blur(SwitchFocusEvent {
+                    focused: Reflect::get(value, &JsValue::from_str("focused"))
+                        .expect("focused should be set")
+                        .as_bool()
+                        .expect("focused encodes a bool"),
+                    on: Reflect::get(value, &JsValue::from_str("on"))
+                        .expect("on should be set")
+                        .as_bool()
+                        .expect("on encodes a bool"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                "key" => SwitchTelemetryEvent::Key(SwitchKeyEvent {
+                    key: parse_control_key(
+                        &Reflect::get(value, &JsValue::from_str("key")).expect("key should be set"),
+                    ),
+                    previous: Reflect::get(value, &JsValue::from_str("previous"))
+                        .expect("previous should be set")
+                        .as_bool()
+                        .expect("previous encodes a bool"),
+                    next: Reflect::get(value, &JsValue::from_str("next"))
+                        .expect("next should be set")
+                        .as_bool()
+                        .expect("next encodes a bool"),
+                    disabled: Reflect::get(value, &JsValue::from_str("disabled"))
+                        .expect("disabled should be set")
+                        .as_bool()
+                        .expect("disabled encodes a bool"),
+                    analytics_id: optional_string(value, "analyticsId"),
+                    automation_id: optional_string(value, "automationId"),
+                    label: Reflect::get(value, &JsValue::from_str("label"))
+                        .expect("label should be set")
+                        .as_string()
+                        .expect("label encodes a string"),
+                }),
+                other => panic!("unexpected telemetry kind {other}"),
+            }
+        }
+
+        fn telemetry_recorder() -> (
+            Function,
+            Rc<RefCell<Vec<SwitchTelemetryEvent>>>,
+            Closure<dyn FnMut(JsValue)>,
+        ) {
+            let events = Rc::new(RefCell::new(Vec::new()));
+            let stored = Rc::clone(&events);
+            let closure = Closure::wrap(Box::new(move |value: JsValue| {
+                let event = decode_switch_event(&value);
+                stored.borrow_mut().push(event);
+            }) as Box<dyn FnMut(JsValue)>);
+            let function: Function = closure.as_ref().clone().unchecked_into();
+            (function, events, closure)
+        }
+
+        fn event_kinds(events: &[SwitchTelemetryEvent]) -> Vec<&'static str> {
+            events
+                .iter()
+                .map(|event| match event {
+                    SwitchTelemetryEvent::Change(_) => "change",
+                    SwitchTelemetryEvent::Focus(_) => "focus",
+                    SwitchTelemetryEvent::Blur(_) => "blur",
+                    SwitchTelemetryEvent::Key(_) => "key",
+                })
+                .collect()
+        }
+
+        fn invoke(handler: &Option<Function>, event: JsValue) {
+            if let Some(function) = handler {
+                let _ = function.call1(&JsValue::NULL, &event);
+            }
+        }
+
+        fn keyboard_event(key: &str) -> JsValue {
+            let event = Object::new();
+            Reflect::set(&event, &JsValue::from_str("key"), &JsValue::from_str(key))
+                .expect("set key");
+            let prevent = Closure::wrap(Box::new(|| {}) as Box<dyn FnMut()>);
+            Reflect::set(
+                &event,
+                &JsValue::from_str("preventDefault"),
+                prevent.as_ref(),
+            )
+            .expect("set preventDefault");
+            prevent.forget();
+            event.into()
+        }
+
+        fn build_props(state: SwitchState, telemetry: Option<Function>) -> ReactSwitchProps {
+            ReactSwitchProps {
+                switch: SwitchProps::new("Notifications"),
+                state,
+                on_change: None,
+                on_focus: None,
+                on_blur: None,
+                on_key: None,
+                telemetry_delegate: telemetry,
+            }
+        }
+
+        #[wasm_bindgen_test]
+        fn uncontrolled_handlers_emit_ordered_telemetry() {
+            let (delegate, events, closure) = telemetry_recorder();
+            let props = build_props(SwitchState::uncontrolled(false, false), Some(delegate));
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let handlers = handlers(&props, Rc::clone(&state_handle));
+
+            // Focus telemetry should lead so analytics observe the untouched switch.
+            invoke(&handlers.on_focus, JsValue::UNDEFINED);
+            invoke(&handlers.on_blur, JsValue::UNDEFINED);
+
+            // Key payloads precede change events to honour the analytics → key/focus
+            // → change choreography shared across adapters.
+            invoke(&handlers.on_key, keyboard_event(" "));
+
+            // Pointer toggles run after keyboard telemetry, ensuring mutation commits
+            // happen last in the sequence.
+            invoke(&handlers.on_change, JsValue::UNDEFINED);
+
+            let kinds = event_kinds(&events.borrow());
+            assert_eq!(kinds, vec!["focus", "blur", "key", "change", "change"]);
+            assert!(!state_handle.borrow().on());
+            drop(closure);
+        }
+
+        #[wasm_bindgen_test]
+        fn controlled_handlers_preserve_state() {
+            let (delegate, events, closure) = telemetry_recorder();
+            let props = build_props(SwitchState::controlled(false, false), Some(delegate));
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let handlers = handlers(&props, Rc::clone(&state_handle));
+
+            invoke(&handlers.on_key, keyboard_event("Enter"));
+            invoke(&handlers.on_change, JsValue::UNDEFINED);
+
+            // Controlled consumers receive telemetry while retaining their external
+            // truth, demonstrating analytics → key → change ordering without local
+            // mutation.
+            assert_eq!(
+                event_kinds(&events.borrow()),
+                vec!["key", "change", "change"]
+            );
+            assert!(!state_handle.borrow().on());
+            drop(closure);
+        }
+    }
+
     /// React component rendering the Material switch.
     ///
     /// * A [`TelemetryContext`] seeded with the fully-qualified component path

--- a/crates/rustic-ui-system/Cargo.toml
+++ b/crates/rustic-ui-system/Cargo.toml
@@ -30,6 +30,10 @@ dioxus = { workspace = true, optional = true }
 sycamore = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen.workspace = true
+web-sys.workspace = true
+
 [dev-dependencies]
 wasm-bindgen-test.workspace = true
 


### PR DESCRIPTION
## Summary
- add wasm-bindgen test suites for the React checkbox, switch, and radio adapters that capture telemetry into strongly typed vectors for sequencing assertions
- document the wasm test harness and expose a `cargo wasm-react-test` alias for contributors, wiring in the required `web-sys` dependency for wasm builds
- decode telemetry payloads back into Rust events inside the tests to verify analytics, focus, key, change, and commit ordering while guarding controlled state

## Testing
- `cargo wasm-react-test` *(fails: existing compilation errors around `JsValue::strict_eq` and `PartialEq` impls in the workspace when building the React adapters for wasm)*

------
https://chatgpt.com/codex/tasks/task_e_68de0a774a54832eb6542e0b2ad9b42e