### PR TITLE
Add selection control descriptor helpers

### DIFF
--- a/crates/rustic-ui-material/README.md
+++ b/crates/rustic-ui-material/README.md
@@ -34,6 +34,31 @@ Current gaps most relevant to enterprise adopters include:
 Contributions that land these components should reference the report to keep
 the automation in sync; `cargo xtask material-parity` refreshes the metrics.
 
+## Selection control descriptor factories
+
+Enterprise teams integrating checkboxes, switches, and radio buttons across SSR
+and multiple front-end runtimes can now rely on the shared
+[`SelectionControlDescriptor`](src/selection_control.rs) factories. The helpers
+wrap headless state-machine snapshots and automatically merge themed defaults,
+managed telemetry identifiers, and ARIA/data attributes so adapters avoid
+duplicating boilerplate.
+
+- [`SelectionControlThemeTokens`](src/selection_control.rs) encapsulates the
+  automation selectors and classes emitted by centralized configuration
+  services, keeping SSR and hydration output aligned.
+- [`SelectionControlTelemetry`](src/selection_control.rs) carries the configured
+  [`TelemetryHooks`](src/telemetry.rs) plus analytics/automation identifiers and
+  enforces override policies when required by compliance platforms.
+- `SelectionControlDescriptor::from_headless` consumes the headless
+  [`CheckboxState`](../rustic-ui-headless/src/checkbox.rs) or
+  [`SwitchState`](../rustic-ui-headless/src/switch.rs) and returns both the
+  themed attributes and resolved telemetry metadata for adapters and SSR
+  renderers.
+
+The accompanying unit tests (`cargo test -p rustic-ui-material selection_control`)
+demonstrate telemetry defaults, attribute overrides, and strict error handling
+when managed analytics identifiers conflict with headless overrides.
+
 ## Feature Flags
 
 Select a single front-end framework to keep builds lean. All features are

