### PR TITLE
docs: clarify adapter telemetry builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ archived Material UI change history now lives in [`docs/archives/material-ui-cha
 
 ### Highlights
 
+- Documented the new `SelectionControlTelemetry` and `TelemetryHooks` helpers so
+  adapter authors can integrate the builder workflow, centralise enterprise
+  telemetry, and enforce managed analytics/automation identifiers across
+  renderers. 【F:README.md†L170-L209】【F:docs/architecture/selection-controls.md†L73-L127】
+- Expanded inline rustdoc on the telemetry helpers to guide future maintainers
+  when evolving builder invariants or adding lifecycle hooks for adapters.
+  【F:crates/rustic-ui-material/src/selection_control.rs†L334-L368】【F:crates/rustic-ui-material/src/telemetry.rs†L198-L205】
 - Expanded the selection control builder documentation to cover keyboard
   navigation, focus-visible semantics, telemetry hooks, SSR/hydration
   guarantees, and enterprise bootstrap patterns shared across checkbox, radio,
@@ -25,6 +32,7 @@ archived Material UI change history now lives in [`docs/archives/material-ui-cha
 
 ### Verification
 
+- `cargo xtask accessibility-audit`
 - `cargo fmt`
 - `cargo test -p rustic-ui-material --lib --features leptos`
 - `cargo test -p rustic-ui-material --lib --features sycamore`

--- a/README.md
+++ b/README.md
@@ -159,6 +159,45 @@ copious documentation and attribute builders so adapters remain declarative:
 Pair these primitives with the existing dialog/popover state machines to build modals that are concurrency-safe, WCAG-compliant, and instrumented
 for large-scale QA suites.
 
+## Adapter builders and telemetry orchestration
+
+New helper builders ship with the selection control adapters so frameworks can wire telemetry, analytics, and automation markers
+without bespoke glue. Enterprise maintainers now interact with three layered primitives:
+
+- **Descriptor builders** – `SelectionControlAttributes::builder`, `RadioOptionAttributes::builder`, and
+  `RadioGroupAttributes::builder` expose fluent APIs for merging headless ARIA state, Material defaults, and caller overrides.
+  Adapters pass the finalized descriptors directly into their renderers, eliminating ad-hoc attribute mutation and keeping SSR
+  parity deterministic.
+- **`SelectionControlTelemetry` helper** – The helper wraps shared `TelemetryHooks` and stamps analytics/automation identifiers
+  onto every descriptor generated through the builders. Central platforms override identifiers or enforce managed defaults once
+  so downstream adapters stay aligned across React, Yew, Leptos, and Sycamore.
+- **`TelemetryHooks` builder** – Enterprise observability stacks configure analytics channels, focus/state/commit callbacks, and
+  panic reporting handlers in one place. The hooks feed into the descriptor builders which automatically merge context metadata
+  (component name, label, evaluated attributes) before invoking delegates.
+
+To integrate the builders inside a custom adapter:
+
+1. Instantiate `TelemetryHooks` with your automation identifiers, analytics channel, and observability delegates.
+2. Construct a `SelectionControlTelemetry` with the hooks, optionally overriding managed `data-*` keys or marking the defaults as
+   authoritative.
+3. Feed the helper into `SelectionControlDescriptor::from_headless` or the fluent builders for the specific control you are
+   rendering. The builders return immutable descriptors carrying merged attributes, telemetry context, and framework-agnostic
+   automation markers.
+4. Forward `descriptor.to_ssr_html()` or the framework-specific renderer output to your view layer. Because the descriptor is
+   immutable, adapters stay free of manual mutations and enterprise telemetry receives identical payloads across SSR and CSR
+   environments.
+
+Enterprise telemetry pipelines receive richer context through the merged descriptor metadata. Each telemetry callback receives a
+`TelemetryContext` containing:
+
+- the fully qualified component path,
+- stable analytics and automation identifiers suitable for correlating distributed traces, and
+- a frozen snapshot of the rendered attributes for debugging SSR/CSR diffs.
+
+Adapters never need to parse HTML or mutate DOM nodes; instead they forward the context into logging/tracing sinks so automation
+and SecOps dashboards observe the same lifecycle events (analytics beacons, focus transitions, state mutations, commit
+acknowledgements, and panic reporting) regardless of renderer.
+
 ## Workspace automation
 
 Automation is consolidated in the root `Makefile` and `cargo xtask` binary so teams can wire CI once and scale confidently.

--- a/crates/rustic-ui-material/src/selection_control.rs
+++ b/crates/rustic-ui-material/src/selection_control.rs
@@ -333,7 +333,9 @@ pub struct SelectionControlThemeTokens {
 /// [`SelectionControlTelemetry`] helper drives these builders through a common
 /// trait so centralised telemetry defaults (analytics IDs, automation IDs, and
 /// future managed metadata) flow through a single code path regardless of which
-/// descriptor is being constructed.
+/// descriptor is being constructed. Maintain the helper invariants whenever the
+/// descriptors grow new fields; adapter authors rely on this struct to keep
+/// enterprise telemetry stable across renderers without duplicating merge logic.
 pub trait TelemetryAttributesBuilder: Sized {
     /// Record an ARIA attribute surfaced by the headless state machine or
     /// caller-supplied overrides.
@@ -461,7 +463,9 @@ impl SelectionControlTelemetry {
     /// Construct telemetry defaults from a configured [`TelemetryHooks`]
     /// instance.  The helper reuses any analytics or automation identifiers
     /// already stored on the hooks so enterprise instrumentation propagates to
-    /// the descriptor automatically.
+    /// the descriptor automatically.  When adding new lifecycle hooks, extend
+    /// [`TelemetryHooks`] first, then thread the data through this constructor so
+    /// downstream adapters inherit the behaviour without additional patching.
     #[must_use]
     pub fn new(hooks: TelemetryHooks) -> Self {
         let analytics_id = hooks.analytics_id.clone();

--- a/crates/rustic-ui-material/src/telemetry.rs
+++ b/crates/rustic-ui-material/src/telemetry.rs
@@ -192,6 +192,12 @@ pub type TelemetryCommitCallback =
 pub type TelemetryErrorCallback = dyn Fn(TelemetryContext, TelemetryError) + Send + Sync + 'static;
 
 /// Configurable hooks invoked around adapter renders.
+///
+/// Maintain exhaustive field-level guidance here whenever new callbacks land;
+/// selection control builders and adapter plans clone this struct verbatim, and
+/// downstream maintainers rely on the documentation to map hooks back to
+/// enterprise observability requirements. Prefer additive changes with safe
+/// defaults so existing integrations inherit capabilities without churn.
 #[derive(Clone, Default)]
 pub struct TelemetryHooks {
     /// Optional analytics identifier automatically applied when the adapter

--- a/docs/architecture/selection-controls.md
+++ b/docs/architecture/selection-controls.md
@@ -99,6 +99,56 @@ instead of cloning descriptor assembly logic. Doing so keeps analytics spans,
 automation hooks, and SSR output consistent even as new telemetry sinks or
 attributes are introduced centrally.
 
+## Telemetry orchestration helpers
+
+Selection controls now lean on two telemetry-centric helpers that eliminate
+adapter-specific glue code:
+
+- `SelectionControlTelemetry` wraps a configured `TelemetryHooks` instance and
+  exposes builder-like methods (`with_analytics_id`, `with_automation_id`,
+  `with_data_keys`, `enforce_defaults`) for centrally managed identifiers.
+- `TelemetryHooks` acts as the enterprise integration surface, carrying
+  analytics/focus/change/commit/error callbacks plus panic handling. Hooks are
+  thread-safe so adapters can clone them into concurrent renderers without
+  additional locking.
+
+### Integration steps for adapters
+
+1. Construct a `TelemetryHooks` value during application/bootstrap and register
+   its delegates with your observability systems (tracing, logging, data lake,
+   compliance archive). The hooks expose optional analytics and automation IDs
+   that downstream descriptors inherit automatically.
+2. Wrap the hooks with `SelectionControlTelemetry::new(hooks.clone())`. Override
+   managed data keys or identifiers if your renderer needs bespoke attribute
+   names (for example, to integrate with legacy DOM listeners).
+3. Pass the helper into `SelectionControlDescriptor::from_headless`, the
+   dedicated render plans, or the fluent attribute builders. The descriptor will
+   merge ARIA/data/automation metadata, Material defaults, and telemetry context
+   without requiring adapter-level mutation.
+4. When rendering, call the descriptor’s `to_ssr_html` or feed
+   `themed_attributes()` into your framework. After the render finishes, the
+   telemetry helper ensures analytics, focus, state change, commit, and error
+   callbacks fire in a deterministic order before consumer callbacks, keeping
+   enterprise dashboards trustworthy.
+
+### Enterprise telemetry considerations
+
+- **Consistent context** – Telemetry callbacks receive a `TelemetryContext`
+  containing the fully qualified component path, merged analytics/automation
+  identifiers, and snapshot metadata describing the descriptor label and final
+  attributes. Incident response teams can diff SSR/CSR output using this
+  context without scraping HTML.
+- **Deterministic ordering** – Checkbox/switch/radio adapters emit telemetry
+  before invoking consumer handlers. Maintain this sequencing when authoring
+  additional adapters so automation harnesses observe identical lifecycles.
+- **Central overrides** – Use `SelectionControlTelemetry::enforce_defaults()`
+  when platform governance mandates canonical identifiers. Builders will refuse
+  to overwrite analytics/automation IDs, protecting compliance-critical hooks
+  from local overrides.
+- **Testing** – Extend the existing wasm-bindgen tests and integration suites to
+  cover new telemetry delegates. Tests should assert ordering and attribute
+  propagation to prevent regressions during framework upgrades.
+
 ## Testing Expectations
 
 Unit tests now live under `crates/rustic-ui-material/tests/selection_control.rs`

--- a/docs/releases/2025-08-05-adapter-telemetry.md
+++ b/docs/releases/2025-08-05-adapter-telemetry.md
@@ -1,0 +1,30 @@
+# Release notes – Adapter builders & telemetry orchestration
+
+**Date:** 2025-08-05  \
+**Audience:** Product engineering, observability, and platform reliability stakeholders
+
+## Summary
+
+We rolled out end-to-end documentation and inline guidance for the new selection control builder stack:
+
+- README and architecture guides now describe how `SelectionControlAttributes::builder`, `SelectionControlTelemetry`, and `TelemetryHooks` collaborate to deliver immutable descriptors and automation markers across adapters.
+- Maintainer-facing rustdoc was expanded so future builder enhancements automatically inherit enterprise telemetry defaults and keep managed identifiers authoritative.
+- Stakeholders receive an explicit integration playbook that minimises repetitive adapter wiring while maximising observability parity across SSR, CSR, and multi-framework deployments.
+
+## Impact
+
+- **Automation:** Central platforms can register telemetry delegates and analytics IDs once; builder outputs mirror those settings across React, Yew, Leptos, Sycamore, and bespoke adapters without manual patches.
+- **Scalability:** Immutable descriptors and context-rich telemetry payloads reduce divergence between renderers, unblocking horizontal scaling in distributed UI surfaces.
+- **Operational excellence:** Enhanced inline guidance and changelog coverage clarify migration steps, testing expectations, and failure handling so release trains remain predictable.
+
+## Required actions
+
+- Review the updated [adapter builders and telemetry orchestration](../../README.md#adapter-builders-and-telemetry-orchestration) section to align custom adapters with the new workflow.
+- Platform observability teams should register shared `TelemetryHooks` instances during application bootstrap and rely on the descriptors to surface analytics/focus/change/commit events.
+- Ensure CI pipelines invoke `cargo xtask accessibility-audit` alongside existing Rust/wasm smoke tests so documentation drift is caught automatically.
+
+## Next steps
+
+- Monitor telemetry streams for consistent analytics identifiers across frameworks and report anomalies to the platform guild.
+- Evaluate extending the builder workflow to input primitives so form telemetry matches the rigor now available for selection controls.
+- Continue migrating remaining adapters to the descriptor helpers to eliminate legacy HTML string manipulation.


### PR DESCRIPTION
## Summary
- document the adapter builder + telemetry workflow in the README and architecture guide so integrators can wire the new helpers consistently
- expand rustdoc guidance for the telemetry helpers and capture the changes in dedicated release notes for stakeholders
- update the changelog with migration details and test expectations for the new builders

## Testing
- cargo xtask accessibility-audit

------
https://chatgpt.com/codex/tasks/task_e_68e116e4fce8832ea5375253bb1b80ec