### PR TITLE
docs(material): describe descriptor-driven SSR for toggles

### DIFF
--- a/crates/rustic-ui-material/src/checkbox.rs
+++ b/crates/rustic-ui-material/src/checkbox.rs
@@ -1,49 +1,118 @@
-//! Material flavored checkbox built on the headless [`CheckboxState`].
+//! Material flavored checkbox built on the headless [`CheckboxState`] and the
+//! descriptor pipeline shared across RusticUI selection controls.
 //!
-//! Feature flags expose idiomatic components for each supported framework so
-//! enterprise teams can wire the same behavioral core into multi-runtime
-//! surfaces without maintaining parallel markup:
+//! The module routes every render path through
+//! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor)
+//! so the same attribute snapshot powers:
+//!
+//! * Server-side serialization via
+//!   [`render_toggle_html`](crate::selection_control::render_toggle_html) for
+//!   HTML-first frameworks and static-site generators.
+//! * Client adapters for React, Yew, Leptos, Dioxus, and Sycamore which reuse
+//!   those attributes during hydration to avoid checksum drift while the
+//!   descriptor feeds the shared style registry.
+//!
+//! Each adapter is feature gated so enterprise teams can compose a tailored
+//! footprint while still sharing the same automation-friendly metadata:
 //!
 //! * `react` – Enables [`react::ReactCheckbox`] which returns [`Jsx`] elements
-//!   via the `wasm_bindgen` bridge and delegates style injection to the shared
-//!   descriptor helpers.
-//! * `yew` – Enables [`yew::YewCheckbox`] driven by `#[function_component]` for
-//!   seamless integration with existing Yew applications.
+//!   via the `wasm_bindgen` bridge while mirroring SSR attributes into the
+//!   client render for hydration safety.
+//! * `yew` – Enables [`yew::YewCheckbox`] implemented with
+//!   `#[function_component]` so attribute pairs land directly in the Yew `Html`
+//!   node tree without re-stringifying during hydration.
 //! * `leptos` – Enables [`leptos::LeptosCheckbox`] composed with
-//!   `#[component]`, returning a [`leptos::View`] so Leptos signals can hydrate
-//!   without diff churn.
+//!   `#[component]`; descriptors feed Leptos `View` nodes so signal-driven
+//!   updates respect SSR state.
 //! * `dioxus` – Enables [`dioxus::DioxusCheckbox`] implemented with `rsx!`
-//!   markup for ergonomic client rendering and SSR parity.
+//!   markup, ensuring the WASM runtime consumes the same descriptor snapshot
+//!   emitted on the server.
 //! * `sycamore` – Enables [`sycamore::SycamoreCheckbox`] returning a Sycamore
-//!   [`Template`](sycamore::view::Template) for teams building signal-driven
-//!   dashboards.
+//!   [`Template`](sycamore::view::Template) that hydrates from the descriptor’s
+//!   attribute cache without custom glue.
 //!
-//! All adapters delegate attribute hydration to the shared
-//! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor)
-//! so automation hooks and ARIA metadata remain consistent across frameworks.
+//! # Feature flags & setup
 //!
-//! Downstream orchestration layers should populate the analytics and automation
-//! identifiers within [`TelemetryHooks`] *before* calling any render helper so
-//! every adapter emits identical instrumentation. Providing the identifiers up
-//! front allows SSR, WASM bridges, and component frameworks to produce matching
-//! telemetry payloads without bolting on per-platform patches, keeping
-//! enterprise monitoring pipelines aligned across runtimes.
+//! ```toml
+//! rustic-ui-material = {
+//!     version = "0.1",
+//!     default-features = false,
+//!     features = ["forms", "react", "yew", "leptos", "dioxus", "sycamore"]
+//! }
+//! tracing = "0.1"
+//! ```
 //!