--- a/crates/rustic-ui-material/src/checkbox.rs
+++ b/crates/rustic-ui-material/src/checkbox.rs
@@ -116,7 +116,10 @@
 //! and Sycamore surfaces.
 
 use crate::{
-    selection_control::SelectionControlAttributes,
+    selection_control::{
+        SelectionControlAttributes, SelectionControlDescriptor, SelectionControlTelemetry,
+        SelectionControlThemeTokens,
+    },
     telemetry::{
         instrument_render, TelemetryAnalyticsCallback, TelemetryCommitCallback, TelemetryContext,
         TelemetryErrorCallback, TelemetryFocusCallback, TelemetryHooks,
@@ -330,42 +333,17 @@ impl CheckboxProps {
 }
 
 #[allow(dead_code)]
-fn build_descriptor(props: &CheckboxProps, state: &CheckboxState) -> SelectionControlAttributes {
-    let mut builder =
-        SelectionControlAttributes::builder(props.label.clone(), themed_checkbox_style());
-
-    let mut has_analytics = false;
-    let mut has_automation = false;
-
-    for (key, value) in state.aria_attributes() {
-        if key.starts_with("aria-") {
-            builder = builder.aria(key, value);
-        } else if key.starts_with("data-") {
-            if key == "data-rustic-analytics-id" {
-                has_analytics = true;
-            }
-            if key == "data-automation-id" {
-                has_automation = true;
-            }
-            builder = builder.data(key, value);
-        } else {
-            builder = builder.attribute(key, value);
-        }
-    }
-
-    if !has_analytics {
-        if let Some(analytics) = &props.telemetry.analytics_id {
-            builder = builder.data("rustic-analytics-id", analytics.clone());
-        }
-    }
-
-    if !has_automation {
-        if let Some(automation) = &props.telemetry.automation_id {
-            builder = builder.automation_id("id", automation.clone());
-        }
-    }
-
-    builder.build()
+fn build_descriptor(props: &CheckboxProps, state: &CheckboxState) -> SelectionControlDescriptor {
+    let theme = SelectionControlThemeTokens::material_defaults().with_data("variant", "checkbox");
+    let telemetry = SelectionControlTelemetry::from(props.telemetry.clone());
+    SelectionControlDescriptor::from_headless(
+        props.label.clone(),
+        themed_checkbox_style(),
+        state,
+        &theme,
+        &telemetry,
+    )
+    .expect("checkbox descriptor must merge headless metadata")
 }
 
 #[allow(dead_code)]
@@ -440,12 +418,21 @@ fn descriptor_with_context(
     CheckboxDescriptorSnapshot,
 ) {
     let descriptor = build_descriptor(props, state);
-    let snapshot = CheckboxDescriptorSnapshot::from_descriptor(&descriptor);
+    let snapshot = CheckboxDescriptorSnapshot::from_descriptor(descriptor.attributes());
+    let telemetry = descriptor.telemetry().clone();
     let context = TelemetryContext::new(component)
-        .with_analytics(props.telemetry.analytics_id.clone())
-        .with_automation(props.telemetry.automation_id.clone())
+        .with_analytics(
+            telemetry
+                .effective_analytics_id()
+                .map(|value| value.to_owned()),
+        )
+        .with_automation(
+            telemetry
+                .effective_automation_id()
+                .map(|value| value.to_owned()),
+        )
         .with_descriptor_metadata(snapshot.label.clone(), snapshot.themed_attributes.clone());
-    (context, descriptor, snapshot)
+    (context, descriptor.into_attributes(), snapshot)
 }
 
 #[cfg(feature = "react")]
@@ -2422,11 +2409,12 @@ mod tests {
     #[test]
     fn themed_attributes_include_role() {
         let state = CheckboxState::uncontrolled(false, true);
-        let attrs = build_descriptor(
+        let descriptor = build_descriptor(
             &CheckboxProps::new("Accept", TelemetryHooks::default()),
             &state,
         );
-        assert!(attrs
+        assert!(descriptor
+            .attributes()
             .aria_attributes()
             .any(|(k, v)| k == "role" && v == "checkbox"));
     }
@@ -2448,7 +2436,7 @@ mod tests {
         props.telemetry.automation_id = Some("automation-42".into());
 
         let descriptor = build_descriptor(&props, &state);
-        let data_attrs = descriptor.data_state_attributes();
+        let data_attrs = descriptor.attributes().data_state_attributes();
 
         assert!(data_attrs
             .iter()

--- a/crates/rustic-ui-material/src/selection_control.rs
+++ b/crates/rustic-ui-material/src/selection_control.rs
@@ -207,6 +207,11 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::{Arc, OnceLock};
 
+use crate::telemetry::TelemetryHooks;
+
+#[cfg(feature = "forms")]
+use rustic_ui_headless::{checkbox::CheckboxState, switch::SwitchState};
+
 use rustic_ui_styled_engine::Style;
 use rustic_ui_utils::attributes_to_html;
 
@@ -264,6 +269,403 @@ where
     RADIO_GROUP_HOOK
         .set(Arc::new(hook))
         .map_err(|_| "radio group hook already registered")
+}
+
+/// Error emitted when descriptor construction detects invalid overrides.
+///
+/// The helper is intentionally conservative: enterprise control planes often
+/// wire managed analytics and automation identifiers globally. Surfacing
+/// conflicts early avoids silently drifting from the centralized configuration
+/// and keeps compliance dashboards consistent across SSR and hydration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectionControlError {
+    /// Telemetry defaults forbade overriding the supplied attribute.
+    TelemetryConflict {
+        /// Attribute that produced the conflict (for example
+        /// `data-rustic-analytics-id`).
+        key: String,
+        /// Managed default expected to land on the descriptor.
+        expected: String,
+        /// Value surfaced by the headless state machine.
+        actual: String,
+    },
+}
+
+impl fmt::Display for SelectionControlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TelemetryConflict {
+                key,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "telemetry attribute `{key}` expected `{expected}` but received `{actual}`"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SelectionControlError {}
+
+/// Centralised theme tokens applied to every selection control descriptor.
+///
+/// Platform teams frequently maintain managed configuration services that emit
+/// mandatory CSS classes or `data-*` hooks for downstream analytics
+/// pipelines.  Feeding those defaults through a dedicated struct keeps adapter
+/// factories terse while still exposing an ergonomic API for per-component
+/// overrides.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SelectionControlThemeTokens {
+    classes: Vec<String>,
+    aria: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+    attributes: BTreeMap<String, String>,
+}
+
+impl SelectionControlThemeTokens {
+    fn normalize_data_key(key: String) -> String {
+        if key.starts_with("data-") {
+            key
+        } else {
+            format!("data-{key}")
+        }
+    }
+
+    /// Material defaults applied to every descriptor when no overrides are
+    /// supplied.  The defaults intentionally install an enterprise friendly
+    /// `data-component` hook so QA and analytics suites can target controls
+    /// without bespoke wiring in each adapter.
+    #[must_use]
+    pub fn material_defaults() -> Self {
+        let mut tokens = Self::default();
+        tokens.classes.push("rustic-selection-control".into());
+        tokens
+            .data
+            .insert("data-component".into(), "selection-control".into());
+        tokens
+    }
+
+    /// Append a CSS class that should always decorate the control root.
+    #[must_use]
+    pub fn with_class(mut self, class: impl Into<String>) -> Self {
+        self.classes.push(class.into());
+        self
+    }
+
+    /// Append multiple CSS classes in one call.
+    #[must_use]
+    pub fn with_classes<I, S>(mut self, classes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.classes.extend(classes.into_iter().map(Into::into));
+        self
+    }
+
+    /// Inject a managed ARIA attribute (for example `aria-describedby`).
+    #[must_use]
+    pub fn with_aria(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.aria.insert(key.into(), value.into());
+        self
+    }
+
+    /// Inject a managed `data-*` attribute.
+    #[must_use]
+    pub fn with_data(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = Self::normalize_data_key(key.into());
+        self.data.insert(key, value.into());
+        self
+    }
+
+    /// Inject an additional attribute (for example `role` or `tabindex`).
+    #[must_use]
+    pub fn with_attribute(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    /// Apply the configured tokens to the supplied builder.
+    pub fn apply(
+        &self,
+        mut builder: SelectionControlAttributesBuilder,
+    ) -> SelectionControlAttributesBuilder {
+        if !self.classes.is_empty() {
+            builder = builder.classes(self.classes.clone());
+        }
+        for (key, value) in &self.aria {
+            builder = builder.aria(key.clone(), value.clone());
+        }
+        for (key, value) in &self.data {
+            builder = builder.data(key.clone(), value.clone());
+        }
+        for (key, value) in &self.attributes {
+            builder = builder.attribute(key.clone(), value.clone());
+        }
+        builder
+    }
+
+    /// Inspect the managed CSS classes. Primarily useful for tests.
+    pub fn classes(&self) -> &[String] {
+        &self.classes
+    }
+
+    /// Inspect managed data attributes. Primarily useful for tests.
+    pub fn data_attributes(&self) -> &BTreeMap<String, String> {
+        &self.data
+    }
+}
+
+/// Telemetry defaults merged into descriptors produced from headless states.
+///
+/// The struct carries the managed [`TelemetryHooks`] configuration alongside
+/// optional analytics and automation identifiers.  Factories feed it into
+/// [`SelectionControlDescriptor::from_headless`] so theme tokens, ARIA state, and
+/// telemetry IDs merge automatically without every adapter rewriting the same
+/// boilerplate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectionControlTelemetry {
+    hooks: TelemetryHooks,
+    analytics_id: Option<String>,
+    automation_id: Option<String>,
+    analytics_key: String,
+    automation_key: String,
+    allow_overrides: bool,
+}
+
+impl SelectionControlTelemetry {
+    /// Construct telemetry defaults from a configured [`TelemetryHooks`]
+    /// instance.  The helper reuses any analytics or automation identifiers
+    /// already stored on the hooks so enterprise instrumentation propagates to
+    /// the descriptor automatically.
+    #[must_use]
+    pub fn new(hooks: TelemetryHooks) -> Self {
+        let analytics_id = hooks.analytics_id.clone();
+        let automation_id = hooks.automation_id.clone();
+        Self {
+            hooks,
+            analytics_id,
+            automation_id,
+            analytics_key: "data-rustic-analytics-id".into(),
+            automation_key: "data-automation-id".into(),
+            allow_overrides: true,
+        }
+    }
+
+    /// Override the analytics identifier that should land on the descriptor.
+    #[must_use]
+    pub fn with_analytics_id(mut self, analytics_id: Option<String>) -> Self {
+        self.analytics_id = analytics_id;
+        self
+    }
+
+    /// Override the automation identifier that should land on the descriptor.
+    #[must_use]
+    pub fn with_automation_id(mut self, automation_id: Option<String>) -> Self {
+        self.automation_id = automation_id;
+        self
+    }
+
+    /// Override the `data-*` keys used to store telemetry identifiers.
+    #[must_use]
+    pub fn with_data_keys(
+        mut self,
+        analytics_key: impl Into<String>,
+        automation_key: impl Into<String>,
+    ) -> Self {
+        self.analytics_key = SelectionControlThemeTokens::normalize_data_key(analytics_key.into());
+        self.automation_key =
+            SelectionControlThemeTokens::normalize_data_key(automation_key.into());
+        self
+    }
+
+    /// Prevent headless state machines from overriding managed telemetry IDs.
+    #[must_use]
+    pub fn enforce_defaults(mut self) -> Self {
+        self.allow_overrides = false;
+        self
+    }
+
+    /// Underlying telemetry hooks used by adapters to instrument renders.
+    pub fn hooks(&self) -> &TelemetryHooks {
+        &self.hooks
+    }
+
+    /// Effective analytics identifier resolved after descriptor construction.
+    pub fn effective_analytics_id(&self) -> Option<&str> {
+        self.analytics_id.as_deref()
+    }
+
+    /// Effective automation identifier resolved after descriptor construction.
+    pub fn effective_automation_id(&self) -> Option<&str> {
+        self.automation_id.as_deref()
+    }
+
+    fn merge_into_builder<'a, I>(
+        &self,
+        mut builder: SelectionControlAttributesBuilder,
+        attributes: I,
+    ) -> Result<
+        (
+            SelectionControlAttributesBuilder,
+            Option<String>,
+            Option<String>,
+        ),
+        SelectionControlError,
+    >
+    where
+        I: IntoIterator<Item = (&'a str, String)>,
+    {
+        let mut analytics = None;
+        let mut automation = None;
+
+        for (key, value) in attributes {
+            if key.starts_with("aria-") {
+                builder = builder.aria(key, value);
+                continue;
+            }
+
+            if key.starts_with("data-") {
+                let cloned = value.clone();
+                if key == self.analytics_key {
+                    if let Some(default) = &self.analytics_id {
+                        if !self.allow_overrides && *default != cloned {
+                            return Err(SelectionControlError::TelemetryConflict {
+                                key: key.to_string(),
+                                expected: default.clone(),
+                                actual: cloned,
+                            });
+                        }
+                    }
+                    analytics = Some(cloned.clone());
+                } else if key == self.automation_key {
+                    if let Some(default) = &self.automation_id {
+                        if !self.allow_overrides && *default != cloned {
+                            return Err(SelectionControlError::TelemetryConflict {
+                                key: key.to_string(),
+                                expected: default.clone(),
+                                actual: cloned,
+                            });
+                        }
+                    }
+                    automation = Some(cloned.clone());
+                }
+                builder = builder.data(key, value);
+                continue;
+            }
+
+            builder = builder.attribute(key, value);
+        }
+
+        if analytics.is_none() {
+            if let Some(default) = &self.analytics_id {
+                builder = builder.data(self.analytics_key.clone(), default.clone());
+                analytics = Some(default.clone());
+            }
+        }
+
+        if automation.is_none() {
+            if let Some(default) = &self.automation_id {
+                builder = builder.automation_id("id", default.clone());
+                automation = Some(default.clone());
+            }
+        }
+
+        Ok((builder, analytics, automation))
+    }
+
+    fn with_effective_ids(&self, analytics: Option<String>, automation: Option<String>) -> Self {
+        let mut resolved = self.clone();
+        if let Some(value) = analytics {
+            resolved.analytics_id = Some(value);
+        }
+        if let Some(value) = automation {
+            resolved.automation_id = Some(value);
+        }
+        resolved
+    }
+}
+
+impl From<TelemetryHooks> for SelectionControlTelemetry {
+    fn from(value: TelemetryHooks) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Trait implemented by headless state machines that can be converted into
+/// descriptor attributes.
+pub trait SelectionControlStateAdapter {
+    /// Snapshot ARIA and `data-*` attributes describing the current state.
+    fn snapshot_attributes(&self) -> Vec<(&'static str, String)>;
+}
+
+#[cfg(feature = "forms")]
+impl SelectionControlStateAdapter for CheckboxState {
+    fn snapshot_attributes(&self) -> Vec<(&'static str, String)> {
+        self.aria_attributes()
+    }
+}
+
+#[cfg(feature = "forms")]
+impl SelectionControlStateAdapter for SwitchState {
+    fn snapshot_attributes(&self) -> Vec<(&'static str, String)> {
+        self.aria_attributes()
+    }
+}
+
+/// Combined descriptor containing themed attributes and resolved telemetry.
+#[derive(Debug, Clone)]
+pub struct SelectionControlDescriptor {
+    attributes: SelectionControlAttributes,
+    telemetry: SelectionControlTelemetry,
+}
+
+impl SelectionControlDescriptor {
+    /// Build a descriptor directly from a headless state machine snapshot.
+    pub fn from_headless<S>(
+        label: impl Into<String>,
+        style: Style,
+        state: &S,
+        theme: &SelectionControlThemeTokens,
+        telemetry: &SelectionControlTelemetry,
+    ) -> Result<Self, SelectionControlError>
+    where
+        S: SelectionControlStateAdapter,
+    {
+        let builder = SelectionControlAttributes::builder(label, style);
+        let builder = theme.apply(builder);
+        let (builder, analytics, automation) =
+            telemetry.merge_into_builder(builder, state.snapshot_attributes())?;
+        let attributes = builder.build();
+        let telemetry = telemetry.with_effective_ids(analytics, automation);
+        Ok(Self {
+            attributes,
+            telemetry,
+        })
+    }
+
+    /// Borrow the resolved attributes.
+    pub fn attributes(&self) -> &SelectionControlAttributes {
+        &self.attributes
+    }
+
+    /// Borrow the resolved telemetry defaults.
+    pub fn telemetry(&self) -> &SelectionControlTelemetry {
+        &self.telemetry
+    }
+
+    /// Consume the descriptor, returning both parts.
+    pub fn into_parts(self) -> (SelectionControlAttributes, SelectionControlTelemetry) {
+        (self.attributes, self.telemetry)
+    }
+
+    /// Consume the descriptor, returning only the attributes.
+    pub fn into_attributes(self) -> SelectionControlAttributes {
+        self.attributes
+    }
 }
 
 /// Data object describing a Material selection control (checkbox/switch).
@@ -896,9 +1298,21 @@ impl fmt::Display for RadioGroupAttributes {
 #[cfg(test)]
 mod internal_tests {
     use super::*;
+    use crate::telemetry::TelemetryHooks;
 
     fn style() -> Style {
         Style::new(rustic_ui_styled_engine::css!("color: inherit;")).expect("valid style")
+    }
+
+    #[derive(Clone, Default)]
+    struct FakeState {
+        attributes: Vec<(&'static str, String)>,
+    }
+
+    impl SelectionControlStateAdapter for FakeState {
+        fn snapshot_attributes(&self) -> Vec<(&'static str, String)> {
+            self.attributes.clone()
+        }
     }
 
     #[test]
@@ -932,5 +1346,128 @@ mod internal_tests {
         let html = group.to_ssr_html();
         assert!(html.contains("role=\"radiogroup\""));
         assert!(html.contains("radio-a"));
+    }
+
+    #[test]
+    fn telemetry_defaults_apply_when_missing() {
+        let state = FakeState {
+            attributes: vec![("aria-checked", "true".into())],
+        };
+        let theme = SelectionControlThemeTokens::material_defaults();
+        let telemetry = SelectionControlTelemetry::new(TelemetryHooks::default())
+            .with_analytics_id(Some("defaults.analytics".into()))
+            .with_automation_id(Some("defaults.automation".into()));
+
+        let descriptor = SelectionControlDescriptor::from_headless(
+            "Defaults",
+            style(),
+            &state,
+            &theme,
+            &telemetry,
+        )
+        .expect("descriptor to build");
+
+        let data_attrs = descriptor.attributes().data_state_attributes();
+        assert!(
+            data_attrs
+                .iter()
+                .any(|(key, value)| key == "data-rustic-analytics-id"
+                    && value == "defaults.analytics")
+        );
+        assert!(descriptor
+            .telemetry()
+            .effective_automation_id()
+            .is_some_and(|value| value == "defaults.automation"));
+    }
+
+    #[test]
+    fn headless_overrides_are_respected_when_allowed() {
+        let state = FakeState {
+            attributes: vec![
+                ("aria-checked", "false".into()),
+                ("data-rustic-analytics-id", "headless.analytics".into()),
+            ],
+        };
+        let theme = SelectionControlThemeTokens::material_defaults();
+        let telemetry = SelectionControlTelemetry::new(TelemetryHooks::default())
+            .with_analytics_id(Some("defaults.analytics".into()));
+
+        let descriptor = SelectionControlDescriptor::from_headless(
+            "Overrides",
+            style(),
+            &state,
+            &theme,
+            &telemetry,
+        )
+        .expect("descriptor to build");
+
+        assert!(
+            descriptor
+                .attributes()
+                .data_state_attributes()
+                .iter()
+                .any(|(key, value)| key == "data-rustic-analytics-id"
+                    && value == "headless.analytics")
+        );
+        assert_eq!(
+            descriptor.telemetry().effective_analytics_id(),
+            Some("headless.analytics")
+        );
+    }
+
+    #[test]
+    fn telemetry_conflicts_error_when_enforced() {
+        let state = FakeState {
+            attributes: vec![("data-rustic-analytics-id", "headless.analytics".into())],
+        };
+        let theme = SelectionControlThemeTokens::material_defaults();
+        let telemetry = SelectionControlTelemetry::new(TelemetryHooks::default())
+            .with_analytics_id(Some("defaults.analytics".into()))
+            .enforce_defaults();
+
+        let result = SelectionControlDescriptor::from_headless(
+            "Conflicts",
+            style(),
+            &state,
+            &theme,
+            &telemetry,
+        );
+
+        match result {
+            Err(SelectionControlError::TelemetryConflict {
+                key,
+                expected,
+                actual,
+            }) => {
+                assert_eq!(key, "data-rustic-analytics-id");
+                assert_eq!(expected, "defaults.analytics");
+                assert_eq!(actual, "headless.analytics");
+            }
+            other => panic!("expected telemetry conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn theme_tokens_can_be_overridden() {
+        let state = FakeState {
+            attributes: vec![("data-component", "overridden".into())],
+        };
+        let theme = SelectionControlThemeTokens::material_defaults();
+        let telemetry = SelectionControlTelemetry::new(TelemetryHooks::default());
+
+        let descriptor = SelectionControlDescriptor::from_headless(
+            "Overrides",
+            style(),
+            &state,
+            &theme,
+            &telemetry,
+        )
+        .expect("descriptor to build");
+
+        assert!(descriptor
+            .attributes()
+            .data_state_attributes()
+            .iter()
+            .any(|(key, value)| key == "data-component" && value == "overridden"));
     }
 }

--- a/crates/rustic-ui-material/src/switch.rs
+++ b/crates/rustic-ui-material/src/switch.rs
@@ -106,7 +106,10 @@
 //! all reuse the same descriptor-driven attributes across runtimes.
 
 use crate::{
-    selection_control::SelectionControlAttributes,
+    selection_control::{
+        SelectionControlAttributes, SelectionControlDescriptor, SelectionControlTelemetry,
+        SelectionControlThemeTokens,
+    },
     telemetry::{
         instrument_render, TelemetryAnalyticsCallback, TelemetryCommitCallback, TelemetryContext,
         TelemetryErrorCallback, TelemetryFocusCallback, TelemetryHooks,
@@ -300,42 +303,17 @@ fn control_key_from_str(key: &str) -> Option<ControlKey> {
 }
 
 #[allow(dead_code)]
-fn build_descriptor(props: &SwitchProps, state: &SwitchState) -> SelectionControlAttributes {
-    let mut builder =
-        SelectionControlAttributes::builder(props.label.clone(), themed_switch_style());
-
-    let mut has_analytics = false;
-    let mut has_automation = false;
-
-    for (key, value) in state.aria_attributes() {
-        if key.starts_with("aria-") {
-            builder = builder.aria(key, value);
-        } else if key.starts_with("data-") {
-            if key == "data-rustic-analytics-id" {
-                has_analytics = true;
-            }
-            if key == "data-automation-id" {
-                has_automation = true;
-            }
-            builder = builder.data(key, value);
-        } else {
-            builder = builder.attribute(key, value);
-        }
-    }
-
-    if !has_analytics {
-        if let Some(analytics) = &props.telemetry.analytics_id {
-            builder = builder.data("rustic-analytics-id", analytics.clone());
-        }
-    }
-
-    if !has_automation {
-        if let Some(automation) = &props.telemetry.automation_id {
-            builder = builder.automation_id("id", automation.clone());
-        }
-    }
-
-    builder.build()
+fn build_descriptor(props: &SwitchProps, state: &SwitchState) -> SelectionControlDescriptor {
+    let theme = SelectionControlThemeTokens::material_defaults().with_data("variant", "switch");
+    let telemetry = SelectionControlTelemetry::from(props.telemetry.clone());
+    SelectionControlDescriptor::from_headless(
+        props.label.clone(),
+        themed_switch_style(),
+        state,
+        &theme,
+        &telemetry,
+    )
+    .expect("switch descriptor must merge headless metadata")
 }
 
 #[allow(dead_code)]
@@ -482,12 +460,21 @@ fn descriptor_with_context(
     SwitchDescriptorSnapshot,
 ) {
     let descriptor = build_descriptor(props, state);
-    let snapshot = SwitchDescriptorSnapshot::from_descriptor(&descriptor);
+    let snapshot = SwitchDescriptorSnapshot::from_descriptor(descriptor.attributes());
+    let telemetry = descriptor.telemetry().clone();
     let context = TelemetryContext::new(component)
-        .with_analytics(props.telemetry.analytics_id.clone())
-        .with_automation(props.telemetry.automation_id.clone())
+        .with_analytics(
+            telemetry
+                .effective_analytics_id()
+                .map(|value| value.to_owned()),
+        )
+        .with_automation(
+            telemetry
+                .effective_automation_id()
+                .map(|value| value.to_owned()),
+        )
         .with_descriptor_metadata(snapshot.label.clone(), snapshot.themed_attributes.clone());
-    (context, descriptor, snapshot)
+    (context, descriptor.into_attributes(), snapshot)
 }
 
 fn dispatch_change_event(


### PR DESCRIPTION
## Summary
- introduce SelectionControlThemeTokens, SelectionControlTelemetry, and SelectionControlDescriptor to centralize selection-control defaults and telemetry merging
- refactor checkbox and switch descriptors to consume the new factory helpers for consistent analytics and automation wiring
- document the descriptor workflow in the crate README and extend unit coverage for telemetry defaults, overrides, and conflict handling

## Testing
- cargo test -p rustic-ui-material selection_control

------
https://chatgpt.com/codex/tasks/task_e_68df2e7c029c832e951f41e4b0f905b6