### PR TITLE
docs: modernize selection control README telemetry wiring

### DIFF
--- a/examples/selection-controls-dioxus/README.md
+++ b/examples/selection-controls-dioxus/README.md
@@ -1,14 +1,47 @@
 # Selection Controls with Dioxus
 
+Use the typed Dioxus components so hydration stays deterministic, telemetry is
+attached up-front, and automation suites can reuse the same patterns that power
+the full design system.
+
 ```rust
 use dioxus::prelude::*;
-use rustic_ui_headless::checkbox::CheckboxState;
-use rustic_ui_headless::switch::SwitchState;
-use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
-use rustic_ui_material::checkbox::{self, CheckboxProps};
-use rustic_ui_material::switch::{self, SwitchProps};
-use std::rc::Rc;
-use rustic_ui_material::radio::{self, RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent};
+use rustic_ui_headless::{
+    checkbox::CheckboxState,
+    radio::{RadioGroupState, RadioOrientation},
+    switch::SwitchState,
+};
+use rustic_ui_material::{TelemetryContext, TelemetryHooks};
+use rustic_ui_material::checkbox::{
+    CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
+    dioxus::{DioxusCheckbox, DioxusCheckboxProps},
+};
+use rustic_ui_material::radio::{
+    RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent,
+    dioxus::{DioxusRadioGroup, DioxusRadioGroupProps},
+};
+use rustic_ui_material::switch::{
+    SwitchChangeEvent, SwitchProps, SwitchTelemetryEvent,
+    dioxus::{DioxusSwitch, DioxusSwitchProps},
+};
+use std::{rc::Rc, sync::Arc};
+
+fn telemetry(channel: &'static str) -> TelemetryHooks {
+    let mut hooks = TelemetryHooks::default();
+    hooks.analytics_id = Some(format!("selection-controls.dioxus.{channel}"));
+    hooks.automation_id = Some(format!("automation.selection-controls.{channel}"));
+    let channel_label = format!("selection_controls::{channel}");
+    hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
+        println!(
+            "telemetry::render channel={} component={} analytics={:?} automation={:?}",
+            channel_label,
+            context.component,
+            context.analytics_id,
+            context.automation_id,
+        );
+    }));
+    hooks
+}
 
 pub fn selection_controls(cx: Scope) -> Element {
     let checkbox_state = CheckboxState::uncontrolled(false, false);
@@ -20,22 +53,75 @@ pub fn selection_controls(cx: Scope) -> Element {
         Some(2),
     );
 
-    let on_change: Rc<dyn Fn(RadioChangeEvent)> = Rc::new(|event| {
-        println!("radio-change next={}", event.next);
+    let checkbox_props = CheckboxProps {
+        label: "Accept terms".into(),
+        telemetry: telemetry("checkbox"),
+    };
+    let switch_props = SwitchProps {
+        label: "Enable quick checkout".into(),
+        telemetry: telemetry("switch"),
+    };
+    let radio_props = RadioGroupProps::from_state(&radio_state)
+        .with_telemetry(telemetry("radio"));
+
+    let checkbox_telemetry: Rc<dyn Fn(CheckboxTelemetryEvent)> = Rc::new(|event| {
+        println!("checkbox telemetry::{event:?}");
     });
-    let telemetry: Rc<dyn Fn(RadioTelemetryEvent)> = Rc::new(|event| {
-        println!("telemetry::{:?}", event);
+    let switch_telemetry: Rc<dyn Fn(SwitchTelemetryEvent)> = Rc::new(|event| {
+        println!("switch telemetry::{event:?}");
+    });
+    let radio_telemetry: Rc<dyn Fn(RadioTelemetryEvent)> = Rc::new(|event| {
+        println!("radio telemetry::{event:?}");
     });
 
+    let checkbox_component = DioxusCheckboxProps {
+        checkbox: checkbox_props.clone(),
+        state: checkbox_state.clone(),
+        on_change: Some(Rc::new(|event: CheckboxChangeEvent| {
+            println!("checkbox::change next={} disabled={}", event.next, event.disabled);
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(checkbox_telemetry.clone()),
+    };
+    let switch_component = DioxusSwitchProps {
+        switch: switch_props.clone(),
+        state: switch_state.clone(),
+        on_change: Some(Rc::new(|event: SwitchChangeEvent| {
+            println!("switch::change next={} disabled={}", event.next, event.disabled);
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(switch_telemetry.clone()),
+    };
+    let radio_component = DioxusRadioGroupProps {
+        group: radio_props.clone(),
+        state: radio_state.clone(),
+        on_change: Some(Rc::new(|event: RadioChangeEvent| {
+            println!(
+                "radio::change previous={:?} next={} label={}",
+                event.previous,
+                event.next,
+                event.label,
+            );
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(radio_telemetry.clone()),
+        telemetry: Some(telemetry("radio.component")),
+    };
+
     cx.render(rsx! {
-        div { dangerous_inner_html: checkbox::dioxus::render(&CheckboxProps::new("Accept terms"), &checkbox_state) }
-        div { dangerous_inner_html: switch::dioxus::render(&SwitchProps::new("Enable quick checkout"), &switch_state) }
-        radio::dioxus::DioxusRadioGroup {
-            group: RadioGroupProps::from_state(&radio_state),
-            state: radio_state.clone(),
-            on_change: Some(on_change),
-            telemetry_delegate: Some(telemetry),
-        }
+        DioxusCheckbox { ..checkbox_component }
+        DioxusSwitch { ..switch_component }
+        DioxusRadioGroup { ..radio_component }
     })
 }
 ```
