### PR TITLE
Introduce builder-based selection control descriptors

### DIFF
--- a/crates/rustic-ui-material/src/checkbox.rs
+++ b/crates/rustic-ui-material/src/checkbox.rs
@@ -2,11 +2,11 @@
 //! descriptor pipeline shared across RusticUI selection controls.
 //!
 //! The module routes every render path through
-//! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor)
+//! [`SelectionControlAttributes`](crate::selection_control::SelectionControlAttributes)
 //! so the same attribute snapshot powers:
 //!
-//! * Server-side serialization via
-//!   [`render_toggle_html`](crate::selection_control::render_toggle_html) for
+//! * Server-side serialization via [`SelectionControlAttributes::to_ssr_html`]
+//!   for
 //!   HTML-first frameworks and static-site generators.
 //! * Client adapters for React, Yew, Leptos, Dioxus, and Sycamore which reuse
 //!   those attributes during hydration to avoid checksum drift while the
@@ -51,13 +51,13 @@
 //! # Descriptor-driven SSR & hydration
 //!
 //! The descriptor API keeps SSR and CSR perfectly aligned. Server renderers call
-//! [`render_toggle_html`](crate::selection_control::render_toggle_html) to
-//! serialize HTML while client adapters hydrate from the same attribute cache.
+//! [`SelectionControlAttributes::to_ssr_html`] to serialize HTML while client
+//! adapters hydrate from the same attribute cache.
 //!
 //! ```rust,no_run
 //! use rustic_ui_headless::checkbox::{CheckboxState, CheckboxValue};
 //! use rustic_ui_material::checkbox::CheckboxProps;
-//! use rustic_ui_material::selection_control::{render_toggle_html, ToggleControlDescriptor};
+//! use rustic_ui_material::selection_control::SelectionControlAttributes;
 //! use rustic_ui_material::telemetry::TelemetryHooks;
 //! use rustic_ui_styled_engine::{css, Style};
 //! use std::sync::Arc;
@@ -68,16 +68,17 @@
 //!
 //! # fn orchestrate_descriptor_round_trip() {
 //!     let state = CheckboxState::uncontrolled(false, CheckboxValue::Off);
-//!     let descriptor = ToggleControlDescriptor::new(
+//!     let descriptor = SelectionControlAttributes::builder(
 //!         "Accept terms",
 //!         Style::new(css!("display: inline-flex; align-items: center;"))
 //!             .expect("style to compile"),
 //!     )
-//!     .with_attributes(state.aria_attributes());
+//!     .attribute("role", "checkbox")
+//!     .build();
 //!
 //!     // SSR builds a stable HTML fragment that already includes hydration-safe
 //!     // data attributes and scoped class names.
-//!     let ssr_html = render_toggle_html(&descriptor);
+//!     let ssr_html = descriptor.to_ssr_html();
 //!     assert!(ssr_html.contains("aria-checked=\"false\""));
 //!
 //!     // Hydration reuses the descriptor metadata so analytics and automation
