### PR TITLE
Add Yew telemetry harnesses for switch and radio

### DIFF
--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -2339,6 +2339,410 @@ pub mod yew {
             node
         })
     }
+
+    #[cfg(all(test, feature = "yew"))]
+    mod tests {
+        use super::*;
+        use ::yew::{virtual_dom::Listener, Callback};
+        use wasm_bindgen_test::*;
+        use web_sys::{
+            Event as WebEvent, FocusEvent as WebFocusEvent, KeyboardEvent as WebKeyboardEvent,
+            KeyboardEventInit, MouseEvent as WebMouseEvent,
+        };
+
+        wasm_bindgen_test_configure!(run_in_browser);
+
+        struct RadioHarness {
+            telemetry: Rc<RefCell<Vec<RadioTelemetryEvent>>>,
+            changes: Rc<RefCell<Vec<RadioChangeEvent>>>,
+            focuses: Rc<RefCell<Vec<RadioFocusEvent>>>,
+            blurs: Rc<RefCell<Vec<RadioFocusEvent>>>,
+            keys: Rc<RefCell<Vec<RadioKeyEvent>>>,
+        }
+
+        impl RadioHarness {
+            fn new() -> Self {
+                Self {
+                    telemetry: Rc::new(RefCell::new(Vec::new())),
+                    changes: Rc::new(RefCell::new(Vec::new())),
+                    focuses: Rc::new(RefCell::new(Vec::new())),
+                    blurs: Rc::new(RefCell::new(Vec::new())),
+                    keys: Rc::new(RefCell::new(Vec::new())),
+                }
+            }
+        }
+
+        fn build_props(controlled: bool) -> (YewRadioGroupProps, RadioHarness) {
+            let labels = vec!["Alpha".to_string(), "Beta".to_string()];
+            let mut group = RadioGroupProps::new(labels.clone());
+            group.telemetry.analytics_id = Some(format!("radio.group.analytics.{controlled}"));
+            group.telemetry.automation_id = Some(format!("radio.group.automation.{controlled}"));
+
+            let telemetry = TelemetryHooks {
+                analytics_id: Some(format!("radio.props.analytics.{controlled}")),
+                automation_id: Some(format!("radio.props.automation.{controlled}")),
+                ..TelemetryHooks::default()
+            };
+
+            let state = if controlled {
+                RadioGroupState::controlled(
+                    labels.clone(),
+                    false,
+                    RadioOrientation::Horizontal,
+                    Some(0),
+                )
+            } else {
+                RadioGroupState::uncontrolled(
+                    labels.clone(),
+                    false,
+                    RadioOrientation::Horizontal,
+                    None,
+                )
+            };
+
+            let harness = RadioHarness::new();
+
+            let props = YewRadioGroupProps {
+                group,
+                state,
+                telemetry,
+                on_change: Some({
+                    let sink = Rc::clone(&harness.changes);
+                    Callback::from(move |event: RadioChangeEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                on_focus: Some({
+                    let sink = Rc::clone(&harness.focuses);
+                    Callback::from(move |event: RadioFocusEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                on_blur: Some({
+                    let sink = Rc::clone(&harness.blurs);
+                    Callback::from(move |event: RadioFocusEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                on_key: Some({
+                    let sink = Rc::clone(&harness.keys);
+                    Callback::from(move |event: RadioKeyEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                telemetry_delegate: Some({
+                    let sink = Rc::clone(&harness.telemetry);
+                    Callback::from(move |event: RadioTelemetryEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+            };
+
+            (props, harness)
+        }
+
+        fn arrow_down_event() -> WebEvent {
+            let mut init = KeyboardEventInit::new();
+            init.key("ArrowDown");
+            init.bubbles(true);
+            init.cancelable(true);
+            WebKeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init)
+                .expect("keyboard event should construct")
+                .into()
+        }
+
+        fn focus_event(kind: &str) -> WebEvent {
+            WebFocusEvent::new(kind)
+                .expect("focus event should construct")
+                .into()
+        }
+
+        fn click_event() -> WebEvent {
+            WebMouseEvent::new("click")
+                .expect("mouse event should construct")
+                .into()
+        }
+
+        /// Validates that uncontrolled handlers emit analytics → change → commit
+        /// before invoking consumers and that keyboard flows include the
+        /// documented analytics → key → focus → blur → change → commit cadence.
+        #[wasm_bindgen_test]
+        fn uncontrolled_option_handlers_emit_ordered_sequences() {
+            let (props, harness) = build_props(false);
+            let telemetry = super::merged_telemetry(&props.telemetry, &props.group.telemetry);
+            let (_context, _descriptor, snapshot) = super::descriptor_with_context(
+                "rustic_ui_material::radio::yew::tests::uncontrolled",
+                &props.group,
+                &telemetry,
+                &props.state,
+            );
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let options = Rc::new(snapshot.options.clone());
+            let builder = YewOptionHandlerBuilder::new(
+                Rc::clone(&state_handle),
+                Rc::clone(&options),
+                props.on_change.clone(),
+                props.on_focus.clone(),
+                props.on_blur.clone(),
+                props.on_key.clone(),
+                props.telemetry_delegate.clone(),
+            );
+            let handlers = builder.build(0);
+
+            handlers.onclick.handle(click_event());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    3,
+                    "pointer interaction emits analytics/change/commit"
+                );
+                assert!(matches!(telemetry[0], RadioTelemetryEvent::Analytics(_)));
+                match &telemetry[1] {
+                    RadioTelemetryEvent::Change(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.changes.borrow()[0],
+                            "change telemetry matches consumer payload",
+                        );
+                    }
+                    other => panic!("expected change telemetry, received {other:?}"),
+                }
+                match &telemetry[2] {
+                    RadioTelemetryEvent::Commit(event) => {
+                        assert_eq!(event.selected, Some(0));
+                        assert!(!event.controlled);
+                    }
+                    other => panic!("expected commit telemetry, received {other:?}"),
+                }
+            }
+            assert_eq!(
+                state_handle.borrow().selected_index(),
+                Some(0),
+                "uncontrolled pointer commits the requested selection",
+            );
+
+            handlers.onfocus.handle(focus_event("focus"));
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    5,
+                    "focus emits analytics + focus telemetry"
+                );
+                assert!(matches!(telemetry[3], RadioTelemetryEvent::Analytics(_)));
+                match &telemetry[4] {
+                    RadioTelemetryEvent::Focus(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.focuses.borrow()[0],
+                            "focus telemetry mirrors consumer payload",
+                        );
+                    }
+                    other => panic!("expected focus telemetry, received {other:?}"),
+                }
+            }
+            assert_eq!(
+                state_handle.borrow().focus_visible_index(),
+                Some(0),
+                "focus handler activates roving focus",
+            );
+
+            handlers.onblur.handle(focus_event("blur"));
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(telemetry.len(), 7, "blur emits analytics + blur telemetry");
+                assert!(matches!(telemetry[5], RadioTelemetryEvent::Analytics(_)));
+                match &telemetry[6] {
+                    RadioTelemetryEvent::Blur(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.blurs.borrow()[0],
+                            "blur telemetry mirrors consumer payload",
+                        );
+                    }
+                    other => panic!("expected blur telemetry, received {other:?}"),
+                }
+            }
+            assert_eq!(
+                state_handle.borrow().focus_visible_index(),
+                None,
+                "blur handler clears roving focus",
+            );
+
+            handlers.onkeydown.handle(arrow_down_event());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    13,
+                    "keyboard path emits analytics → key → focus → blur → change → commit",
+                );
+                assert!(matches!(telemetry[7], RadioTelemetryEvent::Analytics(_)));
+                match &telemetry[8] {
+                    RadioTelemetryEvent::Key(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.keys.borrow()[0],
+                            "key telemetry mirrors consumer payload",
+                        );
+                        assert_eq!(event.next, Some(1));
+                    }
+                    other => panic!("expected key telemetry, received {other:?}"),
+                }
+                match &telemetry[9] {
+                    RadioTelemetryEvent::Focus(event) => {
+                        assert_eq!(event.index, 1);
+                        assert!(event.focused);
+                    }
+                    other => panic!("expected focus telemetry for new option, received {other:?}"),
+                }
+                match &telemetry[10] {
+                    RadioTelemetryEvent::Blur(event) => {
+                        assert_eq!(event.index, 0);
+                        assert!(!event.focused);
+                    }
+                    other => {
+                        panic!("expected blur telemetry for origin option, received {other:?}")
+                    }
+                }
+                match &telemetry[11] {
+                    RadioTelemetryEvent::Change(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.changes.borrow()[1],
+                            "keyboard change telemetry matches consumer payload",
+                        );
+                        assert_eq!(event.next, 1);
+                    }
+                    other => panic!(
+                        "expected change telemetry for keyboard selection, received {other:?}"
+                    ),
+                }
+                match &telemetry[12] {
+                    RadioTelemetryEvent::Commit(event) => {
+                        assert_eq!(event.selected, Some(1));
+                        assert!(!event.controlled);
+                    }
+                    other => panic!(
+                        "expected commit telemetry for keyboard selection, received {other:?}"
+                    ),
+                }
+            }
+            let state = state_handle.borrow();
+            assert_eq!(state.selected_index(), Some(1));
+            assert_eq!(state.focus_visible_index(), Some(1));
+        }
+
+        /// Demonstrates that controlled adapters emit telemetry without mutating
+        /// their cached [`RadioGroupState`] while still advancing roving focus.
+        #[wasm_bindgen_test]
+        fn controlled_option_handlers_preserve_selection() {
+            let (props, harness) = build_props(true);
+            let telemetry = super::merged_telemetry(&props.telemetry, &props.group.telemetry);
+            let (_context, _descriptor, snapshot) = super::descriptor_with_context(
+                "rustic_ui_material::radio::yew::tests::controlled",
+                &props.group,
+                &telemetry,
+                &props.state,
+            );
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let options = Rc::new(snapshot.options.clone());
+            let builder = YewOptionHandlerBuilder::new(
+                Rc::clone(&state_handle),
+                Rc::clone(&options),
+                props.on_change.clone(),
+                props.on_focus.clone(),
+                props.on_blur.clone(),
+                props.on_key.clone(),
+                props.telemetry_delegate.clone(),
+            );
+            let handlers = builder.build(0);
+
+            handlers.onclick.handle(click_event());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    3,
+                    "controlled pointer emits analytics/change/commit"
+                );
+                match &telemetry[2] {
+                    RadioTelemetryEvent::Commit(event) => {
+                        assert_eq!(event.selected, Some(0));
+                        assert!(event.controlled);
+                    }
+                    other => panic!("expected commit telemetry, received {other:?}"),
+                }
+            }
+            assert_eq!(
+                state_handle.borrow().selected_index(),
+                Some(0),
+                "controlled pointer keeps the cached snapshot immutable",
+            );
+
+            handlers.onfocus.handle(focus_event("focus"));
+            handlers.onblur.handle(focus_event("blur"));
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert!(matches!(telemetry[3], RadioTelemetryEvent::Analytics(_)));
+                assert!(matches!(telemetry[4], RadioTelemetryEvent::Focus(_)));
+                assert!(matches!(telemetry[5], RadioTelemetryEvent::Analytics(_)));
+                assert!(matches!(telemetry[6], RadioTelemetryEvent::Blur(_)));
+            }
+            assert_eq!(
+                state_handle.borrow().focus_visible_index(),
+                None,
+                "blur clears focus visibility even when controlled",
+            );
+
+            handlers.onkeydown.handle(arrow_down_event());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    13,
+                    "controlled keyboard emits full telemetry sequence"
+                );
+                match &telemetry[8] {
+                    RadioTelemetryEvent::Key(event) => {
+                        assert_eq!(event.next, Some(1));
+                        assert_eq!(
+                            *event,
+                            harness.keys.borrow()[0],
+                            "controlled key telemetry mirrors consumer payload",
+                        );
+                    }
+                    other => panic!("expected key telemetry, received {other:?}"),
+                }
+                match &telemetry[11] {
+                    RadioTelemetryEvent::Change(event) => {
+                        assert_eq!(event.next, 1);
+                        assert_eq!(
+                            *event,
+                            harness.changes.borrow()[1],
+                            "controlled change telemetry mirrors consumer payload",
+                        );
+                    }
+                    other => panic!("expected change telemetry, received {other:?}"),
+                }
+                match &telemetry[12] {
+                    RadioTelemetryEvent::Commit(event) => {
+                        assert_eq!(event.selected, Some(0));
+                        assert!(event.controlled);
+                    }
+                    other => panic!("expected commit telemetry, received {other:?}"),
+                }
+            }
+            let state = state_handle.borrow();
+            assert_eq!(state.selected_index(), Some(0));
+            assert_eq!(
+                state.focus_visible_index(),
+                Some(1),
+                "controlled key flow advances roving focus while selection remains caller-owned",
+            );
+        }
+    }
 }
 
 #[cfg(feature = "leptos")]