+
+> **Compile-time note:** Enable the `dioxus` feature when pulling `rustic-ui-material`
+> into an example crate: `cargo add rustic-ui-material --features dioxus` and
+> `cargo add rustic-ui-headless --features forms` before running `cargo check`.

--- a/examples/selection-controls-leptos/README.md
+++ b/examples/selection-controls-leptos/README.md
@@ -1,21 +1,46 @@
 # Selection Controls with Leptos
 
-The headless selection control states compose cleanly with Leptos. Generate
-markup using the `leptos` adapters and mount it with `leptos::html::Div` or the
-`leptos::view!` macro.
+Typed Leptos components expose the same telemetry lifecycle as the Yew/Dioxus
+adapters while remaining hydration safe – no more unchecked HTML fragments.
 
 ```rust
 use leptos::*;
-use std::rc::Rc;
-use rustic_ui_headless::checkbox::CheckboxState;
-use rustic_ui_headless::switch::SwitchState;
-use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
-use rustic_ui_material::checkbox::{self, CheckboxProps};
-use rustic_ui_material::switch::{self, SwitchProps};
+use rustic_ui_headless::{
+    checkbox::CheckboxState,
+    radio::{RadioGroupState, RadioOrientation},
+    switch::SwitchState,
+};
+use rustic_ui_material::{TelemetryContext, TelemetryHooks};
+use rustic_ui_material::checkbox::{
+    CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
+    leptos::{LeptosCheckbox, LeptosCheckboxProps},
+};
 use rustic_ui_material::radio::{
     RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent,
     leptos::{LeptosRadioGroup, LeptosRadioGroupProps},
 };
+use rustic_ui_material::switch::{
+    SwitchChangeEvent, SwitchProps, SwitchTelemetryEvent,
+    leptos::{LeptosSwitch, LeptosSwitchProps},
+};
+use std::{rc::Rc, sync::Arc};
+
+fn telemetry(channel: &'static str) -> TelemetryHooks {
+    let mut hooks = TelemetryHooks::default();
+    hooks.analytics_id = Some(format!("selection-controls.leptos.{channel}"));
+    hooks.automation_id = Some(format!("automation.selection-controls.{channel}"));
+    let channel_label = format!("selection_controls::{channel}");
+    hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
+        leptos::logging::log!(
+            "telemetry::render channel={} component={} analytics={:?} automation={:?}",
+            channel_label,
+            context.component,
+            context.analytics_id,
+            context.automation_id,
+        );
+    }));
+    hooks
+}
 
 #[component]
 pub fn SelectionControls() -> impl IntoView {
@@ -28,28 +53,85 @@ pub fn SelectionControls() -> impl IntoView {
         Some(1),
     );
 
+    let checkbox_props = CheckboxProps {
+        label: "Save card".into(),
+        telemetry: telemetry("checkbox"),
+    };
+    let switch_props = SwitchProps {
+        label: "Enable auto-pay".into(),
+        telemetry: telemetry("switch"),
+    };
+    let radio_props = RadioGroupProps::from_state(&radio_state)
+        .with_telemetry(telemetry("radio"));
+
+    let checkbox_delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = Rc::new(|event| {
+        leptos::logging::log!("checkbox telemetry: {:?}", event);
+    });
+    let switch_delegate: Rc<dyn Fn(SwitchTelemetryEvent)> = Rc::new(|event| {
+        leptos::logging::log!("switch telemetry: {:?}", event);
+    });
     let radio_delegate: Rc<dyn Fn(RadioTelemetryEvent)> = Rc::new(|event| {
         leptos::logging::log!("radio telemetry: {:?}", event);
     });
-    let radio_change: Rc<dyn Fn(RadioChangeEvent)> = Rc::new(|event| {
-        leptos::logging::log!("radio changed to {}", event.next);
-    });
 
-    let mut radio_props = LeptosRadioGroupProps::new(
-        RadioGroupProps::from_state(&radio_state),
-        radio_state.clone(),
-    );
-    radio_props.on_change = Some(radio_change);
-    radio_props.telemetry_delegate = Some(radio_delegate);
-
-    let radio_group = LeptosRadioGroup(radio_props);
+    let checkbox_component = LeptosCheckboxProps {
+        checkbox: checkbox_props.clone(),
+        state: checkbox_state.clone(),
+        on_change: Some(Rc::new(|event: CheckboxChangeEvent| {
+            leptos::logging::log!(
+                "checkbox::change next={} disabled={}",
+                event.next,
+                event.disabled,
+            );
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(checkbox_delegate.clone()),
+    };
+    let switch_component = LeptosSwitchProps {
+        switch: switch_props.clone(),
+        state: switch_state.clone(),
+        on_change: Some(Rc::new(|event: SwitchChangeEvent| {
+            leptos::logging::log!(
+                "switch::change next={} disabled={}",
+                event.next,
+                event.disabled,
+            );
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(switch_delegate.clone()),
+    };
+    let radio_component = {
+        let mut props = LeptosRadioGroupProps::new(radio_props.clone(), radio_state.clone());
+        props.telemetry = telemetry("radio.component");
+        props.on_change = Some(Rc::new(|event: RadioChangeEvent| {
+            leptos::logging::log!(
+                "radio::change previous={:?} next={} label={}",
+                event.previous,
+                event.next,
+                event.label,
+            );
+        }));
+        props.on_focus = None;
+        props.on_blur = None;
+        props.on_key = None;
+        props.telemetry_delegate = Some(radio_delegate.clone());
+        props
+    };
 
     view! {
         <div>
-            <div inner_html=checkbox::leptos::render(&CheckboxProps::new("Save card"), &checkbox_state)/>
-            <div inner_html=switch::leptos::render(&SwitchProps::new("Enable auto-pay"), &switch_state)/>
-            {radio_group}
+            {LeptosCheckbox(checkbox_component)}
+            {LeptosSwitch(switch_component)}
+            {LeptosRadioGroup(radio_component)}
         </div>
     }
 }
 ```