-//! The same `TelemetryHooks` handle higher-order enterprise observability.
-//! Teams pipe analytics beacons, focus transitions, state mutations, commit
-//! acknowledgements, and panic reports into centralized data planes by wiring
-//! closures into the new hook accessors on [`CheckboxProps`]. The props expose
-//! trait-object accessors so automated pipelines can subscribe once and receive
-//! uniform payloads across React, Yew, Leptos, Sycamore, and Dioxus surfaces
-//! without hand-coding framework-specific glue.
+//! Enable `react`, `yew`, `leptos`, `dioxus`, or `sycamore` depending on the
+//! client runtimes you need, and ensure your telemetry stack configures a
+//! `tracing` subscriber (for example via `tracing_subscriber::fmt()`) before
+//! hydrating any widgets so `TelemetryHooks` callbacks can emit spans and
+//! metrics deterministically.
 //!
-//! Every adapter now exposes optional change/focus/blur/key callbacks alongside
-//! a telemetry delegate so large applications can bubble structured
-//! [`CheckboxTelemetryEvent`] payloads into centralized analytics collectors.
-//! The helpers reuse the headless [`CheckboxState`] to compute prior/next
-//! values, ensuring automation harnesses attached to React, Yew, Leptos,
-//! Dioxus, or Sycamore receive identical event contracts without writing
-//! adapter-specific plumbing.
+//! # Descriptor-driven SSR & hydration
+//!
+//! The descriptor API keeps SSR and CSR perfectly aligned. Server renderers call
+//! [`render_toggle_html`](crate::selection_control::render_toggle_html) to
+//! serialize HTML while client adapters hydrate from the same attribute cache.
+//!
+//! ```rust,no_run
+//! use rustic_ui_headless::checkbox::{CheckboxState, CheckboxValue};
+//! use rustic_ui_material::checkbox::CheckboxProps;
+//! use rustic_ui_material::selection_control::{render_toggle_html, ToggleControlDescriptor};
+//! use rustic_ui_material::telemetry::TelemetryHooks;
+//! use rustic_ui_styled_engine::{css, Style};
+//! use std::sync::Arc;
+//! use tracing::info;
+//!
+//! # #[cfg(feature = "react")]
+//! use rustic_ui_material::checkbox::react::{ReactCheckbox, ReactCheckboxProps};
+//!
+//! # fn orchestrate_descriptor_round_trip() {
+//!     let state = CheckboxState::uncontrolled(false, CheckboxValue::Off);
+//!     let descriptor = ToggleControlDescriptor::new(
+//!         "Accept terms",
+//!         Style::new(css!("display: inline-flex; align-items: center;"))
+//!             .expect("style to compile"),
+//!     )
+//!     .with_attributes(state.aria_attributes());
+//!
+//!     // SSR builds a stable HTML fragment that already includes hydration-safe
+//!     // data attributes and scoped class names.
+//!     let ssr_html = render_toggle_html(&descriptor);
+//!     assert!(ssr_html.contains("aria-checked=\"false\""));
+//!
+//!     // Hydration reuses the descriptor metadata so analytics and automation
+//!     // selectors stay identical across runtimes.
+//!     let mut telemetry = TelemetryHooks::default();
+//!     telemetry.analytics_id = Some("checkbox.accept".into());
+//!     telemetry.automation_id = Some("accept-terms".into());
+//!     telemetry.on_render = Some(Arc::new(|ctx| {
+//!         info!(target: "rusticui.telemetry", component = ctx.component, "hydrated");
+//!     }));
+//!
+//!     # #[cfg(feature = "react")]
+//!     {
+//!         let props = ReactCheckboxProps {
+//!             checkbox: CheckboxProps::new("Accept terms", telemetry.clone()),
+//!             state: state.clone(),
+//!             on_change: None,
+//!             on_focus: None,
+//!             on_blur: None,
+//!             on_key: None,
+//!             telemetry_delegate: None,
+//!         };
+//!         let node = ReactCheckbox(&props);
+//!         let _ = node;
+//!     }
+//! }
+//! # orchestrate_descriptor_round_trip();
+//! ```
+//!
+//! Populate the analytics and automation identifiers inside [`TelemetryHooks`]
+//! *before* rendering so SSR, WASM bridges, and component adapters all reuse the
+//! same data attributes. Doing so keeps enterprise instrumentation aligned
+//! across observability stacks, prevents hydration mismatches, and minimises the
+//! manual wiring typically required to coordinate React, Yew, Leptos, Dioxus,
+//! and Sycamore surfaces.
 
 use crate::{
     selection_control::{self, ToggleControlDescriptor},

--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -1,28 +1,124 @@
-//! Material radio group built atop the headless [`RadioGroupState`].
+//! Material radio group built atop the headless [`RadioGroupState`] and the
+//! descriptor system that unifies SSR and hydration across frameworks.
 //!
-//! Feature gates expose first-class components for each supported framework
-//! while the shared [`RadioGroupDescriptor`](crate::selection_control::RadioGroupDescriptor)
-//! guarantees consistent styling and automation hooks:
+//! [`RadioGroupDescriptor`](crate::selection_control::RadioGroupDescriptor) and
+//! [`RadioOptionDescriptor`](crate::selection_control::RadioOptionDescriptor)
+//! capture ARIA, automation, and theming metadata once so both server renderers
+//! and client adapters consume the same snapshot:
 //!
-//! * `react` – [`react::ReactRadioGroup`] yields [`Jsx`] through the
-//!   `wasm_bindgen` bridge, wiring descriptors directly into React elements.
-//! * `yew` – [`yew::YewRadioGroup`] leverages `#[function_component]` so Yew apps
-//!   can bind to the group without string conversions.
-//! * `leptos` – [`leptos::LeptosRadioGroup`] composes with `#[component]` and
-//!   returns a [`leptos::View`].
-//! * `dioxus` – [`dioxus::DioxusRadioGroup`] uses `rsx!` for idiomatic Dioxus
-//!   rendering.
-//! * `sycamore` – [`sycamore::SycamoreRadioGroup`] returns a Sycamore
-//!   [`Template`](sycamore::view::Template) for signal driven dashboards.
+//! * [`render_radio_group_html`](crate::selection_control::render_radio_group_html)
+//!   serializes HTML for SSR, static hosting, or streaming pipelines while reusing
+//!   the descriptor’s hydration-safe attributes.
+//! * Framework adapters for React, Yew, Leptos, Dioxus, and Sycamore hydrate by
+//!   reading the descriptor’s themed attribute vectors, ensuring automation
+//!   selectors, analytics hooks, and ARIA metadata remain identical to the SSR
+//!   output.
 //!
-//! Each adapter reads from the same descriptor so automation selectors and ARIA
-//! metadata stay synchronized across frameworks and SSR pipelines.
+//! Feature gates let teams activate only the clients they deploy without giving
+//! up descriptor parity:
 //!
-//! Central platform teams can register analytics, focus, state transition,
-//! commit acknowledgement, and panic handlers once via [`RadioGroupProps`]'s
-//! hook accessors. Those hooks proxy directly to [`TelemetryHooks`], ensuring
-//! enterprise observability stacks ingest consistent payloads regardless of the
-//! frontend framework driving the radio group.
+//! * `react` – [`react::ReactRadioGroup`] mirrors descriptor attributes into
+//!   [`Jsx`] nodes so React hydrates without recomputing group state.
+//! * `yew` – [`yew::YewRadioGroup`] renders a `Html` tree seeded by descriptor
+//!   snapshots to avoid checksum drift.
+//! * `leptos` – [`leptos::LeptosRadioGroup`] composes with `#[component]`,
+//!   reusing descriptors inside the Leptos signal graph for reactive hydration.
+//! * `dioxus` – [`dioxus::DioxusRadioGroup`] maps descriptor metadata into
+//!   `rsx!` markup for WASM-based shells.
+//! * `sycamore` – [`sycamore::SycamoreRadioGroup`] outputs
+//!   [`Template`](sycamore::view::Template) instances hydrated directly from the
+//!   descriptor cache.
+//!
+//! # Feature flags & setup
+//!
+//! ```toml
+//! rustic-ui-material = {
+//!     version = "0.1",
+//!     default-features = false,
+//!     features = ["forms", "react", "yew", "leptos", "dioxus", "sycamore"]
+//! }
+//! tracing = "0.1"
+//! ```
+//!
+//! Configure a `tracing` subscriber (for example with
+//! `tracing_subscriber::fmt::init()`) before hydrating adapters so
+//! [`TelemetryHooks`] can forward render spans, analytics payloads, and error
+//! reports into your observability stack.
+//!
+//! # Descriptor-driven SSR & hydration
+//!
+//! ```rust,no_run
+//! use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
+//! use rustic_ui_material::radio::RadioGroupProps;
+//! use rustic_ui_material::selection_control::{
+//!     render_radio_group_html, RadioGroupDescriptor, RadioOptionDescriptor,
+//! };
+//! use rustic_ui_material::telemetry::TelemetryHooks;
+//! use rustic_ui_styled_engine::{css, Style};
+//! use std::sync::Arc;
+//! use tracing::info;
+//!
+//! # #[cfg(feature = "leptos")]
+//! use rustic_ui_material::radio::leptos::{LeptosRadioGroup, LeptosRadioGroupProps};
+//!
+//! # fn orchestrate_radio_round_trip() {
+//!     let state = RadioGroupState::uncontrolled(
+//!         vec!["Email".to_string(), "SMS".to_string()],
+//!         false,
+//!         RadioOrientation::Horizontal,
+//!         Some(0),
+//!     );
+//!     let group_style = Style::new(css!("display: grid; gap: 0.5rem;"))
+//!         .expect("style to compile");
+//!     let option_style = Style::new(css!("padding: 0.25rem 0.5rem;"))
+//!         .expect("style to compile");
+//!     let descriptor = RadioGroupDescriptor::new(group_style.clone())
+//!         .with_group_attributes(state.group_aria_attributes())
+//!         .option(
+//!             RadioOptionDescriptor::new("Email", option_style.clone())
+//!                 .with_attributes(state.option_aria_attributes(0)),
+//!         )
+//!         .option(
+//!             RadioOptionDescriptor::new("SMS", option_style.clone())
+//!                 .with_attributes(state.option_aria_attributes(1)),
+//!         );
+//!
+//!     // SSR produces deterministic markup using the descriptor metadata.
+//!     let ssr_html = render_radio_group_html(&descriptor);
+//!     assert!(ssr_html.contains("role=\"radiogroup\""));
+//!
+//!     // Hydration merges telemetry hooks so analytics fire before user
+//!     // callbacks while keeping descriptor attributes intact.
+//!     let mut telemetry = TelemetryHooks::default();
+//!     telemetry.analytics_id = Some("radio.delivery".into());
+//!     telemetry.on_render = Some(Arc::new(|ctx| {
+//!         info!(target: "rusticui.telemetry", component = ctx.component, "hydrated");
+//!     }));
+//!
+//!     # #[cfg(feature = "leptos")]
+//!     {
+//!         let props = LeptosRadioGroupProps {
+//!             group: RadioGroupProps::from_state(&state, telemetry.clone()),
+//!             state: state.clone(),
+//!             telemetry: telemetry.clone(),
+//!             on_change: None,
+//!             on_focus: None,
+//!             on_blur: None,
+//!             on_key: None,
+//!             telemetry_delegate: None,
+//!         };
+//!         let view = LeptosRadioGroup(props);
+//!         let _ = view;
+//!     }
+//! }
+//! # orchestrate_radio_round_trip();
+//! ```
+//!
+//! Register analytics, focus, state transition, commit acknowledgement, and
+//! panic handlers on [`TelemetryHooks`] before rendering. Doing so guarantees
+//! SSR markup, hydration adapters, and enterprise observability pipelines all
+//! reuse the same descriptor-provided metadata regardless of whether React,
+//! Yew, Leptos, Dioxus, or Sycamore drives the client surface.
 
 use rustic_ui_headless::{
     interaction::ControlKey,

--- a/crates/rustic-ui-material/src/switch.rs
+++ b/crates/rustic-ui-material/src/switch.rs
@@ -1,34 +1,108 @@
-//! Material switch built from the headless [`SwitchState`].
+//! Material switch built from the headless [`SwitchState`] and the shared
+//! descriptor pipeline that aligns SSR output with multi-framework hydration.
 //!
-//! Feature-gated adapters expose idiomatic components per framework while
-//! sharing styling, accessibility metadata, and telemetry ordering via
+//! Every render path flows through
 //! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor)
-//! and the helper dispatchers defined below.
+//! so the same attribute snapshot drives:
 //!
-//! * `react` – [`react::ReactSwitch`] returns [`Jsx`] using the `wasm_bindgen`
-//!   bridge and the shared descriptor metadata.
-//! * `yew` – [`yew::YewSwitch`] is decorated with `#[function_component]` for
-//!   seamless use in Yew apps.
-//! * `leptos` – [`leptos::LeptosSwitch`] leverages the Leptos `#[component]`
-//!   macro and returns a [`leptos::View`].
-//! * `dioxus` – [`dioxus::DioxusSwitch`] renders markup with `rsx!` so Dioxus
-//!   shells gain first-class primitives instead of raw HTML strings.
-//! * `sycamore` – [`sycamore::SycamoreSwitch`] yields a Sycamore
-//!   [`Template`](sycamore::view::Template) for signal-driven experiences.
+//! * [`render_toggle_html`](crate::selection_control::render_toggle_html) for
+//!   deterministic SSR fragments that can be cached or streamed.
+//! * React, Yew, Leptos, Dioxus, and Sycamore adapters which hydrate with the
+//!   exact attribute set captured during SSR, preventing hydration checksum
+//!   drift and ensuring analytics markers stay stable.
 //!
-//! All adapters derive their attributes from the same descriptor ensuring parity
-//! between SSR and client renders regardless of framework. Telemetry hooks and
-//! analytics callbacks are routed through [`instrument_render`],
-//! [`TelemetryContext`], and the dispatch helpers so analytics capture always
-//! precedes local side effects. Controlled integrations remain authoritative
-//! because every adapter checks [`SwitchState::is_controlled`] before mutating
-//! the cached state while still emitting telemetry and change callbacks.
+//! Feature gates allow teams to activate only the clients they deploy while
+//! retaining descriptor consistency:
 //!
-//! Enterprise teams can now wire analytics batching, focus visibility, state
-//! mutation, commit acknowledgement, and panic handling delegates through the
-//! hook accessors on [`SwitchProps`]. Doing so keeps compliance logging, SRE
-//! alerting, and growth dashboards synchronized without sprinkling repetitive
-//! wiring logic into every adapter.
+//! * `react` – [`react::ReactSwitch`] mirrors SSR attributes into [`Jsx`] nodes
+//!   via the `wasm_bindgen` bridge so React hydrates without recomputing ARIA
+//!   metadata.
+//! * `yew` – [`yew::YewSwitch`] leverages `#[function_component]` so the
+//!   descriptor’s themed attribute pairs map directly onto the Yew virtual DOM.
+//! * `leptos` – [`leptos::LeptosSwitch`] composes with `#[component]`, feeding
+//!   descriptor metadata into Leptos signals for reactive hydration.
+//! * `dioxus` – [`dioxus::DioxusSwitch`] uses `rsx!`, reusing the descriptor to
+//!   seed Dioxus’ virtual DOM snapshots.
+//! * `sycamore` – [`sycamore::SycamoreSwitch`] produces
+//!   [`Template`](sycamore::view::Template) instances that hydrate directly from
+//!   the descriptor cache.
+//!
+//! # Feature flags & setup
+//!
+//! ```toml
+//! rustic-ui-material = {
+//!     version = "0.1",
+//!     default-features = false,
+//!     features = ["forms", "react", "yew", "leptos", "dioxus", "sycamore"]
+//! }
+//! tracing = "0.1"
+//! ```
+//!
+//! Ensure a `tracing` subscriber (for example
+//! `tracing_subscriber::fmt::init()`) is installed before hydrating adapters so
+//! [`TelemetryHooks`] can pipe render spans, analytics payloads, and error
+//! reports into your observability fabric automatically.
+//!
+//! # Descriptor-driven SSR & hydration
+//!
+//! ```rust,no_run
+//! use rustic_ui_headless::switch::SwitchState;
+//! use rustic_ui_material::selection_control::{render_toggle_html, ToggleControlDescriptor};
+//! use rustic_ui_material::switch::SwitchProps;
+//! use rustic_ui_material::telemetry::TelemetryHooks;
+//! use rustic_ui_styled_engine::{css, Style};
+//! use std::sync::Arc;
+//! use tracing::info;
+//!
+//! # #[cfg(feature = "yew")]
+//! use rustic_ui_material::switch::yew::{YewSwitch, YewSwitchProps};
+//! # #[cfg(feature = "yew")]
+//! use yew::html::Html;
+//!
+//! # fn orchestrate_switch_round_trip() {
+//!     let state = SwitchState::uncontrolled(false, false);
+//!     let descriptor = ToggleControlDescriptor::new(
+//!         "Notifications",
+//!         Style::new(css!("display: inline-flex;"))
+//!             .expect("style to compile"),
+//!     )
+//!     .with_attributes(state.aria_attributes());
+//!
+//!     // Server renderers emit deterministic HTML using the descriptor.
+//!     let ssr_html = render_toggle_html(&descriptor);
+//!     assert!(ssr_html.contains("data-on=\"false\""));
+//!
+//!     // Hydration paths merge telemetry so analytics spans fire before user
+//!     // callbacks. The descriptor attributes are reused verbatim.
+//!     let mut telemetry = TelemetryHooks::default();
+//!     telemetry.analytics_id = Some("switch.notifications".into());
+//!     telemetry.on_render = Some(Arc::new(|ctx| {
+//!         info!(target = "rusticui.telemetry", component = ctx.component, "hydrated");
+//!     }));
+//!
+//!     # #[cfg(feature = "yew")]
+//!     {
+//!         let props = YewSwitchProps {
+//!             switch: SwitchProps::new("Notifications", telemetry.clone()),
+//!             state: state.clone(),
+//!             on_change: None,
+//!             on_focus: None,
+//!             on_blur: None,
+//!             on_key: None,
+//!             telemetry_delegate: None,
+//!         };
+//!         let view: Html = YewSwitch(&props);
+//!         let _ = view;
+//!     }
+//! }
+//! # orchestrate_switch_round_trip();
+//! ```
+//!
+//! Controlled integrations remain authoritative because each adapter checks
+//! [`SwitchState::is_controlled`] before mutating local snapshots while still
+//! emitting telemetry and change callbacks. Populate [`TelemetryHooks`]
+//! *before* rendering so SSR output, hydration, analytics, and automation hooks
+//! all reuse the same descriptor-driven attributes across runtimes.
 
 use crate::{
     selection_control::{self, ToggleControlDescriptor},


### PR DESCRIPTION
## Summary
- expand the checkbox, switch, and radio module docs to explain how the shared descriptor API drives SSR markup and multi-framework hydration
- add enterprise-oriented setup guidance covering feature flags, telemetry wiring, and tracing configuration
- embed code samples that serialize HTML alongside React, Yew, and Leptos adapter hydration to demonstrate attribute reuse and telemetry integration

## Testing
- cargo doc -p rustic-ui-material --no-deps


------
https://chatgpt.com/codex/tasks/task_e_68defa5e8730832eb1669ad368332aeb