--- a/crates/rustic-ui-material/src/switch.rs
+++ b/crates/rustic-ui-material/src/switch.rs
@@ -1228,6 +1228,144 @@ pub mod yew {
         pub telemetry_delegate: Option<Callback<SwitchTelemetryEvent>>,
     }
 
+    #[cfg(any(test, not(test)))]
+    pub(crate) fn build_yew_switch_handlers(
+        switch_props: SwitchProps,
+        state_handle: Rc<RefCell<SwitchState>>,
+        on_change: Option<Callback<SwitchChangeEvent>>,
+        on_focus: Option<Callback<SwitchFocusEvent>>,
+        on_blur: Option<Callback<SwitchFocusEvent>>,
+        on_key: Option<Callback<SwitchKeyEvent>>,
+        telemetry_delegate: Option<Callback<SwitchTelemetryEvent>>,
+    ) -> (
+        Callback<MouseEvent>,
+        Callback<FocusEvent>,
+        Callback<FocusEvent>,
+        Callback<KeyboardEvent>,
+    ) {
+        let switch_props = Rc::new(switch_props);
+
+        let change_handler = {
+            let on_change = on_change.clone();
+            let telemetry = telemetry_delegate.clone();
+            let switch_props = Rc::clone(&switch_props);
+            let state = Rc::clone(&state_handle);
+            Callback::from(move |_event: MouseEvent| {
+                let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                    Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                        as Box<dyn FnMut(SwitchTelemetryEvent)>
+                });
+                let mut change_runner = on_change.clone().map(|callback| {
+                    Box::new(move |event: SwitchChangeEvent| callback.emit(event))
+                        as Box<dyn FnMut(SwitchChangeEvent)>
+                });
+                let telemetry_ref = telemetry_runner
+                    .as_mut()
+                    .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                let change_ref = change_runner
+                    .as_mut()
+                    .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
+                let mut state = state.borrow_mut();
+                dispatch_change_event(&switch_props, &mut state, telemetry_ref, change_ref);
+            })
+        };
+
+        let focus_handler = {
+            let on_focus = on_focus.clone();
+            let telemetry = telemetry_delegate.clone();
+            let switch_props = Rc::clone(&switch_props);
+            let state = Rc::clone(&state_handle);
+            Callback::from(move |_event: FocusEvent| {
+                let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                    Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                        as Box<dyn FnMut(SwitchTelemetryEvent)>
+                });
+                let mut focus_runner = on_focus.clone().map(|callback| {
+                    Box::new(move |event: SwitchFocusEvent| callback.emit(event))
+                        as Box<dyn FnMut(SwitchFocusEvent)>
+                });
+                let telemetry_ref = telemetry_runner
+                    .as_mut()
+                    .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                let focus_ref = focus_runner
+                    .as_mut()
+                    .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
+                let mut state = state.borrow_mut();
+                dispatch_focus_event(&switch_props, &mut state, true, telemetry_ref, focus_ref);
+            })
+        };
+
+        let blur_handler = {
+            let on_blur = on_blur.clone();
+            let telemetry = telemetry_delegate.clone();
+            let switch_props = Rc::clone(&switch_props);
+            let state = Rc::clone(&state_handle);
+            Callback::from(move |_event: FocusEvent| {
+                let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                    Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                        as Box<dyn FnMut(SwitchTelemetryEvent)>
+                });
+                let mut blur_runner = on_blur.clone().map(|callback| {
+                    Box::new(move |event: SwitchFocusEvent| callback.emit(event))
+                        as Box<dyn FnMut(SwitchFocusEvent)>
+                });
+                let telemetry_ref = telemetry_runner
+                    .as_mut()
+                    .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                let blur_ref = blur_runner
+                    .as_mut()
+                    .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
+                let mut state = state.borrow_mut();
+                dispatch_focus_event(&switch_props, &mut state, false, telemetry_ref, blur_ref);
+            })
+        };
+
+        let key_handler = {
+            let on_key = on_key.clone();
+            let on_change = on_change.clone();
+            let telemetry = telemetry_delegate.clone();
+            let switch_props = Rc::clone(&switch_props);
+            let state = Rc::clone(&state_handle);
+            Callback::from(move |event: KeyboardEvent| {
+                if let Some(control) = control_key_from_str(event.key().as_str()) {
+                    event.prevent_default();
+                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
+                        Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
+                            as Box<dyn FnMut(SwitchTelemetryEvent)>
+                    });
+                    let mut key_runner = on_key.clone().map(|callback| {
+                        Box::new(move |event: SwitchKeyEvent| callback.emit(event))
+                            as Box<dyn FnMut(SwitchKeyEvent)>
+                    });
+                    let mut change_runner = on_change.clone().map(|callback| {
+                        Box::new(move |event: SwitchChangeEvent| callback.emit(event))
+                            as Box<dyn FnMut(SwitchChangeEvent)>
+                    });
+                    let telemetry_ref = telemetry_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
+                    let key_ref = key_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchKeyEvent));
+                    let change_ref = change_runner
+                        .as_mut()
+                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
+                    let mut state = state.borrow_mut();
+                    dispatch_key_event(
+                        &switch_props,
+                        &mut state,
+                        control,
+                        telemetry_ref,
+                        key_ref,
+                        change_ref,
+                    );
+                }
+            })
+        };
+
+        (change_handler, focus_handler, blur_handler, key_handler)
+    }
+
     /// Switch rendered inside Yew applications.
     ///
     /// Controlled parents stay authoritative because the adapter defers local