+
+> **Compile-time note:** Add `rustic-ui-material` with the `leptos` feature and
+> enable the matching `forms` feature on `rustic-ui-headless` before running
+> `cargo leptos build` or `cargo check` inside an example crate.

--- a/examples/selection-controls-sycamore/README.md
+++ b/examples/selection-controls-sycamore/README.md
@@ -1,14 +1,47 @@
 # Selection Controls with Sycamore
 
+Typed Sycamore components let us mount interactive selection controls without
+`dangerously_set_inner_html` while still registering deterministic telemetry
+hooks for analytics and automation.
+
 ```rust
-use std::rc::Rc;
+use rustic_ui_headless::{
+    checkbox::CheckboxState,
+    radio::{RadioGroupState, RadioOrientation},
+    switch::SwitchState,
+};
+use rustic_ui_material::{TelemetryContext, TelemetryHooks};
+use rustic_ui_material::checkbox::{
+    CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
+    sycamore::{SycamoreCheckbox, SycamoreCheckboxProps},
+};
+use rustic_ui_material::radio::{
+    RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent,
+    sycamore::{SycamoreRadioGroup, SycamoreRadioGroupProps},
+};
+use rustic_ui_material::switch::{
+    SwitchChangeEvent, SwitchProps, SwitchTelemetryEvent,
+    sycamore::{SycamoreSwitch, SycamoreSwitchProps},
+};
+use std::{rc::Rc, sync::Arc};
 use sycamore::prelude::*;
-use rustic_ui_headless::checkbox::CheckboxState;
-use rustic_ui_headless::switch::SwitchState;
-use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
-use rustic_ui_material::checkbox::{self, CheckboxProps};
-use rustic_ui_material::switch::{self, SwitchProps};
-use rustic_ui_material::radio::{self, RadioGroupProps, RadioChangeEvent, RadioTelemetryEvent};
+
+fn telemetry(channel: &'static str) -> TelemetryHooks {
+    let mut hooks = TelemetryHooks::default();
+    hooks.analytics_id = Some(format!("selection-controls.sycamore.{channel}"));
+    hooks.automation_id = Some(format!("automation.selection-controls.{channel}"));
+    let channel_label = format!("selection_controls::{channel}");
+    hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
+        println!(
+            "telemetry::render channel={} component={} analytics={:?} automation={:?}",
+            channel_label,
+            context.component,
+            context.analytics_id,
+            context.automation_id,
+        );
+    }));
+    hooks
+}
 
 #[component]
 pub fn SelectionControls<G: Html>(cx: Scope) -> View<G> {
@@ -21,19 +54,75 @@ pub fn SelectionControls<G: Html>(cx: Scope) -> View<G> {
         Some(0),
     );
 
-    let radio_props = RadioGroupProps::from_state(&radio_state);
-    let mut interactive = radio::sycamore::SycamoreRadioGroupProps::new(radio_props.clone(), radio_state.clone());
-    interactive.telemetry_delegate = Some(Rc::new(|event: RadioTelemetryEvent| {
-        println!("telemetry::{:?}", event);
-    }));
-    interactive.on_change = Some(Rc::new(|event: RadioChangeEvent| {
-        println!("change::next={}", event.next);
-    }));
+    let checkbox_props = CheckboxProps {
+        label: "Light theme".into(),
+        telemetry: telemetry("checkbox"),
+    };
+    let switch_props = SwitchProps {
+        label: "Enable system overrides".into(),
+        telemetry: telemetry("switch"),
+    };
+    let radio_props = RadioGroupProps::from_state(&radio_state)
+        .with_telemetry(telemetry("radio"));
+
+    let checkbox_delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = Rc::new(|event| {
+        println!("checkbox telemetry::{event:?}");
+    });
+    let switch_delegate: Rc<dyn Fn(SwitchTelemetryEvent)> = Rc::new(|event| {
+        println!("switch telemetry::{event:?}");
+    });
+    let radio_delegate: Rc<dyn Fn(RadioTelemetryEvent)> = Rc::new(|event| {
+        println!("radio telemetry::{event:?}");
+    });
+
+    let checkbox_component = SycamoreCheckboxProps {
+        checkbox: checkbox_props.clone(),
+        state: checkbox_state.clone(),
+        on_change: Some(Rc::new(|event: CheckboxChangeEvent| {
+            println!("checkbox::change next={} disabled={}", event.next, event.disabled);
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(checkbox_delegate.clone()),
+    };
+    let switch_component = SycamoreSwitchProps {
+        switch: switch_props.clone(),
+        state: switch_state.clone(),
+        on_change: Some(Rc::new(|event: SwitchChangeEvent| {
+            println!("switch::change next={} disabled={}", event.next, event.disabled);
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(switch_delegate.clone()),
+    };
+    let radio_component = {
+        let mut props = SycamoreRadioGroupProps::new(radio_props.clone(), radio_state.clone());
+        props.telemetry = telemetry("radio.component");
+        props.on_change = Some(Rc::new(|event: RadioChangeEvent| {
+            println!(
+                "radio::change previous={:?} next={} label={}",
+                event.previous,
+                event.next,
+                event.label,
+            );
+        }));
+        props.on_focus = None;
+        props.on_blur = None;
+        props.on_key = None;
+        props.telemetry_delegate = Some(radio_delegate.clone());
+        props
+    };
 
     view! { cx,
-        div(dangerously_set_inner_html=checkbox::sycamore::render(&CheckboxProps::new("Light theme"), &checkbox_state)) {}
-        div(dangerously_set_inner_html=switch::sycamore::render(&SwitchProps::new("Enable system overrides"), &switch_state)) {}
-        radio::sycamore::SycamoreRadioGroup(interactive)
+        SycamoreCheckbox(checkbox_component)
+        SycamoreSwitch(switch_component)
+        SycamoreRadioGroup(radio_component)
     }
 }
 ```