@@ -115,7 +116,7 @@
 //! and Sycamore surfaces.
 
 use crate::{
-    selection_control::{self, ToggleControlDescriptor},
+    selection_control::SelectionControlAttributes,
     telemetry::{
         instrument_render, TelemetryAnalyticsCallback, TelemetryCommitCallback, TelemetryContext,
         TelemetryErrorCallback, TelemetryFocusCallback, TelemetryHooks,
@@ -329,53 +330,49 @@ impl CheckboxProps {
 }
 
 #[allow(dead_code)]
-fn build_descriptor(props: &CheckboxProps, state: &CheckboxState) -> ToggleControlDescriptor {
-    let descriptor = ToggleControlDescriptor::new(props.label.clone(), themed_checkbox_style())
-        .with_attributes(state.aria_attributes());
-    let descriptor = if let Some(analytics) = &props.telemetry.analytics_id {
-        descriptor.attribute("data-rustic-analytics-id", analytics.clone())
-    } else {
-        descriptor
-    };
-    if let Some(automation) = &props.telemetry.automation_id {
-        descriptor.attribute("data-automation-id", automation.clone())
-    } else {
-        descriptor
+fn build_descriptor(props: &CheckboxProps, state: &CheckboxState) -> SelectionControlAttributes {
+    let mut builder =
+        SelectionControlAttributes::builder(props.label.clone(), themed_checkbox_style());
+
+    let mut has_analytics = false;
+    let mut has_automation = false;
+
+    for (key, value) in state.aria_attributes() {
+        if key.starts_with("aria-") {
+            builder = builder.aria(key, value);
+        } else if key.starts_with("data-") {
+            if key == "data-rustic-analytics-id" {
+                has_analytics = true;
+            }
+            if key == "data-automation-id" {
+                has_automation = true;
+            }
+            builder = builder.data(key, value);
+        } else {
+            builder = builder.attribute(key, value);
+        }
     }
+
+    if !has_analytics {
+        if let Some(analytics) = &props.telemetry.analytics_id {
+            builder = builder.data("rustic-analytics-id", analytics.clone());
+        }
+    }
+
+    if !has_automation {
+        if let Some(automation) = &props.telemetry.automation_id {
+            builder = builder.automation_id("id", automation.clone());
+        }
+    }
+
+    builder.build()
 }
 
 #[allow(dead_code)]
 fn render_html(props: &CheckboxProps, state: &CheckboxState) -> String {
     let (context, descriptor, _snapshot) =
         descriptor_with_context("rustic_ui_material::checkbox::render_html", props, state);
-    instrument_render(&props.telemetry, context, || {
-        selection_control::render_toggle_html(&descriptor)
-    })
-}
-
-fn merge_descriptor_telemetry(
-    mut descriptor: ToggleControlDescriptor,
-    telemetry: &TelemetryHooks,
-) -> ToggleControlDescriptor {
-    let has_analytics = descriptor
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-rustic-analytics-id");
-    if !has_analytics {
-        if let Some(analytics) = &telemetry.analytics_id {
-            descriptor = descriptor.attribute("data-rustic-analytics-id", analytics.clone());
-        }
-    }
-
-    let has_automation = descriptor
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-automation-id");
-    if !has_automation {
-        if let Some(automation) = &telemetry.automation_id {
-            descriptor = descriptor.attribute("data-automation-id", automation.clone());
-        }
-    }
-
-    descriptor
+    instrument_render(&props.telemetry, context, || descriptor.to_ssr_html())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -393,7 +390,7 @@ struct CheckboxDescriptorSnapshot {
 }
 
 impl CheckboxDescriptorSnapshot {
-    fn from_descriptor(descriptor: &ToggleControlDescriptor) -> Self {
+    fn from_descriptor(descriptor: &SelectionControlAttributes) -> Self {
         let themed_attributes = descriptor.themed_attributes();
         let mut class = String::new();
         let mut role = String::from("checkbox");
@@ -439,10 +436,10 @@ fn descriptor_with_context(
     state: &CheckboxState,
 ) -> (
     TelemetryContext,
-    ToggleControlDescriptor,
+    SelectionControlAttributes,
     CheckboxDescriptorSnapshot,
 ) {
-    let descriptor = merge_descriptor_telemetry(build_descriptor(props, state), &props.telemetry);
+    let descriptor = build_descriptor(props, state);
     let snapshot = CheckboxDescriptorSnapshot::from_descriptor(&descriptor);
     let context = TelemetryContext::new(component)
         .with_analytics(props.telemetry.analytics_id.clone())
@@ -1356,7 +1353,7 @@ pub mod yew {
     ///   ensuring render panics propagate structured
     ///   [`crate::telemetry::TelemetryError`] events.
     /// * Descriptor telemetry defaults are merged prior to calling
-    ///   [`ToggleControlDescriptor::themed_attributes`], keeping SSR/CSR output
+    ///   [`SelectionControlAttributes::themed_attributes`], keeping SSR/CSR output
     ///   aligned even when consumers omit explicit identifiers.
     /// * Event handlers route structured [`CheckboxTelemetryEvent`] payloads to
     ///   the optional telemetry delegate **before** invoking user callbacks so
@@ -1990,8 +1987,8 @@ pub mod dioxus {
     #[cfg(all(test, feature = "dioxus"))]
     mod tests {
         use super::*;
-        use crate::selection_control::CheckboxValue;
         use keyboard_types::{ControlKey, Key};
+        use rustic_ui_headless::checkbox::CheckboxValue;
 
         struct Harness {
             state: Rc<RefCell<CheckboxState>>,
@@ -2451,10 +2448,7 @@ mod tests {
         props.telemetry.automation_id = Some("automation-42".into());
 
         let descriptor = build_descriptor(&props, &state);
-        let data_attrs: Vec<_> = descriptor
-            .data_state_attributes()
-            .map(|(key, value)| (key.to_string(), value.to_string()))
-            .collect();
+        let data_attrs = descriptor.data_state_attributes();
 
         assert!(data_attrs
             .iter()

--- a/crates/rustic-ui-material/src/lib.rs
+++ b/crates/rustic-ui-material/src/lib.rs
@@ -66,7 +66,7 @@ pub mod paper;
 pub mod radio;
 mod render_helpers;
 pub mod select;
-mod selection_control;
+pub mod selection_control;
 #[cfg(feature = "progress")]
 pub mod skeleton;
 #[cfg(feature = "forms")]

--- a/crates/rustic-ui-material/src/radio.rs
+++ b/crates/rustic-ui-material/src/radio.rs
@@ -1,13 +1,13 @@
 //! Material radio group built atop the headless [`RadioGroupState`] and the
 //! descriptor system that unifies SSR and hydration across frameworks.
 //!
-//! [`RadioGroupDescriptor`](crate::selection_control::RadioGroupDescriptor) and
-//! [`RadioOptionDescriptor`](crate::selection_control::RadioOptionDescriptor)
+//! [`RadioGroupAttributes`](crate::selection_control::RadioGroupAttributes) and
+//! [`RadioOptionAttributes`](crate::selection_control::RadioOptionAttributes)
 //! capture ARIA, automation, and theming metadata once so both server renderers
 //! and client adapters consume the same snapshot:
 //!
-//! * [`render_radio_group_html`](crate::selection_control::render_radio_group_html)
-//!   serializes HTML for SSR, static hosting, or streaming pipelines while reusing
+//! * [`RadioGroupAttributes::to_ssr_html`] serializes HTML for SSR, static
+//!   hosting, or streaming pipelines while reusing
 //!   the descriptor’s hydration-safe attributes.
 //! * Framework adapters for React, Yew, Leptos, Dioxus, and Sycamore hydrate by
 //!   reading the descriptor’s themed attribute vectors, ensuring automation
@@ -51,7 +51,7 @@
 //! use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
 //! use rustic_ui_material::radio::RadioGroupProps;
 //! use rustic_ui_material::selection_control::{
-//!     render_radio_group_html, RadioGroupDescriptor, RadioOptionDescriptor,
+//!     RadioGroupAttributes, RadioOptionAttributes,
 //! };
 //! use rustic_ui_material::telemetry::TelemetryHooks;
 //! use rustic_ui_styled_engine::{css, Style};
@@ -72,19 +72,22 @@
 //!         .expect("style to compile");
 //!     let option_style = Style::new(css!("padding: 0.25rem 0.5rem;"))
 //!         .expect("style to compile");
-//!     let descriptor = RadioGroupDescriptor::new(group_style.clone())
-//!         .with_group_attributes(state.group_aria_attributes())
+//!     let descriptor = RadioGroupAttributes::builder(group_style.clone())
+//!         .aria("role", "radiogroup")
 //!         .option(
-//!             RadioOptionDescriptor::new("Email", option_style.clone())
-//!                 .with_attributes(state.option_aria_attributes(0)),
+//!             RadioOptionAttributes::builder("Email", option_style.clone())
+//!                 .aria("role", "radio")
+//!                 .build(),
 //!         )
 //!         .option(
-//!             RadioOptionDescriptor::new("SMS", option_style.clone())
-//!                 .with_attributes(state.option_aria_attributes(1)),
-//!         );
+//!             RadioOptionAttributes::builder("SMS", option_style.clone())
+//!                 .aria("role", "radio")
+//!                 .build(),
+//!         )
+//!         .build();
 //!
 //!     // SSR produces deterministic markup using the descriptor metadata.
-//!     let ssr_html = render_radio_group_html(&descriptor);
+//!     let ssr_html = descriptor.to_ssr_html();
 //!     assert!(ssr_html.contains("role=\"radiogroup\""));
 //!
 //!     // Hydration merges telemetry hooks so analytics fire before user
@@ -127,7 +130,7 @@ use rustic_ui_headless::{
 use rustic_ui_styled_engine::{css_with_theme, Style};
 
 use crate::{
-    selection_control::{self, RadioGroupDescriptor, RadioOptionDescriptor},
+    selection_control::{RadioGroupAttributes, RadioOptionAttributes},
     telemetry::{
         instrument_render, TelemetryAnalyticsCallback, TelemetryCommitCallback, TelemetryContext,
         TelemetryErrorCallback, TelemetryFocusCallback, TelemetryHooks,
@@ -443,7 +446,7 @@ fn build_descriptor(
     props: &RadioGroupProps,
     telemetry: &TelemetryHooks,
     state: &RadioGroupState,
-) -> RadioGroupDescriptor {
+) -> RadioGroupAttributes {
     let orientation_value = match state.orientation() {
         RadioOrientation::Horizontal => "horizontal",
         RadioOrientation::Vertical => "vertical",
@@ -455,86 +458,116 @@ fn build_descriptor(
         props.option_labels.clone()
     };
 
-    let mut descriptor = RadioGroupDescriptor::new(themed_radio_group_style())
-        .with_group_attributes(state.group_aria_attributes())
-        .group_attribute("data-orientation", orientation_value);
+    let mut builder = RadioGroupAttributes::builder(themed_radio_group_style());
+    let mut has_group_analytics = false;
+    let mut has_group_automation = false;
 
-    for (key, value) in &props.additional_group_attributes {
-        descriptor = descriptor.group_attribute(key.clone(), value.clone());
+    for (key, value) in state.group_aria_attributes() {
+        if key.starts_with("aria-") {
+            builder = builder.aria(key, value);
+        } else if key.starts_with("data-") {
+            if key == "data-rustic-analytics-id" {
+                has_group_analytics = true;
+            }
+            if key == "data-automation-id" {
+                has_group_automation = true;
+            }
+            builder = builder.data(key, value);
+        } else {
+            builder = builder.attribute(key, value);
+        }
     }
 
-    descriptor = apply_group_telemetry(descriptor, telemetry);
+    builder = builder.data("orientation", orientation_value);
+
+    for (key, value) in &props.additional_group_attributes {
+        if key.starts_with("aria-") {
+            builder = builder.aria(key.as_str(), value.clone());
+        } else if key.starts_with("data-") {
+            if key == "data-rustic-analytics-id" {
+                has_group_analytics = true;
+            }
+            if key == "data-automation-id" {
+                has_group_automation = true;
+            }
+            builder = builder.data(key.as_str(), value.clone());
+        } else {
+            builder = builder.attribute(key.clone(), value.clone());
+        }
+    }
+
+    if !has_group_analytics {
+        if let Some(analytics) = &telemetry.analytics_id {
+            builder = builder.data("rustic-analytics-id", analytics.clone());
+        }
+    }
+
+    if !has_group_automation {
+        if let Some(automation) = &telemetry.automation_id {
+            builder = builder.automation_id("id", automation.clone());
+        }
+    }
+
+    let mut builder = builder;
 
     for (index, option) in state.options().iter().enumerate() {
         let label = labels.get(index).cloned().unwrap_or_else(|| option.clone());
-        let option_descriptor = RadioOptionDescriptor::new(label, themed_radio_option_style())
-            .with_attributes(state.option_aria_attributes(index))
-            .attribute("data-index", index.to_string());
-        let option_descriptor = apply_option_telemetry(option_descriptor, telemetry);
-        let option_descriptor =
-            if let Some(additional) = props.additional_option_attributes.get(index) {
-                additional
-                    .iter()
-                    .fold(option_descriptor, |descriptor, (key, value)| {
-                        descriptor.attribute(key.clone(), value.clone())
-                    })
+        let mut option_builder = RadioOptionAttributes::builder(label, themed_radio_option_style());
+        let mut option_has_analytics = false;
+        let mut option_has_automation = false;
+
+        for (key, value) in state.option_aria_attributes(index) {
+            if key.starts_with("aria-") {
+                option_builder = option_builder.aria(key, value);
+            } else if key.starts_with("data-") {
+                if key == "data-rustic-analytics-id" {
+                    option_has_analytics = true;
+                }
+                if key == "data-automation-id" {
+                    option_has_automation = true;
+                }
+                option_builder = option_builder.data(key, value);
             } else {
-                option_descriptor
-            };
-        descriptor = descriptor.option(option_descriptor);
-    }
-
-    descriptor
-}
-
-fn apply_group_telemetry(
-    mut descriptor: RadioGroupDescriptor,
-    telemetry: &TelemetryHooks,
-) -> RadioGroupDescriptor {
-    let has_analytics = descriptor
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-rustic-analytics-id");
-    if !has_analytics {
-        if let Some(analytics) = &telemetry.analytics_id {
-            descriptor = descriptor.group_attribute("data-rustic-analytics-id", analytics.clone());
+                option_builder = option_builder.attribute(key, value);
+            }
         }
-    }
 
-    let has_automation = descriptor
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-automation-id");
-    if !has_automation {
-        if let Some(automation) = &telemetry.automation_id {
-            descriptor = descriptor.group_attribute("data-automation-id", automation.clone());
+        option_builder = option_builder.data("index", index.to_string());
+
+        if let Some(additional) = props.additional_option_attributes.get(index) {
+            for (key, value) in additional {
+                if key.starts_with("aria-") {
+                    option_builder = option_builder.aria(key.as_str(), value.clone());
+                } else if key.starts_with("data-") {
+                    if key == "data-rustic-analytics-id" {
+                        option_has_analytics = true;
+                    }
+                    if key == "data-automation-id" {
+                        option_has_automation = true;
+                    }
+                    option_builder = option_builder.data(key.as_str(), value.clone());
+                } else {
+                    option_builder = option_builder.attribute(key.clone(), value.clone());
+                }
+            }
         }
-    }
 
-    descriptor
-}
-
-fn apply_option_telemetry(
-    mut option: RadioOptionDescriptor,
-    telemetry: &TelemetryHooks,
-) -> RadioOptionDescriptor {
-    let has_analytics = option
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-rustic-analytics-id");
-    if !has_analytics {
-        if let Some(analytics) = &telemetry.analytics_id {
-            option = option.attribute("data-rustic-analytics-id", analytics.clone());
+        if !option_has_analytics {
+            if let Some(analytics) = &telemetry.analytics_id {
+                option_builder = option_builder.data("rustic-analytics-id", analytics.clone());
+            }
         }
-    }
 
-    let has_automation = option
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-automation-id");
-    if !has_automation {
-        if let Some(automation) = &telemetry.automation_id {
-            option = option.attribute("data-automation-id", automation.clone());
+        if !option_has_automation {
+            if let Some(automation) = &telemetry.automation_id {
+                option_builder = option_builder.automation_id("id", automation.clone());
+            }
         }
+
+        builder = builder.option(option_builder.build());
     }
 
-    option
+    builder.build()
 }
 
 #[allow(dead_code)]
@@ -546,9 +579,7 @@ fn render_html(props: &RadioGroupProps, state: &RadioGroupState) -> String {
         &telemetry,
         state,
     );
-    instrument_render(&telemetry, context, || {
-        selection_control::render_radio_group_html(&descriptor)
-    })
+    instrument_render(&telemetry, context, || descriptor.to_ssr_html())
 }
 
 fn merged_telemetry(primary: &TelemetryHooks, fallback: &TelemetryHooks) -> TelemetryHooks {
@@ -593,7 +624,7 @@ fn merged_telemetry(primary: &TelemetryHooks, fallback: &TelemetryHooks) -> Tele
 struct RadioOptionSnapshot {
     label: String,
     themed_attributes: Vec<(String, String)>,
-    /// Attribute pairs produced by [`RadioOptionDescriptor::themed_attributes`]
+    /// Attribute pairs produced by [`RadioOptionAttributes::themed_attributes`]
     /// that the snapshot does not recognise yet.
     ///
     /// We store these eagerly so framework adapters can forward future theme
@@ -616,7 +647,7 @@ struct RadioOptionSnapshot {
 }
 
 impl RadioOptionSnapshot {
-    fn from_descriptor(descriptor: &RadioOptionDescriptor) -> Self {
+    fn from_descriptor(descriptor: &RadioOptionAttributes) -> Self {
         let themed_attributes = descriptor.themed_attributes();
         let mut class = String::new();
         let mut role = String::from("radio");
@@ -668,7 +699,7 @@ impl RadioOptionSnapshot {
 struct RadioGroupDescriptorSnapshot {
     label: String,
     group_thematic_attributes: Vec<(String, String)>,
-    /// Attribute pairs emitted by [`RadioGroupDescriptor::group_thematic_attributes`]
+    /// Attribute pairs emitted by [`RadioGroupAttributes::themed_attributes`]
     /// that do not have a dedicated field in the snapshot yet.
     ///
     /// Preserving these values allows framework adapters to forward newly
@@ -689,8 +720,8 @@ struct RadioGroupDescriptorSnapshot {
 }
 
 impl RadioGroupDescriptorSnapshot {
-    fn from_descriptor(descriptor: &RadioGroupDescriptor) -> Self {
-        let group_thematic_attributes = descriptor.group_thematic_attributes();
+    fn from_descriptor(descriptor: &RadioGroupAttributes) -> Self {
+        let group_thematic_attributes = descriptor.themed_attributes();
         let mut class = String::new();
         let mut role = String::from("radiogroup");
         let mut aria_orientation = String::from("horizontal");
@@ -744,7 +775,7 @@ fn descriptor_with_context(
     state: &RadioGroupState,
 ) -> (
     TelemetryContext,
-    RadioGroupDescriptor,
+    RadioGroupAttributes,
     RadioGroupDescriptorSnapshot,
 ) {
     let descriptor = build_descriptor(props, telemetry, state);
@@ -5426,7 +5457,7 @@ pub mod sycamore {
                         // Convert the descriptor snapshot into a Sycamore spread so any
                         // new keys added by the theming pipeline flow directly into the
                         // rendered span without editing this adapter again.  Future
-                        // contributors should extend `RadioOptionDescriptor` rather than
+                        // contributors should extend `RadioOptionAttributes` rather than
                         // binding individual attributes here.
                         let option_attributes = sycamore_attributes_from_pairs(&themed_attributes);
 

--- a/crates/rustic-ui-material/src/selection_control.rs
+++ b/crates/rustic-ui-material/src/selection_control.rs
@@ -1,464 +1,738 @@
-//! Shared rendering helpers for Material selection controls.
+//! Strongly typed builders for Material selection control rendering.
 //!
-//! The helpers now surface structured descriptors so adapters can decide whether
-//! to emit HTML strings (SSR) or hydrate individual frameworks with attribute
-//! maps.  Centralizing the metadata keeps the individual component modules
-//! focused on data flow rather than DOM string assembly while making it trivial
-//! to serialize the same descriptor in multiple environments.
+//! These builders replace ad-hoc HTML helpers with enterprise-friendly
+//! descriptors that separate visual classes, ARIA metadata, automation signals
+//! and analytics hints.  Builders can be converted into attribute maps for
+//! hydration or serialized into deterministic HTML for SSR.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, OnceLock};
 
 use rustic_ui_styled_engine::Style;
 use rustic_ui_utils::attributes_to_html;
 
 use crate::style_helpers;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AttributeKind {
-    Aria,
-    DataState,
-    Standard,
+/// Global hook signature used to customize selection control builders.
+pub type SelectionControlHook =
+    dyn Fn(&mut SelectionControlAttributesBuilder) + Send + Sync + 'static;
+
+/// Global hook signature used to customize radio option builders.
+pub type RadioOptionHook = dyn Fn(&mut RadioOptionAttributesBuilder) + Send + Sync + 'static;
+
+/// Global hook signature used to customize radio group builders.
+pub type RadioGroupHook = dyn Fn(&mut RadioGroupAttributesBuilder) + Send + Sync + 'static;
+
+static SELECTION_CONTROL_HOOK: OnceLock<Arc<SelectionControlHook>> = OnceLock::new();
+static RADIO_OPTION_HOOK: OnceLock<Arc<RadioOptionHook>> = OnceLock::new();
+static RADIO_GROUP_HOOK: OnceLock<Arc<RadioGroupHook>> = OnceLock::new();
+
+/// Registers a global selection control hook that runs before finalizing any
+/// [`SelectionControlAttributes`].
+///
+/// This enables centralized analytics/theming providers to inject classes or
+/// automation IDs without every adapter repeating that wiring.  The hook is
+/// stored in a [`OnceLock`], so the first registration wins and subsequent
+/// attempts will return an error to avoid unpredictable overrides in multi-tenant
+/// environments.
+#[allow(clippy::missing_panics_doc)]
+pub fn register_selection_control_hook<F>(hook: F) -> Result<(), &'static str>
+where
+    F: Fn(&mut SelectionControlAttributesBuilder) + Send + Sync + 'static,
+{
+    SELECTION_CONTROL_HOOK
+        .set(Arc::new(hook))
+        .map_err(|_| "selection control hook already registered")
 }
 
+/// Registers a global radio option hook.  See [`register_selection_control_hook`]
+/// for details on lifecycle guarantees.
+pub fn register_radio_option_hook<F>(hook: F) -> Result<(), &'static str>
+where
+    F: Fn(&mut RadioOptionAttributesBuilder) + Send + Sync + 'static,
+{
+    RADIO_OPTION_HOOK
+        .set(Arc::new(hook))
+        .map_err(|_| "radio option hook already registered")
+}
+
+/// Registers a global radio group hook.  See [`register_selection_control_hook`]
+/// for details on lifecycle guarantees.
+pub fn register_radio_group_hook<F>(hook: F) -> Result<(), &'static str>
+where
+    F: Fn(&mut RadioGroupAttributesBuilder) + Send + Sync + 'static,
+{
+    RADIO_GROUP_HOOK
+        .set(Arc::new(hook))
+        .map_err(|_| "radio group hook already registered")
+}
+
+/// Data object describing a Material selection control (checkbox/switch).
+///
+/// The struct is intentionally verbose to provide predictable extension points
+/// for enterprise telemetry teams.  Values are stored in deterministic
+/// [`BTreeMap`]s so that SSR output is stable across releases.
 #[derive(Debug, Clone)]
-struct AttributeEntry {
-    key: String,
-    value: String,
-    kind: AttributeKind,
+pub struct SelectionControlAttributes {
+    label: String,
+    style: Style,
+    classes: Vec<String>,
+    aria: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+    automation_ids: BTreeMap<String, String>,
+    attributes: BTreeMap<String, String>,
 }
 
-impl AttributeEntry {
-    fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+impl SelectionControlAttributes {
+    /// Starts a new builder for a selection control descriptor.
+    pub fn builder(label: impl Into<String>, style: Style) -> SelectionControlAttributesBuilder {
+        SelectionControlAttributesBuilder::new(label, style)
+    }
+
+    /// Returns the label intended for end users and analytics payloads.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Returns a clone of the Material style handle so adapters can preload CSS.
+    pub fn style(&self) -> Style {
+        self.style.clone()
+    }
+
+    /// Returns all CSS classes that should be applied to the control root.
+    pub fn classes(&self) -> &[String] {
+        &self.classes
+    }
+
+    /// Returns ARIA attributes for accessibility testing and hydration as an
+    /// iterator compatible with the legacy descriptor API.
+    pub fn aria_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.aria
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+    }
+
+    /// Direct access to the internal ARIA map for adapters that require owned
+    /// metadata.
+    pub fn aria_map(&self) -> &BTreeMap<String, String> {
+        &self.aria
+    }
+
+    /// Returns `data-*` attributes used for analytics and focus management as an
+    /// iterator. Automation identifiers are surfaced as `data-automation-*`
+    /// entries so existing instrumentation keeps working.
+    pub fn data_state_attributes(&self) -> Vec<(String, String)> {
+        let mut attrs: Vec<(String, String)> = self
+            .data
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        attrs.extend(
+            self.automation_ids
+                .iter()
+                .map(|(key, value)| (format!("data-automation-{key}"), value.clone())),
+        );
+        attrs
+    }
+
+    /// Direct access to the structured data attribute map.
+    pub fn data_map(&self) -> &BTreeMap<String, String> {
+        &self.data
+    }
+
+    /// Returns automation identifiers (exposed as `data-automation-*`).
+    pub fn automation_ids(&self) -> &BTreeMap<String, String> {
+        &self.automation_ids
+    }
+
+    /// Returns additional non-ARIA attributes (e.g. `role`, `tabindex`) as an
+    /// iterator for backwards compatibility.
+    pub fn standard_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+    }
+
+    /// Direct access to the passthrough attribute map.
+    pub fn extra_attributes(&self) -> &BTreeMap<String, String> {
+        &self.attributes
+    }
+
+    fn base_attribute_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        if !self.classes.is_empty() {
+            pairs.push(("class".into(), self.classes.join(" ")));
+        }
+        pairs.extend(self.attributes.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(self.aria.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(self.data.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(
+            self.automation_ids
+                .iter()
+                .map(|(k, v)| (format!("data-automation-{k}"), v.clone())),
+        );
+        pairs
+    }
+
+    /// Returns the themed attribute pairs ready for framework hydration.
+    pub fn themed_attributes(&self) -> Vec<(String, String)> {
+        style_helpers::themed_attributes(self.style.clone(), self.base_attribute_pairs())
+    }
+
+    /// Serializes the control into a `<span>` suitable for SSR pipelines.
+    pub fn to_ssr_html(&self) -> String {
+        let attrs = self.themed_attributes();
+        format!(
+            "<span {attrs}>{label}</span>",
+            attrs = attributes_to_html(&attrs),
+            label = self.label()
+        )
+    }
+}
+
+/// Builder backing [`SelectionControlAttributes`].
+#[derive(Debug, Clone)]
+pub struct SelectionControlAttributesBuilder {
+    label: String,
+    style: Style,
+    classes: Vec<String>,
+    aria: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+    automation_ids: BTreeMap<String, String>,
+    attributes: BTreeMap<String, String>,
+}
+
+impl SelectionControlAttributesBuilder {
+    fn new(label: impl Into<String>, style: Style) -> Self {
+        Self {
+            label: label.into(),
+            style,
+            classes: Vec::new(),
+            aria: BTreeMap::new(),
+            data: BTreeMap::new(),
+            automation_ids: BTreeMap::new(),
+            attributes: BTreeMap::new(),
+        }
+    }
+
+    /// Applies a CSS class to the control.  Classes are deduplicated during build.
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.classes.push(class.into());
+        self
+    }
+
+    /// Applies multiple classes at once.
+    pub fn classes<I, S>(mut self, classes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.classes.extend(classes.into_iter().map(Into::into));
+        self
+    }
+
+    /// Records an ARIA attribute.
+    pub fn aria(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.aria.insert(key.into(), value.into());
+        self
+    }
+
+    /// Records a `data-*` attribute.  The caller may omit the `data-` prefix to
+    /// reduce boilerplate.
+    pub fn data(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let key = key.into();
-        let kind = if key.starts_with("aria-") || key == "role" || key == "tabindex" {
-            AttributeKind::Aria
-        } else if key.starts_with("data-") {
-            AttributeKind::DataState
+        let normalized = if key.starts_with("data-") {
+            key
         } else {
-            AttributeKind::Standard
+            format!("data-{key}")
         };
-        Self {
-            key,
-            value: value.into(),
-            kind,
+        self.data.insert(normalized, value.into());
+        self
+    }
+
+    /// Records an automation identifier surfaced as `data-automation-{key}`.
+    pub fn automation_id(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.automation_ids.insert(key.into(), value.into());
+        self
+    }
+
+    /// Adds any additional attribute that does not fit the categories above.
+    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    fn apply_global_hook(&mut self) {
+        if let Some(hook) = SELECTION_CONTROL_HOOK.get() {
+            hook(self);
+        }
+    }
+
+    /// Finalizes the builder and returns an immutable descriptor.
+    pub fn build(mut self) -> SelectionControlAttributes {
+        self.apply_global_hook();
+        self.classes.sort();
+        self.classes.dedup();
+        SelectionControlAttributes {
+            label: self.label,
+            style: self.style,
+            classes: self.classes,
+            aria: self.aria,
+            data: self.data,
+            automation_ids: self.automation_ids,
+            attributes: self.attributes,
         }
     }
 }
 
-/// Describes a labelled toggle-style control such as a checkbox or switch.
-///
-/// The descriptor acts as a fluent builder that records ARIA attributes,
-/// automation-focused `data-*` flags, and additional DOM metadata without
-/// stringifying. Framework adapters can request the themed attribute pairs when
-/// hydrating a client render, while SSR pipelines can convert the same
-/// descriptor to HTML using [`render_toggle_html`].
-///
-/// # SSR and hydration flow
-///
-/// 1. Headless state machines expose attribute tuples describing ARIA metadata
-///    and stateful `data-*` flags.
-/// 2. Callers feed those tuples into [`ToggleControlDescriptor::with_attributes`]
-///    which records the metadata and allows inspection without conversion.
-/// 3. Framework adapters call [`ToggleControlDescriptor::themed_attributes`] to
-///    receive a merged `(String, String)` vector suitable for frameworks like
-///    Yew, Leptos, Sycamore or React (through the WASM bridge).
-/// 4. Server renderers invoke [`render_toggle_html`] which serializes the same
-///    descriptor via [`style_helpers::themed_attributes`] and
-///    [`attributes_to_html`].
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// use rustic_ui_material::selection_control::{
-///     render_toggle_html, ToggleControlDescriptor,
-/// };
-/// use rustic_ui_styled_engine::Style;
-///
-/// let style = Style::new(rustic_ui_styled_engine::css!("color: red;"))
-///     .expect("valid style");
-/// let descriptor = ToggleControlDescriptor::new("Notifications", style.clone())
-///     .with_attributes([
-///         ("role", "switch"),
-///         ("aria-checked", "true"),
-///         ("data-on", "true"),
-///     ]);
-///
-/// // Framework adapter hydration:
-/// let themed_pairs = descriptor.themed_attributes();
-/// assert!(themed_pairs.iter().any(|(k, _)| k == "class"));
-///
-/// // SSR pipeline:
-/// let html = render_toggle_html(&descriptor);
-/// assert!(html.contains("aria-checked"));
-/// ```
+/// Data object describing a single radio option.
 #[derive(Debug, Clone)]
-pub struct ToggleControlDescriptor {
+pub struct RadioOptionAttributes {
     label: String,
     style: Style,
-    attributes: Vec<AttributeEntry>,
+    classes: Vec<String>,
+    aria: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+    automation_ids: BTreeMap<String, String>,
+    attributes: BTreeMap<String, String>,
 }
 
-#[allow(dead_code)]
-impl ToggleControlDescriptor {
-    /// Create a new descriptor for a toggle-like control.
-    pub fn new(label: impl Into<String>, style: Style) -> Self {
-        Self {
-            label: label.into(),
-            style,
-            attributes: Vec::new(),
-        }
+impl RadioOptionAttributes {
+    /// Starts a new builder for a radio option descriptor.
+    pub fn builder(label: impl Into<String>, style: Style) -> RadioOptionAttributesBuilder {
+        RadioOptionAttributesBuilder::new(label, style)
     }
 
-    /// Returns the visible label associated with the control.
+    /// The label rendered next to the radio option.
     pub fn label(&self) -> &str {
         &self.label
     }
 
-    /// Returns a clone of the themed style handle so adapters can pre-register
-    /// CSS with their runtime.
+    /// Style handle used for preloading.
     pub fn style(&self) -> Style {
         self.style.clone()
     }
 
-    /// Iterate over ARIA attributes recorded on the descriptor.
+    /// List of classes applied to the option container.
+    pub fn classes(&self) -> &[String] {
+        &self.classes
+    }
+
+    /// Iterator over ARIA attributes retained for the option.
     pub fn aria_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.attributes
+        self.aria
             .iter()
-            .filter(|attr| attr.kind == AttributeKind::Aria)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+            .map(|(key, value)| (key.as_str(), value.as_str()))
     }
 
-    /// Iterate over `data-*` attributes tracked by the descriptor.
-    pub fn data_state_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.attributes
+    /// Owned view of data attributes, including automation identifiers.
+    pub fn data_state_attributes(&self) -> Vec<(String, String)> {
+        let mut attrs: Vec<(String, String)> = self
+            .data
             .iter()
-            .filter(|attr| attr.kind == AttributeKind::DataState)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        attrs.extend(
+            self.automation_ids
+                .iter()
+                .map(|(key, value)| (format!("data-automation-{key}"), value.clone())),
+        );
+        attrs
     }
 
-    /// Iterate over non-ARIA, non-`data-*` attributes.
+    /// Iterator over non-ARIA passthrough attributes.
     pub fn standard_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
         self.attributes
             .iter()
-            .filter(|attr| attr.kind == AttributeKind::Standard)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+            .map(|(key, value)| (key.as_str(), value.as_str()))
     }
 
-    /// Append raw attributes emitted by the headless state machine.
-    pub fn with_attributes<I, K, V>(mut self, attributes: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        for (key, value) in attributes {
-            self.attributes.push(AttributeEntry::new(key, value));
+    /// Automation identifiers as a map for enterprise QA harnesses.
+    pub fn automation_ids(&self) -> &BTreeMap<String, String> {
+        &self.automation_ids
+    }
+
+    fn base_attribute_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        if !self.classes.is_empty() {
+            pairs.push(("class".into(), self.classes.join(" ")));
         }
-        self
+        pairs.extend(self.attributes.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(self.aria.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(self.data.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(
+            self.automation_ids
+                .iter()
+                .map(|(k, v)| (format!("data-automation-{k}"), v.clone())),
+        );
+        pairs
     }
 
-    /// Add a single attribute to the descriptor.
-    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.attributes.push(AttributeEntry::new(key, value));
-        self
-    }
-
-    /// Return the merged themed attributes ready for framework hydration.
+    /// Returns the themed attribute pairs for the option container.
     pub fn themed_attributes(&self) -> Vec<(String, String)> {
-        style_helpers::themed_attributes(self.style.clone(), self.raw_attributes())
+        style_helpers::themed_attributes(self.style.clone(), self.base_attribute_pairs())
     }
 
-    fn raw_attributes(&self) -> Vec<(String, String)> {
-        let mut standard = Vec::new();
-        let mut aria = Vec::new();
-        let mut data = Vec::new();
-
-        for attr in &self.attributes {
-            let pair = (attr.key.clone(), attr.value.clone());
-            match attr.kind {
-                AttributeKind::Standard => standard.push(pair),
-                AttributeKind::Aria => aria.push(pair),
-                AttributeKind::DataState => data.push(pair),
-            }
-        }
-
-        standard.extend(aria);
-        standard.extend(data);
-        standard
+    /// Serializes the option to `<span>` markup for SSR.
+    pub fn to_ssr_html(&self) -> String {
+        let attrs = self.themed_attributes();
+        format!(
+            "<span {attrs}>{label}</span>",
+            attrs = attributes_to_html(&attrs),
+            label = self.label()
+        )
     }
 }
 
-/// Describes an individual option within a radio group.
-///
-/// The descriptor mirrors [`ToggleControlDescriptor`] but focuses on options
-/// that share a group container.  Each option tracks its own theme handle,
-/// attribute metadata and label so adapters can compose option-level DOM nodes
-/// independently of the surrounding group.
+/// Builder for [`RadioOptionAttributes`].
 #[derive(Debug, Clone)]
-pub struct RadioOptionDescriptor {
+pub struct RadioOptionAttributesBuilder {
     label: String,
     style: Style,
-    attributes: Vec<AttributeEntry>,
+    classes: Vec<String>,
+    aria: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+    automation_ids: BTreeMap<String, String>,
+    attributes: BTreeMap<String, String>,
 }
 
-#[allow(dead_code)]
-impl RadioOptionDescriptor {
-    /// Create a new option descriptor.
-    pub fn new(label: impl Into<String>, style: Style) -> Self {
+impl RadioOptionAttributesBuilder {
+    fn new(label: impl Into<String>, style: Style) -> Self {
         Self {
             label: label.into(),
             style,
-            attributes: Vec::new(),
+            classes: Vec::new(),
+            aria: BTreeMap::new(),
+            data: BTreeMap::new(),
+            automation_ids: BTreeMap::new(),
+            attributes: BTreeMap::new(),
         }
     }
 
-    /// Returns the option label displayed to end users.
-    pub fn label(&self) -> &str {
-        &self.label
+    /// Applies a CSS class.
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.classes.push(class.into());
+        self
     }
 
-    /// Returns a clone of the themed style handle for the option container.
+    /// Applies multiple classes.
+    pub fn classes<I, S>(mut self, classes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.classes.extend(classes.into_iter().map(Into::into));
+        self
+    }
+
+    /// Adds an ARIA attribute.
+    pub fn aria(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.aria.insert(key.into(), value.into());
+        self
+    }
+
+    /// Adds a `data-*` attribute, prefixing if necessary.
+    pub fn data(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = key.into();
+        let normalized = if key.starts_with("data-") {
+            key
+        } else {
+            format!("data-{key}")
+        };
+        self.data.insert(normalized, value.into());
+        self
+    }
+
+    /// Adds an automation identifier.
+    pub fn automation_id(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.automation_ids.insert(key.into(), value.into());
+        self
+    }
+
+    /// Adds a passthrough attribute.
+    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    fn apply_global_hook(&mut self) {
+        if let Some(hook) = RADIO_OPTION_HOOK.get() {
+            hook(self);
+        }
+    }
+
+    /// Finalizes the descriptor.
+    pub fn build(mut self) -> RadioOptionAttributes {
+        self.apply_global_hook();
+        self.classes.sort();
+        self.classes.dedup();
+        RadioOptionAttributes {
+            label: self.label,
+            style: self.style,
+            classes: self.classes,
+            aria: self.aria,
+            data: self.data,
+            automation_ids: self.automation_ids,
+            attributes: self.attributes,
+        }
+    }
+}
+
+/// Data object describing a radio group container and its options.
+#[derive(Debug, Clone)]
+pub struct RadioGroupAttributes {
+    style: Style,
+    classes: Vec<String>,
+    aria: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+    automation_ids: BTreeMap<String, String>,
+    attributes: BTreeMap<String, String>,
+    options: Vec<RadioOptionAttributes>,
+}
+
+impl RadioGroupAttributes {
+    /// Starts a new builder for a radio group descriptor.
+    pub fn builder(style: Style) -> RadioGroupAttributesBuilder {
+        RadioGroupAttributesBuilder::new(style)
+    }
+
+    /// Returns all option descriptors, preserving the insertion order.
+    pub fn options(&self) -> &[RadioOptionAttributes] {
+        &self.options
+    }
+
+    /// Returns the style handle for the group container.
     pub fn style(&self) -> Style {
         self.style.clone()
     }
 
-    /// Iterate over ARIA metadata for the option.
+    /// Iterator over ARIA attributes retained for the group container.
     pub fn aria_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.attributes
+        self.aria
             .iter()
-            .filter(|attr| attr.kind == AttributeKind::Aria)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+            .map(|(key, value)| (key.as_str(), value.as_str()))
     }
 
-    /// Iterate over `data-*` flags exposed for analytics and focus management.
-    pub fn data_state_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.attributes
+    /// Owned data attributes, including automation identifiers.
+    pub fn data_state_attributes(&self) -> Vec<(String, String)> {
+        let mut attrs: Vec<(String, String)> = self
+            .data
             .iter()
-            .filter(|attr| attr.kind == AttributeKind::DataState)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        attrs.extend(
+            self.automation_ids
+                .iter()
+                .map(|(key, value)| (format!("data-automation-{key}"), value.clone())),
+        );
+        attrs
     }
 
-    /// Iterate over non-ARIA attributes.
+    /// Iterator over passthrough attributes such as `role` or `tabindex`.
     pub fn standard_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
         self.attributes
             .iter()
-            .filter(|attr| attr.kind == AttributeKind::Standard)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
+            .map(|(key, value)| (key.as_str(), value.as_str()))
     }
 
-    /// Append attributes retrieved from the radio state machine.
-    pub fn with_attributes<I, K, V>(mut self, attributes: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        for (key, value) in attributes {
-            self.attributes.push(AttributeEntry::new(key, value));
+    /// Automation identifiers stored for QA harnesses.
+    pub fn automation_ids(&self) -> &BTreeMap<String, String> {
+        &self.automation_ids
+    }
+
+    fn base_attribute_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        if !self.classes.is_empty() {
+            pairs.push(("class".into(), self.classes.join(" ")));
         }
-        self
+        pairs.extend(self.attributes.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(self.aria.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(self.data.iter().map(|(k, v)| (k.clone(), v.clone())));
+        pairs.extend(
+            self.automation_ids
+                .iter()
+                .map(|(k, v)| (format!("data-automation-{k}"), v.clone())),
+        );
+        pairs
     }
 
-    /// Add a single attribute to the descriptor.
-    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.attributes.push(AttributeEntry::new(key, value));
-        self
-    }
-
-    /// Return the themed attribute pairs for hydration.
+    /// Returns themed attributes for the radio group container.
     pub fn themed_attributes(&self) -> Vec<(String, String)> {
-        style_helpers::themed_attributes(self.style.clone(), self.raw_attributes())
+        style_helpers::themed_attributes(self.style.clone(), self.base_attribute_pairs())
     }
 
-    fn raw_attributes(&self) -> Vec<(String, String)> {
-        let mut standard = Vec::new();
-        let mut aria = Vec::new();
-        let mut data = Vec::new();
-
-        for attr in &self.attributes {
-            let pair = (attr.key.clone(), attr.value.clone());
-            match attr.kind {
-                AttributeKind::Standard => standard.push(pair),
-                AttributeKind::Aria => aria.push(pair),
-                AttributeKind::DataState => data.push(pair),
-            }
+    /// Serializes the entire group to `<div>` markup for SSR.
+    pub fn to_ssr_html(&self) -> String {
+        let group_attrs = self.themed_attributes();
+        let mut options_html = String::new();
+        for option in &self.options {
+            options_html.push_str(&option.to_ssr_html());
         }
-
-        standard.extend(aria);
-        standard.extend(data);
-        standard
+        format!(
+            "<div {attrs}>{options}</div>",
+            attrs = attributes_to_html(&group_attrs),
+            options = options_html
+        )
     }
 }
 
-/// Describes the container and options for a radio group.
-///
-/// The descriptor is intentionally exhaustive, allowing SSR callers to generate
-/// HTML via [`render_radio_group_html`] while giving client renderers direct
-/// access to the themed attribute sets.  Options are stored as
-/// [`RadioOptionDescriptor`] instances so adapters can lazily render only the
-/// portions of the group that changed during hydration.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// use rustic_ui_material::selection_control::{
-///     render_radio_group_html, RadioGroupDescriptor, RadioOptionDescriptor,
-/// };
-/// use rustic_ui_styled_engine::Style;
-///
-/// let group_style = Style::new(rustic_ui_styled_engine::css!("display: flex;"))
-///     .expect("valid style");
-/// let option_style = group_style.clone();
-/// let descriptor = RadioGroupDescriptor::new(group_style)
-///     .with_group_attributes([("role", "radiogroup")])
-///     .option(
-///         RadioOptionDescriptor::new("A", option_style.clone()).with_attributes([
-///             ("role", "radio"),
-///             ("aria-checked", "true"),
-///         ]),
-///     )
-///     .option(
-///         RadioOptionDescriptor::new("B", option_style).with_attributes([
-///             ("role", "radio"),
-///             ("aria-checked", "false"),
-///         ]),
-///     );
-///
-/// // Hydration fetches the attribute pairs lazily.
-/// let group_pairs = descriptor.group_thematic_attributes();
-/// assert!(group_pairs.iter().any(|(k, _)| k == "class"));
-///
-/// // SSR renders deterministic markup.
-/// let html = render_radio_group_html(&descriptor);
-/// assert!(html.contains("role=\"radiogroup\""));
-/// ```
+/// Builder for [`RadioGroupAttributes`].
 #[derive(Debug, Clone)]
-pub struct RadioGroupDescriptor {
+pub struct RadioGroupAttributesBuilder {
     style: Style,
-    attributes: Vec<AttributeEntry>,
-    options: Vec<RadioOptionDescriptor>,
+    classes: Vec<String>,
+    aria: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+    automation_ids: BTreeMap<String, String>,
+    attributes: BTreeMap<String, String>,
+    options: Vec<RadioOptionAttributes>,
 }
 
-#[allow(dead_code)]
-impl RadioGroupDescriptor {
-    /// Create a new descriptor for a radio group container.
-    pub fn new(style: Style) -> Self {
+impl RadioGroupAttributesBuilder {
+    fn new(style: Style) -> Self {
         Self {
             style,
-            attributes: Vec::new(),
+            classes: Vec::new(),
+            aria: BTreeMap::new(),
+            data: BTreeMap::new(),
+            automation_ids: BTreeMap::new(),
+            attributes: BTreeMap::new(),
             options: Vec::new(),
         }
     }
 
-    /// Append attributes emitted by the headless radio group state.
-    pub fn with_group_attributes<I, K, V>(mut self, attributes: I) -> Self
+    /// Applies a CSS class to the group container.
+    pub fn class(mut self, class: impl Into<String>) -> Self {
+        self.classes.push(class.into());
+        self
+    }
+
+    /// Applies multiple CSS classes to the group container.
+    pub fn classes<I, S>(mut self, classes: I) -> Self
     where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
     {
-        for (key, value) in attributes {
-            self.attributes.push(AttributeEntry::new(key, value));
-        }
+        self.classes.extend(classes.into_iter().map(Into::into));
         self
     }
 
-    /// Add an individual attribute to the group container.
-    pub fn group_attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.attributes.push(AttributeEntry::new(key, value));
+    /// Adds an ARIA attribute to the group container.
+    pub fn aria(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.aria.insert(key.into(), value.into());
         self
     }
 
-    /// Push a radio option descriptor into the group.
-    pub fn option(mut self, option: RadioOptionDescriptor) -> Self {
+    /// Adds a `data-*` attribute to the group container.
+    pub fn data(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = key.into();
+        let normalized = if key.starts_with("data-") {
+            key
+        } else {
+            format!("data-{key}")
+        };
+        self.data.insert(normalized, value.into());
+        self
+    }
+
+    /// Adds an automation identifier that will be surfaced as `data-automation-*`.
+    pub fn automation_id(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.automation_ids.insert(key.into(), value.into());
+        self
+    }
+
+    /// Adds a passthrough attribute such as `role` or `tabindex`.
+    pub fn attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    /// Appends an option descriptor that was previously built.
+    pub fn option(mut self, option: RadioOptionAttributes) -> Self {
         self.options.push(option);
         self
     }
 
-    /// Returns all option descriptors for further inspection.
-    pub fn options(&self) -> &[RadioOptionDescriptor] {
-        &self.options
-    }
-
-    /// Returns a clone of the group style for preloading CSS rules.
-    pub fn style(&self) -> Style {
-        self.style.clone()
-    }
-
-    /// Iterate over ARIA attributes attached to the group container.
-    pub fn aria_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.attributes
-            .iter()
-            .filter(|attr| attr.kind == AttributeKind::Aria)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
-    }
-
-    /// Iterate over container-level `data-*` flags.
-    pub fn data_state_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.attributes
-            .iter()
-            .filter(|attr| attr.kind == AttributeKind::DataState)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
-    }
-
-    /// Iterate over standard container attributes.
-    pub fn standard_attributes(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.attributes
-            .iter()
-            .filter(|attr| attr.kind == AttributeKind::Standard)
-            .map(|attr| (attr.key.as_str(), attr.value.as_str()))
-    }
-
-    /// Returns the themed attribute pairs for the group container.
-    pub fn group_thematic_attributes(&self) -> Vec<(String, String)> {
-        style_helpers::themed_attributes(self.style.clone(), self.raw_attributes())
-    }
-
-    fn raw_attributes(&self) -> Vec<(String, String)> {
-        let mut standard = Vec::new();
-        let mut aria = Vec::new();
-        let mut data = Vec::new();
-
-        for attr in &self.attributes {
-            let pair = (attr.key.clone(), attr.value.clone());
-            match attr.kind {
-                AttributeKind::Standard => standard.push(pair),
-                AttributeKind::Aria => aria.push(pair),
-                AttributeKind::DataState => data.push(pair),
-            }
+    fn apply_global_hook(&mut self) {
+        if let Some(hook) = RADIO_GROUP_HOOK.get() {
+            hook(self);
         }
+    }
 
-        standard.extend(aria);
-        standard.extend(data);
-        standard
+    /// Finalizes the descriptor.
+    pub fn build(mut self) -> RadioGroupAttributes {
+        self.apply_global_hook();
+        self.classes.sort();
+        self.classes.dedup();
+        RadioGroupAttributes {
+            style: self.style,
+            classes: self.classes,
+            aria: self.aria,
+            data: self.data,
+            automation_ids: self.automation_ids,
+            attributes: self.attributes,
+            options: self.options,
+        }
     }
 }
 
-/// Serialize a toggle descriptor into HTML for SSR environments.
-#[must_use]
-pub(crate) fn render_toggle_html(descriptor: &ToggleControlDescriptor) -> String {
-    let attrs = descriptor.themed_attributes();
-    format!(
-        "<span {attrs}>{label}</span>",
-        attrs = attributes_to_html(&attrs),
-        label = descriptor.label()
-    )
+impl fmt::Display for SelectionControlAttributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_ssr_html())
+    }
 }
 
-/// Serialize a radio group descriptor into HTML for SSR environments.
-#[must_use]
-pub(crate) fn render_radio_group_html(descriptor: &RadioGroupDescriptor) -> String {
-    let group_attrs = descriptor.group_thematic_attributes();
-    let mut options_html = String::new();
-    for option in descriptor.options() {
-        let attrs = option.themed_attributes();
-        options_html.push_str(&format!(
-            "<span {attrs}>{label}</span>",
-            attrs = attributes_to_html(&attrs),
-            label = option.label()
-        ));
+impl fmt::Display for RadioOptionAttributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_ssr_html())
     }
-    format!(
-        "<div {attrs}>{options}</div>",
-        attrs = attributes_to_html(&group_attrs),
-        options = options_html
-    )
+}
+
+impl fmt::Display for RadioGroupAttributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_ssr_html())
+    }
+}
+
+#[cfg(test)]
+mod internal_tests {
+    use super::*;
+
+    fn style() -> Style {
+        Style::new(rustic_ui_styled_engine::css!("color: inherit;")).expect("valid style")
+    }
+
+    #[test]
+    fn selection_control_ssr_contains_expected_attributes() {
+        let descriptor = SelectionControlAttributes::builder("Toggle", style())
+            .class("root")
+            .aria("role", "switch")
+            .data("state", "on")
+            .automation_id("qa", "toggle-1")
+            .build();
+
+        let html = descriptor.to_ssr_html();
+        assert!(html.contains("role=\"switch\""));
+        assert!(html.contains("data-state=\"on\""));
+        assert!(html.contains("data-automation-qa=\"toggle-1\""));
+        assert!(html.contains("Toggle"));
+    }
+
+    #[test]
+    fn radio_group_ssr_contains_option_markup() {
+        let option_style = style();
+        let option = RadioOptionAttributes::builder("A", option_style.clone())
+            .aria("role", "radio")
+            .automation_id("qa", "radio-a")
+            .build();
+        let group = RadioGroupAttributes::builder(style())
+            .aria("role", "radiogroup")
+            .option(option)
+            .build();
+
+        let html = group.to_ssr_html();
+        assert!(html.contains("role=\"radiogroup\""));
+        assert!(html.contains("radio-a"));
+    }
 }

--- a/crates/rustic-ui-material/src/switch.rs
+++ b/crates/rustic-ui-material/src/switch.rs
@@ -2,11 +2,11 @@
 //! descriptor pipeline that aligns SSR output with multi-framework hydration.
 //!
 //! Every render path flows through
-//! [`ToggleControlDescriptor`](crate::selection_control::ToggleControlDescriptor)
+//! [`SelectionControlAttributes`](crate::selection_control::SelectionControlAttributes)
 //! so the same attribute snapshot drives:
 //!
-//! * [`render_toggle_html`](crate::selection_control::render_toggle_html) for
-//!   deterministic SSR fragments that can be cached or streamed.
+//! * [`SelectionControlAttributes::to_ssr_html`] for deterministic SSR fragments
+//!   that can be cached or streamed.
 //! * React, Yew, Leptos, Dioxus, and Sycamore adapters which hydrate with the
 //!   exact attribute set captured during SSR, preventing hydration checksum
 //!   drift and ensuring analytics markers stay stable.
@@ -47,7 +47,7 @@
 //!
 //! ```rust,no_run
 //! use rustic_ui_headless::switch::SwitchState;
-//! use rustic_ui_material::selection_control::{render_toggle_html, ToggleControlDescriptor};
+//! use rustic_ui_material::selection_control::SelectionControlAttributes;
 //! use rustic_ui_material::switch::SwitchProps;
 //! use rustic_ui_material::telemetry::TelemetryHooks;
 //! use rustic_ui_styled_engine::{css, Style};
@@ -61,15 +61,16 @@
 //!
 //! # fn orchestrate_switch_round_trip() {
 //!     let state = SwitchState::uncontrolled(false, false);
-//!     let descriptor = ToggleControlDescriptor::new(
+//!     let descriptor = SelectionControlAttributes::builder(
 //!         "Notifications",
 //!         Style::new(css!("display: inline-flex;"))
 //!             .expect("style to compile"),
 //!     )
-//!     .with_attributes(state.aria_attributes());
+//!     .attribute("role", "switch")
+//!     .build();
 //!
 //!     // Server renderers emit deterministic HTML using the descriptor.
-//!     let ssr_html = render_toggle_html(&descriptor);
+//!     let ssr_html = descriptor.to_ssr_html();
 //!     assert!(ssr_html.contains("data-on=\"false\""));
 //!
 //!     // Hydration paths merge telemetry so analytics spans fire before user
@@ -105,7 +106,7 @@
 //! all reuse the same descriptor-driven attributes across runtimes.
 
 use crate::{
-    selection_control::{self, ToggleControlDescriptor},
+    selection_control::SelectionControlAttributes,
     telemetry::{
         instrument_render, TelemetryAnalyticsCallback, TelemetryCommitCallback, TelemetryContext,
         TelemetryErrorCallback, TelemetryFocusCallback, TelemetryHooks,
@@ -299,19 +300,49 @@ fn control_key_from_str(key: &str) -> Option<ControlKey> {
 }
 
 #[allow(dead_code)]
-fn build_descriptor(props: &SwitchProps, state: &SwitchState) -> ToggleControlDescriptor {
-    let descriptor = ToggleControlDescriptor::new(props.label.clone(), themed_switch_style())
-        .with_attributes(state.aria_attributes());
-    merge_descriptor_telemetry(descriptor, &props.telemetry)
+fn build_descriptor(props: &SwitchProps, state: &SwitchState) -> SelectionControlAttributes {
+    let mut builder =
+        SelectionControlAttributes::builder(props.label.clone(), themed_switch_style());
+
+    let mut has_analytics = false;
+    let mut has_automation = false;
+
+    for (key, value) in state.aria_attributes() {
+        if key.starts_with("aria-") {
+            builder = builder.aria(key, value);
+        } else if key.starts_with("data-") {
+            if key == "data-rustic-analytics-id" {
+                has_analytics = true;
+            }
+            if key == "data-automation-id" {
+                has_automation = true;
+            }
+            builder = builder.data(key, value);
+        } else {
+            builder = builder.attribute(key, value);
+        }
+    }
+
+    if !has_analytics {
+        if let Some(analytics) = &props.telemetry.analytics_id {
+            builder = builder.data("rustic-analytics-id", analytics.clone());
+        }
+    }
+
+    if !has_automation {
+        if let Some(automation) = &props.telemetry.automation_id {
+            builder = builder.automation_id("id", automation.clone());
+        }
+    }
+
+    builder.build()
 }
 
 #[allow(dead_code)]
 fn render_html(props: &SwitchProps, state: &SwitchState) -> String {
     let (context, descriptor, _snapshot) =
         descriptor_with_context("rustic_ui_material::switch::render_html", props, state);
-    instrument_render(&props.telemetry, context, || {
-        selection_control::render_toggle_html(&descriptor)
-    })
+    instrument_render(&props.telemetry, context, || descriptor.to_ssr_html())
 }
 
 /// Builds the switch track and thumb styling from the active theme tokens. By
@@ -390,31 +421,6 @@ fn themed_switch_style() -> Style {
     )
 }
 
-fn merge_descriptor_telemetry(
-    mut descriptor: ToggleControlDescriptor,
-    telemetry: &TelemetryHooks,
-) -> ToggleControlDescriptor {
-    let has_analytics = descriptor
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-rustic-analytics-id");
-    if !has_analytics {
-        if let Some(analytics) = &telemetry.analytics_id {
-            descriptor = descriptor.attribute("data-rustic-analytics-id", analytics.clone());
-        }
-    }
-
-    let has_automation = descriptor
-        .data_state_attributes()
-        .any(|(key, _)| key == "data-automation-id");
-    if !has_automation {
-        if let Some(automation) = &telemetry.automation_id {
-            descriptor = descriptor.attribute("data-automation-id", automation.clone());
-        }
-    }
-
-    descriptor
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct SwitchDescriptorSnapshot {
     label: String,
@@ -429,7 +435,7 @@ struct SwitchDescriptorSnapshot {
 }
 
 impl SwitchDescriptorSnapshot {
-    fn from_descriptor(descriptor: &ToggleControlDescriptor) -> Self {
+    fn from_descriptor(descriptor: &SelectionControlAttributes) -> Self {
         let themed_attributes = descriptor.themed_attributes();
         let mut class = String::new();
         let mut role = String::from("switch");
@@ -472,10 +478,10 @@ fn descriptor_with_context(
     state: &SwitchState,
 ) -> (
     TelemetryContext,
-    ToggleControlDescriptor,
+    SelectionControlAttributes,
     SwitchDescriptorSnapshot,
 ) {
-    let descriptor = merge_descriptor_telemetry(build_descriptor(props, state), &props.telemetry);
+    let descriptor = build_descriptor(props, state);
     let snapshot = SwitchDescriptorSnapshot::from_descriptor(&descriptor);
     let context = TelemetryContext::new(component)
         .with_analytics(props.telemetry.analytics_id.clone())

--- a/crates/rustic-ui-material/tests/selection_control.rs
+++ b/crates/rustic-ui-material/tests/selection_control.rs
@@ -1,0 +1,109 @@
+use std::sync::Once;
+
+use rustic_ui_material::selection_control::{
+    register_radio_group_hook, register_radio_option_hook, register_selection_control_hook,
+    RadioGroupAttributes, RadioOptionAttributes, SelectionControlAttributes,
+};
+use rustic_ui_styled_engine::Style;
+
+fn style() -> Style {
+    Style::new(rustic_ui_styled_engine::css!("color: inherit;")).expect("valid style")
+}
+
+fn ensure_hooks_registered() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        register_selection_control_hook(|builder| {
+            let updated = builder.clone().class("enterprise-toggle");
+            *builder = updated;
+        })
+        .expect("selection control hook");
+        register_radio_option_hook(|builder| {
+            let updated = builder.clone().automation_id("global", "radio-option");
+            *builder = updated;
+        })
+        .expect("radio option hook");
+        register_radio_group_hook(|builder| {
+            let updated = builder.clone().class("enterprise-group");
+            *builder = updated;
+        })
+        .expect("radio group hook");
+    });
+}
+
+#[test]
+fn selection_control_builder_separates_maps() {
+    ensure_hooks_registered();
+    let descriptor = SelectionControlAttributes::builder("Notifications", style())
+        .aria("role", "switch")
+        .data("tracking", "enabled")
+        .automation_id("qa", "notifications-toggle")
+        .attribute("tabindex", "0")
+        .build();
+
+    assert_eq!(descriptor.label(), "Notifications");
+    assert!(descriptor
+        .classes()
+        .contains(&"enterprise-toggle".to_string()));
+    assert_eq!(
+        descriptor.aria_map().get("role"),
+        Some(&"switch".to_string())
+    );
+    assert_eq!(
+        descriptor.data_map().get("data-tracking"),
+        Some(&"enabled".to_string())
+    );
+    assert_eq!(
+        descriptor.automation_ids().get("qa").map(String::as_str),
+        Some("notifications-toggle")
+    );
+    assert_eq!(
+        descriptor.extra_attributes().get("tabindex"),
+        Some(&"0".to_string())
+    );
+}
+
+#[test]
+fn selection_control_ssr_string_includes_themed_attributes() {
+    ensure_hooks_registered();
+    let descriptor = SelectionControlAttributes::builder("Airplane mode", style())
+        .class("custom-toggle")
+        .aria("aria-checked", "true")
+        .build();
+
+    let html = descriptor.to_ssr_html();
+    assert!(html.contains("Airplane mode"));
+    assert!(html.contains("aria-checked=\"true\""));
+    assert!(html.contains("class=\"custom-toggle enterprise-toggle"));
+}
+
+#[test]
+fn radio_group_hydration_and_ssr_paths_match() {
+    ensure_hooks_registered();
+    let option_style = style();
+    let option = RadioOptionAttributes::builder("Scheduled", option_style.clone())
+        .class("option")
+        .aria("aria-checked", "false")
+        .data("segment", "scheduled")
+        .build();
+    let group = RadioGroupAttributes::builder(style())
+        .aria("role", "radiogroup")
+        .automation_id("qa", "notifications-group")
+        .option(option)
+        .build();
+
+    let hydrated = group.themed_attributes();
+    let html = group.to_ssr_html();
+
+    assert!(hydrated.iter().any(|(k, _)| k == "class"));
+    assert!(html.contains("enterprise-group"));
+    assert!(html.contains("data-automation-qa=\"notifications-group\""));
+    assert!(html.contains("radio-option"));
+}
+
+#[test]
+fn display_trait_round_trips_to_ssr_html() {
+    ensure_hooks_registered();
+    let descriptor = SelectionControlAttributes::builder("Wi-Fi", style()).build();
+    assert_eq!(descriptor.to_ssr_html(), descriptor.to_string());
+}

--- a/docs/architecture/selection-controls.md
+++ b/docs/architecture/selection-controls.md
@@ -1,0 +1,97 @@
+# Selection Control Attribute Builders
+
+> Status: Adopted for `rustic-ui-material` selection controls
+
+## Motivation
+
+Material adapters relied on ad-hoc helpers that eagerly produced HTML strings.
+While simple for SSR, those helpers made it difficult for enterprise consumers to
+plug in telemetry, centralized automation identifiers, or custom theming.  The
+new attribute builders embrace strongly typed descriptors so that:
+
+- **Server renderers** can stringify deterministic markup via `Display` or the
+  `to_ssr_html` helpers.
+- **Hydration adapters** can read the exact ARIA, data, and automation maps
+  without reparsing HTML.
+- **Platform teams** can register global hooks once to stamp analytics payloads
+  onto every control instead of repeating the same wiring in each adapter.
+
+## Builder Overview
+
+The selection control module exposes three core builders:
+
+| Builder | Purpose |
+| --- | --- |
+| `SelectionControlAttributes::builder` | Configures a single checkbox/switch label pair. |
+| `RadioOptionAttributes::builder` | Describes an individual radio option within a group. |
+| `RadioGroupAttributes::builder` | Orchestrates group-level metadata plus a list of option descriptors. |
+
+Each builder yields an immutable descriptor containing:
+
+- `classes`: A deduplicated list of CSS classes.
+- `aria_attributes`: Deterministic ARIA metadata.
+- `data_attributes`: `data-*` flags for analytics, QA, and focus management.
+- `automation_ids`: A map that renders as `data-automation-*` attributes.
+- `extra_attributes`: Remaining passthrough attributes such as `role` and
+  `tabindex`.
+
+Descriptors expose `to_ssr_html` and implement `Display` so that server renderers
+can emit markup without handcrafting templates.  Hydration paths can call
+`themed_attributes` to obtain framework-friendly `(String, String)` vectors.
+
+## Extensibility Hooks
+
+To minimise repetitive plumbing for enterprise telemetry, the module ships with
+three one-time registration hooks:
+
+- `register_selection_control_hook`
+- `register_radio_option_hook`
+- `register_radio_group_hook`
+
+Each hook receives the corresponding builder before it is finalised.  Platform
+integrators can use this to append global classes, analytics metadata, or
+automation identifiers exactly once per process.  Because the hooks are powered
+by `OnceLock`, the first registration wins; this protects against double
+registration in multi-tenant hosting environments.  Consumers that need dynamic
+changes should register a dispatcher that reads from their own configuration
+store.
+
+## Migration Guidelines for Adapter Authors
+
+1. Replace calls to `render_toggle_html` and `render_radio_group_html` with the
+   appropriate builder sequence.  For example:
+
+   ```rust
+   let descriptor = SelectionControlAttributes::builder(label, style)
+       .aria("role", "switch")
+       .data("state", state.as_str())
+       .build();
+   let html = descriptor.to_ssr_html();
+   ```
+
+2. For client adapters, prefer `descriptor.themed_attributes()` instead of
+   deconstructing HTML strings.  This guarantees that theming and automation
+   metadata stay consistent across SSR and hydration.
+
+3. Register any analytics/theming hook once during application start-up.  Avoid
+   per-render registration because the hook is stored in a `OnceLock`.
+
+4. Remove bespoke automation attribute plumbing.  Use
+   `builder.automation_id("qa", id)` to automatically surface
+   `data-automation-qa` attributes in SSR and hydration outputs.
+
+5. Lean on the inline documentation within `selection_control.rs` for the latest
+   field-level behavior and extension points.  The doc comments include
+   rationale for defaults so future migrations remain low-risk.
+
+## Testing Expectations
+
+Unit tests now live under `crates/rustic-ui-material/tests/selection_control.rs`
+and validate:
+
+- Builder separation of ARIA/data/automation maps.
+- SSR string consistency.
+- Hook registration behavior.
+- `Display` trait parity with SSR helpers.
+
+Adapter authors should keep these tests running (`cargo test -p rustic-ui-material selection_control`) when introducing new hooks or metadata.


### PR DESCRIPTION
## Summary
- replace the selection control helpers with structured builders for toggles and radio groups, including global telemetry/theming hooks
- refactor the checkbox, switch, and radio adapters to consume the new builders while exposing SSR conversion helpers
- document the new builder pattern for adapter authors and add targeted integration tests

## Testing
- cargo test -p rustic-ui-material selection_control

------
https://chatgpt.com/codex/tasks/task_e_68df10c83ebc832e9ecb0be687a392db