@@ -1245,120 +1383,16 @@ pub mod yew {
         instrument_render(&props.switch.telemetry, context, || {
             let label = snapshot.label.clone();
             let attrs = snapshot.themed_attributes.clone();
-            let change_handler = {
-                let on_change = props.on_change.clone();
-                let telemetry = props.telemetry_delegate.clone();
-                let switch_props = props.switch.clone();
-                let state = Rc::clone(&state_handle);
-                Callback::from(move |_event: MouseEvent| {
-                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
-                        Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
-                            as Box<dyn FnMut(SwitchTelemetryEvent)>
-                    });
-                    let mut change_runner = on_change.clone().map(|callback| {
-                        Box::new(move |event: SwitchChangeEvent| callback.emit(event))
-                            as Box<dyn FnMut(SwitchChangeEvent)>
-                    });
-                    let telemetry_ref = telemetry_runner
-                        .as_mut()
-                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
-                    let change_ref = change_runner
-                        .as_mut()
-                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
-                    let mut state = state.borrow_mut();
-                    dispatch_change_event(&switch_props, &mut state, telemetry_ref, change_ref);
-                })
-            };
-            let focus_handler = {
-                let on_focus = props.on_focus.clone();
-                let telemetry = props.telemetry_delegate.clone();
-                let switch_props = props.switch.clone();
-                let state = Rc::clone(&state_handle);
-                Callback::from(move |_event: FocusEvent| {
-                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
-                        Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
-                            as Box<dyn FnMut(SwitchTelemetryEvent)>
-                    });
-                    let mut focus_runner = on_focus.clone().map(|callback| {
-                        Box::new(move |event: SwitchFocusEvent| callback.emit(event))
-                            as Box<dyn FnMut(SwitchFocusEvent)>
-                    });
-                    let telemetry_ref = telemetry_runner
-                        .as_mut()
-                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
-                    let focus_ref = focus_runner
-                        .as_mut()
-                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
-                    let mut state = state.borrow_mut();
-                    dispatch_focus_event(&switch_props, &mut state, true, telemetry_ref, focus_ref);
-                })
-            };
-            let blur_handler = {
-                let on_blur = props.on_blur.clone();
-                let telemetry = props.telemetry_delegate.clone();
-                let switch_props = props.switch.clone();
-                let state = Rc::clone(&state_handle);
-                Callback::from(move |_event: FocusEvent| {
-                    let mut telemetry_runner = telemetry.clone().map(|delegate| {
-                        Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
-                            as Box<dyn FnMut(SwitchTelemetryEvent)>
-                    });
-                    let mut blur_runner = on_blur.clone().map(|callback| {
-                        Box::new(move |event: SwitchFocusEvent| callback.emit(event))
-                            as Box<dyn FnMut(SwitchFocusEvent)>
-                    });
-                    let telemetry_ref = telemetry_runner
-                        .as_mut()
-                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
-                    let blur_ref = blur_runner
-                        .as_mut()
-                        .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchFocusEvent));
-                    let mut state = state.borrow_mut();
-                    dispatch_focus_event(&switch_props, &mut state, false, telemetry_ref, blur_ref);
-                })
-            };
-            let key_handler = {
-                let on_key = props.on_key.clone();
-                let on_change = props.on_change.clone();
-                let telemetry = props.telemetry_delegate.clone();
-                let switch_props = props.switch.clone();
-                let state = Rc::clone(&state_handle);
-                Callback::from(move |event: KeyboardEvent| {
-                    if let Some(control) = control_key_from_str(event.key().as_str()) {
-                        event.prevent_default();
-                        let mut telemetry_runner = telemetry.clone().map(|delegate| {
-                            Box::new(move |event: SwitchTelemetryEvent| delegate.emit(event))
-                                as Box<dyn FnMut(SwitchTelemetryEvent)>
-                        });
-                        let mut key_runner = on_key.clone().map(|callback| {
-                            Box::new(move |event: SwitchKeyEvent| callback.emit(event))
-                                as Box<dyn FnMut(SwitchKeyEvent)>
-                        });
-                        let mut change_runner = on_change.clone().map(|callback| {
-                            Box::new(move |event: SwitchChangeEvent| callback.emit(event))
-                                as Box<dyn FnMut(SwitchChangeEvent)>
-                        });
-                        let telemetry_ref = telemetry_runner
-                            .as_mut()
-                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchTelemetryEvent));
-                        let key_ref = key_runner
-                            .as_mut()
-                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchKeyEvent));
-                        let change_ref = change_runner
-                            .as_mut()
-                            .map(|runner| runner.as_mut() as &mut dyn FnMut(SwitchChangeEvent));
-                        let mut state = state.borrow_mut();
-                        dispatch_key_event(
-                            &switch_props,
-                            &mut state,
-                            control,
-                            telemetry_ref,
-                            key_ref,
-                            change_ref,
-                        );
-                    }
-                })
-            };
+            let (change_handler, focus_handler, blur_handler, key_handler) =
+                build_yew_switch_handlers(
+                    props.switch.clone(),
+                    Rc::clone(&state_handle),
+                    props.on_change.clone(),
+                    props.on_focus.clone(),
+                    props.on_blur.clone(),
+                    props.on_key.clone(),
+                    props.telemetry_delegate.clone(),
+                );
 
             let mut node = html! { <span>{label}</span> };
             if let VNode::VTag(ref mut tag) = node {
@@ -1372,6 +1406,318 @@ pub mod yew {
             }
             node
         })