+
+> **Compile-time note:** Pull in `rustic-ui-material` with the `sycamore`
+> feature and the matching `forms` feature from `rustic-ui-headless` before
+> running `cargo check` within a Sycamore example crate.

--- a/examples/selection-controls-yew/README.md
+++ b/examples/selection-controls-yew/README.md
@@ -1,23 +1,52 @@
 # Selection Controls with Yew
 
-This example demonstrates how to wire the headless selection control state
-machines from `rustic_ui_headless` into a Yew application using the render helpers
-from `rustic_ui_material`.
+Replace legacy render helpers with typed Yew components so hydration stays
+predictable and every control registers deterministic telemetry hooks upfront.
 
 ```rust
-use rustic_ui_headless::checkbox::CheckboxState;
 use gloo_console::log;
-use rustic_ui_material::checkbox::{self, CheckboxProps};
-use rustic_ui_material::switch::{self, SwitchProps};
-use rustic_ui_material::radio::{self, RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent};
-use rustic_ui_material::radio::yew::YewRadioGroup;
-use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
+use rustic_ui_headless::{
+    checkbox::CheckboxState,
+    radio::{RadioGroupState, RadioOrientation},
+    switch::SwitchState,
+};
+use rustic_ui_material::{TelemetryContext, TelemetryHooks};
+use rustic_ui_material::checkbox::{
+    CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
+    yew::{YewCheckbox, YewCheckboxProps},
+};
+use rustic_ui_material::radio::{
+    RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent,
+    yew::{YewRadioGroup, YewRadioGroupProps},
+};
+use rustic_ui_material::switch::{
+    SwitchChangeEvent, SwitchProps, SwitchTelemetryEvent,
+    yew::{YewSwitch, YewSwitchProps},
+};
+use std::sync::Arc;
 use yew::prelude::*;
 
+fn telemetry(channel: &'static str) -> TelemetryHooks {
+    let mut hooks = TelemetryHooks::default();
+    hooks.analytics_id = Some(format!("selection-controls.yew.{channel}"));
+    hooks.automation_id = Some(format!("automation.selection-controls.{channel}"));
+    let channel_label = format!("selection_controls::{channel}");
+    hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
+        log!(format!(
+            "telemetry::render channel={} component={} analytics={:?} automation={:?}",
+            channel_label,
+            context.component,
+            context.analytics_id,
+            context.automation_id,
+        ));
+    }));
+    hooks
+}
+
 #[function_component(SelectionControls)]
-fn selection_controls() -> Html {
+pub fn selection_controls() -> Html {
     let checkbox_state = CheckboxState::uncontrolled(false, false);
-    let switch_state = rustic_ui_headless::switch::SwitchState::uncontrolled(false, true);
+    let switch_state = SwitchState::uncontrolled(false, true);
     let radio_state = RadioGroupState::uncontrolled(
         vec!["Email".into(), "SMS".into()],
         false,
@@ -25,32 +54,85 @@ fn selection_controls() -> Html {
         Some(0),
     );
 
-    let on_radio_change = Callback::from(|event: RadioChangeEvent| {
-        log!(format!("selected index: {}", event.next));
+    let checkbox_props = CheckboxProps {
+        label: "Receive updates".into(),
+        telemetry: telemetry("checkbox"),
+    };
+    let switch_props = SwitchProps {
+        label: "Enable notifications".into(),
+        telemetry: telemetry("switch"),
+    };
+    let radio_props = RadioGroupProps::from_state(&radio_state)
+        .with_telemetry(telemetry("radio"));
+
+    let checkbox_delegate = Callback::from(|event: CheckboxTelemetryEvent| {
+        log!(format!("checkbox telemetry: {:?}", event));
     });
-    let on_radio_telemetry = Callback::from(|event: RadioTelemetryEvent| {
-        log!(format!("telemetry: {:?}", event));
+    let switch_delegate = Callback::from(|event: SwitchTelemetryEvent| {
+        log!(format!("switch telemetry: {:?}", event));
     });
+    let radio_delegate = Callback::from(|event: RadioTelemetryEvent| {
+        log!(format!("radio telemetry: {:?}", event));
+    });
+
+    let checkbox_component = YewCheckboxProps {
+        checkbox: checkbox_props.clone(),
+        state: checkbox_state.clone(),
+        on_change: Some(Callback::from(|event: CheckboxChangeEvent| {
+            log!(format!(
+                "checkbox::change next={} disabled={}",
+                event.next,
+                event.disabled,
+            ));
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(checkbox_delegate.clone()),
+    };
+    let switch_component = YewSwitchProps {
+        switch: switch_props.clone(),
+        state: switch_state.clone(),
+        on_change: Some(Callback::from(|event: SwitchChangeEvent| {
+            log!(format!(
+                "switch::change next={} disabled={}",
+                event.next,
+                event.disabled,
+            ));
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(switch_delegate.clone()),
+    };
+    let radio_component = YewRadioGroupProps {
+        group: radio_props.clone(),
+        state: radio_state.clone(),
+        telemetry: telemetry("radio.component"),
+        on_change: Some(Callback::from(|event: RadioChangeEvent| {
+            log!(format!(
+                "radio::change previous={:?} next={} label={}",
+                event.previous,
+                event.next,
+                event.label,
+            ));
+        })),
+        on_focus: None,
+        on_blur: None,
+        on_key: None,
+        telemetry_delegate: Some(radio_delegate.clone()),
+    };
 
     html! {
         <>
-            { Html::from_html_unchecked(AttrValue::from(
-                checkbox::yew::render(&CheckboxProps::new("Receive updates"), &checkbox_state),
-            )) }
-            { Html::from_html_unchecked(AttrValue::from(
-                switch::yew::render(&SwitchProps::new("Enable notifications"), &switch_state),
-            )) }
-            <YewRadioGroup
-                group={RadioGroupProps::from_state(&radio_state)}
-                state={radio_state}
-                on_change={Some(on_radio_change)}
-                telemetry_delegate={Some(on_radio_telemetry)}
-            />
+            <YewCheckbox ..checkbox_component />
+            <YewSwitch ..switch_component />
+            <YewRadioGroup ..radio_component />
         </>
     }
 }
 ```
 
-The radio group now emits structured telemetry before any consumer callbacks
-execute, ensuring analytics capture remains deterministic even as the UI mutates
-through `RadioGroupState`.
+> **Compile-time note:** Add `rustic-ui-material` with the `yew` feature and the
+> `forms` feature on `rustic-ui-headless`, then run `cargo check --target wasm32-unknown-unknown`
+> inside the example crate to validate the snippet.


### PR DESCRIPTION
## Summary
- switch the selection-control example READMEs to use the typed framework components instead of legacy render helpers
- document deterministic TelemetryHooks configuration and delegates for checkboxes, switches, and radio groups across Dioxus, Leptos, Sycamore, and Yew
- add hydration-safe mounting guidance and feature-flag notes so downstream teams can compile the snippets without guesswork

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68deb17f147c832eb96765ff9393b8f0