+    }
+
+    #[cfg(all(test, feature = "yew"))]
+    mod tests {
+        use super::*;
+        use ::yew::Callback;
+        use wasm_bindgen_test::*;
+        use web_sys::{
+            FocusEvent as WebFocusEvent, KeyboardEvent as WebKeyboardEvent, KeyboardEventInit,
+            MouseEvent as WebMouseEvent,
+        };
+
+        wasm_bindgen_test_configure!(run_in_browser);
+
+        struct SwitchHarness {
+            telemetry: Rc<RefCell<Vec<SwitchTelemetryEvent>>>,
+            changes: Rc<RefCell<Vec<SwitchChangeEvent>>>,
+            focuses: Rc<RefCell<Vec<SwitchFocusEvent>>>,
+            blurs: Rc<RefCell<Vec<SwitchFocusEvent>>>,
+            keys: Rc<RefCell<Vec<SwitchKeyEvent>>>,
+        }
+
+        impl SwitchHarness {
+            fn new() -> Self {
+                Self {
+                    telemetry: Rc::new(RefCell::new(Vec::new())),
+                    changes: Rc::new(RefCell::new(Vec::new())),
+                    focuses: Rc::new(RefCell::new(Vec::new())),
+                    blurs: Rc::new(RefCell::new(Vec::new())),
+                    keys: Rc::new(RefCell::new(Vec::new())),
+                }
+            }
+        }
+
+        fn build_props(controlled: bool) -> (YewSwitchProps, SwitchHarness) {
+            let mut switch = SwitchProps::new("Telemetry switch");
+            switch.telemetry.analytics_id =
+                Some(format!("switch.telemetry.analytics.{controlled}"));
+            switch.telemetry.automation_id =
+                Some(format!("switch.telemetry.automation.{controlled}"));
+
+            let state = if controlled {
+                SwitchState::controlled(false, false)
+            } else {
+                SwitchState::uncontrolled(false, false)
+            };
+
+            let harness = SwitchHarness::new();
+
+            let props = YewSwitchProps {
+                switch,
+                state,
+                on_change: Some({
+                    let sink = Rc::clone(&harness.changes);
+                    Callback::from(move |event: SwitchChangeEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                on_focus: Some({
+                    let sink = Rc::clone(&harness.focuses);
+                    Callback::from(move |event: SwitchFocusEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                on_blur: Some({
+                    let sink = Rc::clone(&harness.blurs);
+                    Callback::from(move |event: SwitchFocusEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                on_key: Some({
+                    let sink = Rc::clone(&harness.keys);
+                    Callback::from(move |event: SwitchKeyEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+                telemetry_delegate: Some({
+                    let sink = Rc::clone(&harness.telemetry);
+                    Callback::from(move |event: SwitchTelemetryEvent| {
+                        sink.borrow_mut().push(event);
+                    })
+                }),
+            };
+
+            (props, harness)
+        }
+
+        fn space_key_event() -> WebKeyboardEvent {
+            let mut init = KeyboardEventInit::new();
+            init.key(" ");
+            init.bubbles(true);
+            init.cancelable(true);
+            WebKeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init)
+                .expect("keyboard event should construct")
+        }
+
+        /// Verifies that uncontrolled switches surface telemetry in the
+        /// analytics → change → focus → blur → key → change order without
+        /// regressing the state machine coordination auditors rely on.
+        #[wasm_bindgen_test]
+        fn uncontrolled_handlers_follow_enterprise_choreography() {
+            let (props, harness) = build_props(false);
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let (change_handler, focus_handler, blur_handler, key_handler) =
+                build_yew_switch_handlers(
+                    props.switch.clone(),
+                    Rc::clone(&state_handle),
+                    props.on_change.clone(),
+                    props.on_focus.clone(),
+                    props.on_blur.clone(),
+                    props.on_key.clone(),
+                    props.telemetry_delegate.clone(),
+                );
+
+            change_handler.emit(WebMouseEvent::new("click").unwrap());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    1,
+                    "pointer change emits a single telemetry frame"
+                );
+                match &telemetry[0] {
+                    SwitchTelemetryEvent::Change(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.changes.borrow()[0],
+                            "telemetry change payload mirrors consumer callback",
+                        );
+                    }
+                    other => panic!("expected change telemetry, received {other:?}"),
+                }
+            }
+            assert!(
+                state_handle.borrow().on(),
+                "uncontrolled toggle flips the local snapshot"
+            );
+
+            focus_handler.emit(WebFocusEvent::new("focus").unwrap());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    2,
+                    "focus appends analytics + focus telemetry"
+                );
+                match &telemetry[1] {
+                    SwitchTelemetryEvent::Focus(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.focuses.borrow()[0],
+                            "focus telemetry matches consumer callback snapshot",
+                        );
+                    }
+                    other => panic!("expected focus telemetry, received {other:?}"),
+                }
+            }
+            assert!(
+                state_handle.borrow().focus_visible(),
+                "focus handler toggles focus-visible state for uncontrolled switches",
+            );
+
+            blur_handler.emit(WebFocusEvent::new("blur").unwrap());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    3,
+                    "blur appends analytics + blur telemetry"
+                );
+                match &telemetry[2] {
+                    SwitchTelemetryEvent::Blur(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.blurs.borrow()[0],
+                            "blur telemetry matches consumer callback snapshot",
+                        );
+                    }
+                    other => panic!("expected blur telemetry, received {other:?}"),
+                }
+            }
+            assert!(
+                !state_handle.borrow().focus_visible(),
+                "blur handler clears focus-visible state",
+            );
+
+            key_handler.emit(space_key_event());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    5,
+                    "keyboard path emits key + change telemetry"
+                );
+                match &telemetry[3] {
+                    SwitchTelemetryEvent::Key(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.keys.borrow()[0],
+                            "key telemetry mirrors consumer payload",
+                        );
+                    }
+                    other => panic!("expected key telemetry, received {other:?}"),
+                }
+                match &telemetry[4] {
+                    SwitchTelemetryEvent::Change(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.changes.borrow()[1],
+                            "keyboard change telemetry matches consumer snapshot",
+                        );
+                    }
+                    other => panic!("expected change telemetry, received {other:?}"),
+                }
+            }
+            assert!(
+                !state_handle.borrow().on(),
+                "keyboard toggle returns uncontrolled state to the original snapshot",
+            );
+        }
+
+        /// Ensures controlled adapters emit telemetry without mutating their
+        /// cached [`SwitchState`] so caller owned truth remains authoritative.
+        #[wasm_bindgen_test]
+        fn controlled_handlers_preserve_snapshot_while_streaming_telemetry() {
+            let (props, harness) = build_props(true);
+            let state_handle = Rc::new(RefCell::new(props.state.clone()));
+            let (change_handler, focus_handler, blur_handler, key_handler) =
+                build_yew_switch_handlers(
+                    props.switch.clone(),
+                    Rc::clone(&state_handle),
+                    props.on_change.clone(),
+                    props.on_focus.clone(),
+                    props.on_blur.clone(),
+                    props.on_key.clone(),
+                    props.telemetry_delegate.clone(),
+                );
+
+            change_handler.emit(WebMouseEvent::new("click").unwrap());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    1,
+                    "controlled pointer emits a single telemetry frame"
+                );
+                match &telemetry[0] {
+                    SwitchTelemetryEvent::Change(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.changes.borrow()[0],
+                            "change telemetry matches consumer payload",
+                        );
+                        assert_eq!(event.previous, false);
+                        assert_eq!(event.next, true);
+                    }
+                    other => panic!("expected change telemetry, received {other:?}"),
+                }
+            }
+            assert!(
+                !state_handle.borrow().on(),
+                "controlled pointer interactions do not mutate the cached snapshot",
+            );
+
+            focus_handler.emit(WebFocusEvent::new("focus").unwrap());
+            blur_handler.emit(WebFocusEvent::new("blur").unwrap());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert!(
+                    matches!(&telemetry[1], SwitchTelemetryEvent::Focus(_)),
+                    "focus telemetry remains second in the sequence",
+                );
+                assert!(
+                    matches!(&telemetry[2], SwitchTelemetryEvent::Blur(_)),
+                    "blur telemetry follows focus for controlled flows",
+                );
+            }
+            assert!(
+                !state_handle.borrow().focus_visible(),
+                "controlled blur clears focus-visible state",
+            );
+
+            key_handler.emit(space_key_event());
+            {
+                let telemetry = harness.telemetry.borrow();
+                assert_eq!(
+                    telemetry.len(),
+                    5,
+                    "controlled keyboard emits key + change telemetry"
+                );
+                assert!(
+                    matches!(&telemetry[3], SwitchTelemetryEvent::Key(_)),
+                    "key telemetry remains ahead of change events",
+                );
+                match &telemetry[4] {
+                    SwitchTelemetryEvent::Change(event) => {
+                        assert_eq!(
+                            *event,
+                            harness.changes.borrow()[1],
+                            "controlled keyboard change telemetry matches consumer snapshot",
+                        );
+                        assert_eq!(event.previous, false);
+                        assert_eq!(event.next, true);
+                    }
+                    other => panic!("expected change telemetry, received {other:?}"),
+                }
+            }
+            assert!(
+                !state_handle.borrow().on(),
+                "controlled keyboard interactions keep the cached snapshot immutable",
+            );
+        }
     }
 }
 #[cfg(feature = "leptos")]

--- a/docs/rust-ci.md
+++ b/docs/rust-ci.md
@@ -85,6 +85,16 @@ cargo test -p rustic-ui-material sycamore:: --features sycamore
 
 Each suite consumes the shared fixtures in `crates/rustic-ui-material/tests/common/fixtures.rs` so updating the canonical props or Joy analytics hooks automatically propagates across frameworks.
 
+### Yew adapter telemetry harnesses
+The Material telemetry harnesses for Yew live alongside the adapters so governance teams can assert analytics ordering without spinning up React parity checks. Because the tests emit synthetic `web_sys` events, they must execute against the `wasm32-unknown-unknown` target with the `wasm-bindgen-test` runner enabled:
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo test -p rustic-ui-material --features yew --target wasm32-unknown-unknown -- --nocapture
+```
+
+The command spins up the headless wasm harness, executes the inline unit suites (including the switch and radio telemetry choreography checks), and leaves console logging enabled so analytics sequencing can be audited locally. When browser automation is required, the same assertions run under Chrome via `wasm-pack test --headless --chrome -- --no-default-features --features yew`.
+
 ### WebAssembly integration tests
 Interactive components execute inside a headless Chrome instance using the `wasm-bindgen-test` harness. Install Chrome/Chromium locally so `wasm-pack test --headless --chrome` can launch the browser. The fastest way to exercise every crate/feature pair is:
 


### PR DESCRIPTION
## Summary
- extract reusable Yew switch handler builders and add wasm-bound tests that validate telemetry sequencing for controlled and uncontrolled flows
- add governance-focused Yew radio option handler tests that assert analytics, focus, blur, and commit orderings across pointer and keyboard interactions
- document the wasm32 Yew adapter test workflow in the developer guide so teams can run the new harnesses locally

## Testing
- `cargo test -p rustic-ui-material --features yew --target wasm32-unknown-unknown --no-run` *(fails: existing wasm compile errors across unrelated Yew modules)*

------
https://chatgpt.com/codex/tasks/task_e_68de1171f548832ebea56f5d175d698b