### PR TITLE
Add Leptos selection controls example with telemetry instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,6 +3739,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "selection-controls-leptos"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "gloo-console 0.2.3",
+ "leptos",
+ "rustic-ui-headless",
+ "rustic-ui-material",
+ "rustic-ui-styled-engine",
+ "rustic-ui-system",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "selection-controls-yew"
+version = "0.1.0"
+dependencies = [
+ "gloo-console 0.2.3",
+ "rustic-ui-headless",
+ "rustic-ui-material",
+ "rustic-ui-styled-engine",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "yew",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "examples/inputs-slider-yew",
     "examples/feedback-progress-leptos",
     "examples/selection-controls-yew",
+    "examples/selection-controls-leptos",
     "examples/forms-input-base-shared",
     "examples/forms-input-base-yew",
     "examples/forms-input-base-leptos",

--- a/examples/selection-controls-leptos/Cargo.toml
+++ b/examples/selection-controls-leptos/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "selection-controls-leptos"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+description = "Enterprise-grade Leptos demo wiring RusticUI selection controls with deterministic telemetry"
+
+[lib]
+name = "selection_controls_leptos"
+path = "src/lib.rs"
+crate-type = ["rlib", "cdylib"]
+
+[[bin]]
+name = "selection-controls-leptos"
+path = "src/main.rs"
+
+[features]
+default = ["csr"]
+csr = ["leptos/csr"]
+hydrate = ["leptos/hydrate"]
+ssr = ["tokio", "leptos/ssr"]
+
+[dependencies]
+leptos = { workspace = true, default-features = false }
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", default-features = false, features = ["forms"] }
+rustic-ui-material = { path = "../../crates/rustic-ui-material", default-features = false, features = ["forms", "leptos"] }
+rustic-ui-styled-engine = { path = "../../crates/rustic-ui-styled-engine" }
+rustic-ui-system = { path = "../../crates/rustic-ui-system" }
+tokio = { workspace = true, optional = true }
+gloo-console = "0.2"
+wasm-bindgen = { workspace = true, optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true
+leptos = { workspace = true, default-features = false, features = ["csr", "hydrate", "ssr"] }
+console_error_panic_hook = "0.1"
+
+[package.metadata.leptos]
+output-name = "selection-controls-leptos"
+site-root = "target/leptos-site"
+site-pkg-dir = "pkg"
+assets-dir = "static"
+lib-package = "selection-controls-leptos"
+
+[package.metadata.leptos.watch]
+ignore = ["target", "static"]
+

--- a/examples/selection-controls-leptos/Justfile
+++ b/examples/selection-controls-leptos/Justfile
@@ -1,0 +1,26 @@
+# Enterprise automation harness for the Leptos selection controls example.
+# All tasks are intentionally idempotent and avoid manual configuration so
+# contributors can build and test the demo in a single command even on clean
+# CI agents.
+
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+# Build both the SSR binary and the WASM package ready for hydration.
+just build-all:
+    cargo leptos build --release --features ssr
+
+# Serve the example with SSR + CSR handoff using cargo-leptos' dev server.
+just serve:
+    cargo leptos serve --features ssr
+
+# Run the full test matrix covering host and wasm32 smoke tests.
+just test-all:
+    cargo test --features ssr
+    cargo test --target wasm32-unknown-unknown --features hydrate
+
+# Format and lint the Rust sources (delegates to cargo fmt/clippy for now but
+# keeps the hook in one place for future automation upgrades).
+just lint:
+    cargo fmt
+    cargo clippy --features ssr -- -D warnings
+

--- a/examples/selection-controls-leptos/README.md
+++ b/examples/selection-controls-leptos/README.md
@@ -1,137 +1,72 @@
-# Selection Controls with Leptos
+# RusticUI Selection Controls — Leptos Edition
 
-Typed Leptos components expose the same telemetry lifecycle as the Yew/Dioxus
-adapters while remaining hydration safe – no more unchecked HTML fragments.
+This example crate ports the documented checkbox, switch, and radio guidance
+into fully wired Leptos components.  Every control surfaces deterministic
+telemetry hooks, automation IDs, and change/focus handlers so observability
+pipelines stay aligned between SSR and CSR.
 
-```rust
-use leptos::*;
-use rustic_ui_headless::{
-    checkbox::CheckboxState,
-    radio::{RadioGroupState, RadioOrientation},
-    switch::SwitchState,
-};
-use rustic_ui_material::{TelemetryContext, TelemetryHooks};
-use rustic_ui_material::checkbox::{
-    CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
-    leptos::{LeptosCheckbox, LeptosCheckboxProps},
-};
-use rustic_ui_material::radio::{
-    RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent,
-    leptos::{LeptosRadioGroup, LeptosRadioGroupProps},
-};
-use rustic_ui_material::switch::{
-    SwitchChangeEvent, SwitchProps, SwitchTelemetryEvent,
-    leptos::{LeptosSwitch, LeptosSwitchProps},
-};
-use std::{rc::Rc, sync::Arc};
+## Running the demo
 
-fn telemetry(channel: &'static str) -> TelemetryHooks {
-    let mut hooks = TelemetryHooks::default();
-    hooks.analytics_id = Some(format!("selection-controls.leptos.{channel}"));
-    hooks.automation_id = Some(format!("automation.selection-controls.{channel}"));
-    let channel_label = format!("selection_controls::{channel}");
-    hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
-        leptos::logging::log!(
-            "telemetry::render channel={} component={} analytics={:?} automation={:?}",
-            channel_label,
-            context.component,
-            context.analytics_id,
-            context.automation_id,
-        );
-    }));
-    hooks
-}
+The project relies on [`cargo-leptos`](https://github.com/leptos-rs/cargo-leptos)
+for an ergonomic SSR + WASM workflow.  Install it once (`cargo install
+cargo-leptos`) and then use the bundled [`Justfile`](Justfile) recipes:
 
-#[component]
-pub fn SelectionControls() -> impl IntoView {
-    let checkbox_state = CheckboxState::uncontrolled(false, true);
-    let switch_state = SwitchState::uncontrolled(false, false);
-    let radio_state = RadioGroupState::uncontrolled(
-        vec!["Visa".into(), "Mastercard".into(), "Amex".into()],
-        false,
-        RadioOrientation::Vertical,
-        Some(1),
-    );
+```bash
+# Build release artifacts for both targets (native + wasm32-unknown-unknown)
+just build-all
 
-    let checkbox_props = CheckboxProps {
-        label: "Save card".into(),
-        telemetry: telemetry("checkbox"),
-    };
-    let switch_props = SwitchProps {
-        label: "Enable auto-pay".into(),
-        telemetry: telemetry("switch"),
-    };
-    let radio_props = RadioGroupProps::from_state(&radio_state)
-        .with_telemetry(telemetry("radio"));
-
-    let checkbox_delegate: Rc<dyn Fn(CheckboxTelemetryEvent)> = Rc::new(|event| {
-        leptos::logging::log!("checkbox telemetry: {:?}", event);
-    });
-    let switch_delegate: Rc<dyn Fn(SwitchTelemetryEvent)> = Rc::new(|event| {
-        leptos::logging::log!("switch telemetry: {:?}", event);
-    });
-    let radio_delegate: Rc<dyn Fn(RadioTelemetryEvent)> = Rc::new(|event| {
-        leptos::logging::log!("radio telemetry: {:?}", event);
-    });
-
-    let checkbox_component = LeptosCheckboxProps {
-        checkbox: checkbox_props.clone(),
-        state: checkbox_state.clone(),
-        on_change: Some(Rc::new(|event: CheckboxChangeEvent| {
-            leptos::logging::log!(
-                "checkbox::change next={} disabled={}",
-                event.next,
-                event.disabled,
-            );
-        })),
-        on_focus: None,
-        on_blur: None,
-        on_key: None,
-        telemetry_delegate: Some(checkbox_delegate.clone()),
-    };
-    let switch_component = LeptosSwitchProps {
-        switch: switch_props.clone(),
-        state: switch_state.clone(),
-        on_change: Some(Rc::new(|event: SwitchChangeEvent| {
-            leptos::logging::log!(
-                "switch::change next={} disabled={}",
-                event.next,
-                event.disabled,
-            );
-        })),
-        on_focus: None,
-        on_blur: None,
-        on_key: None,
-        telemetry_delegate: Some(switch_delegate.clone()),
-    };
-    let radio_component = {
-        let mut props = LeptosRadioGroupProps::new(radio_props.clone(), radio_state.clone());
-        props.telemetry = telemetry("radio.component");
-        props.on_change = Some(Rc::new(|event: RadioChangeEvent| {
-            leptos::logging::log!(
-                "radio::change previous={:?} next={} label={}",
-                event.previous,
-                event.next,
-                event.label,
-            );
-        }));
-        props.on_focus = None;
-        props.on_blur = None;
-        props.on_key = None;
-        props.telemetry_delegate = Some(radio_delegate.clone());
-        props
-    };
-
-    view! {
-        <div>
-            {LeptosCheckbox(checkbox_component)}
-            {LeptosSwitch(switch_component)}
-            {LeptosRadioGroup(radio_component)}
-        </div>
-    }
-}
+# Launch the live dev server with SSR + hydration hand-off
+just serve
 ```
 
-> **Compile-time note:** Add `rustic-ui-material` with the `leptos` feature and
-> enable the matching `forms` feature on `rustic-ui-headless` before running
-> `cargo leptos build` or `cargo check` inside an example crate.
+Both commands automatically activate the `ssr` feature so telemetry delegates
+hydrate with the same automation/analytics identifiers emitted during server
+rendering.
+
+## Testing
+
+```bash
+# Host tests: SSR snapshots + telemetry sequencing
+just test-all
+```
+
+`just test-all` runs `cargo test` twice: once on the host (covering SSR
+snapshots and delegate ordering) and once with the `wasm32-unknown-unknown`
+target to smoke test hydration determinism inside a browser runner.
+
+The WASM suite ensures:
+
+* `data-automation-id` attributes survive hydration.
+* `initial-state` telemetry records fire before any `render` events per channel.
+
+## Telemetry expectations
+
+Each control channel advertises stable identifiers:
+
+* **Analytics IDs** – `selection-controls.leptos.<channel>`
+* **Automation IDs** – `automation.selection-controls.<channel>`
+
+Telemetry delegates emit the following phases in strict order, which is
+validated in both test suites:
+
+1. `initial-state` – snapshot recorded before rendering for CI diffing.
+2. `render` – fired from `TelemetryHooks::on_render` during SSR/CSR.
+3. `telemetry` – per-control delegate invoked before user callbacks.
+4. `change-handler`/`focus`/`blur`/`key` – business callbacks invoked after
+   telemetry so state transitions remain deterministic.
+
+Use the [`TelemetryRecorder`](src/lib.rs) utility in your own harnesses to
+assert event order or feed data into analytics stacks without re-implementing
+wiring logic.
+
+## Project layout
+
+* [`src/lib.rs`](src/lib.rs) – Components, telemetry utilities, and SSR
+  descriptors with exhaustive inline documentation.
+* [`src/main.rs`](src/main.rs) – Feature-gated entry points for SSR and CSR.
+* [`tests/wasm.rs`](tests/wasm.rs) – Browser-driven smoke tests for hydration
+  determinism.
+* [`Justfile`](Justfile) – One-touch automation for builds, servers, and tests.
+
+The crate is workspace-aware and opts into RusticUI's shared dependency
+versions, keeping maintenance automated across the monorepo.

--- a/examples/selection-controls-leptos/src/lib.rs
+++ b/examples/selection-controls-leptos/src/lib.rs
@@ -1,0 +1,960 @@
+use std::fmt;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use leptos::prelude::*;
+use rustic_ui_headless::checkbox::{CheckboxState, CheckboxValue};
+use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
+use rustic_ui_headless::switch::SwitchState;
+use rustic_ui_material::checkbox::{
+    leptos::{LeptosCheckbox, LeptosCheckboxProps},
+    CheckboxChangeEvent, CheckboxFocusEvent, CheckboxKeyEvent, CheckboxProps,
+    CheckboxTelemetryEvent,
+};
+use rustic_ui_material::radio::{
+    leptos::{LeptosRadioGroup, LeptosRadioGroupProps},
+    RadioChangeEvent, RadioFocusEvent, RadioGroupProps, RadioKeyEvent, RadioTelemetryEvent,
+};
+use rustic_ui_material::selection_control::{
+    RadioGroupAttributes, RadioOptionAttributes, SelectionControlDescriptor,
+    SelectionControlTelemetry, SelectionControlThemeTokens,
+};
+use rustic_ui_material::switch::{
+    leptos::{LeptosSwitch, LeptosSwitchProps},
+    SwitchChangeEvent, SwitchFocusEvent, SwitchProps, SwitchTelemetryEvent,
+};
+use rustic_ui_material::telemetry::{
+    instrument_render, TelemetryAnalyticsPayload, TelemetryCommitPayload, TelemetryContext,
+    TelemetryError, TelemetryFocusPayload, TelemetryHooks, TelemetryStateChangePayload,
+};
+use rustic_ui_styled_engine::{css, Style};
+
+/// Structured capture of instrumentation emitted while the demos execute.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordedEvent {
+    /// Logical control channel (e.g. `checkbox.controlled`).
+    pub channel: String,
+    /// Lifecycle phase or hook that triggered this record.
+    pub phase: String,
+    /// Human readable payload extracted from telemetry objects.
+    pub detail: String,
+}
+
+impl fmt::Display for RecordedEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{channel}] {phase}: {detail}",
+            channel = self.channel,
+            phase = self.phase,
+            detail = self.detail
+        )
+    }
+}
+
+/// Thread-safe recorder shared between the host smoke tests and WASM harnesses.
+#[derive(Clone, Default)]
+pub struct TelemetryRecorder {
+    events: Arc<Mutex<Vec<RecordedEvent>>>,
+}
+
+impl TelemetryRecorder {
+    /// Construct a new recorder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a named channel used to tag analytics hooks.
+    #[must_use]
+    pub fn channel(&self, name: impl Into<String>) -> TelemetryChannel {
+        TelemetryChannel::new(name.into(), self.clone())
+    }
+
+    /// Snapshot the recorded events in insertion order.
+    pub fn events(&self) -> Vec<RecordedEvent> {
+        self.events.lock().expect("recorder mutex poisoned").clone()
+    }
+
+    fn push(&self, event: RecordedEvent) {
+        self.events
+            .lock()
+            .expect("recorder mutex poisoned")
+            .push(event);
+    }
+}
+
+#[inline]
+fn console_trace(message: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        gloo_console::log!(message);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        println!("{message}");
+    }
+}
+
+/// Wrapper that centralises telemetry ID derivation and hook wiring.
+#[derive(Clone)]
+pub struct TelemetryChannel {
+    name: String,
+    recorder: TelemetryRecorder,
+}
+
+impl TelemetryChannel {
+    fn new(name: String, recorder: TelemetryRecorder) -> Self {
+        Self { name, recorder }
+    }
+
+    /// Fully-qualified analytics identifier used across SSR and hydration.
+    #[must_use]
+    pub fn analytics_id(&self) -> String {
+        format!("selection-controls.leptos.{}", self.name)
+    }
+
+    /// Automation identifier mirrored to data attributes for QA hooks.
+    #[must_use]
+    pub fn automation_id(&self) -> String {
+        format!("automation.selection-controls.{}", self.name)
+    }
+
+    fn record(&self, phase: impl Into<String>, detail: impl Into<String>) {
+        let phase = phase.into();
+        let detail = detail.into();
+        let event = RecordedEvent {
+            channel: self.name.clone(),
+            phase: phase.clone(),
+            detail: detail.clone(),
+        };
+        console_trace(&format!("{event}"));
+        self.recorder.push(event);
+    }
+
+    /// Build [`TelemetryHooks`] instrumented with comprehensive callbacks.
+    #[must_use]
+    pub fn hooks(&self) -> TelemetryHooks {
+        let mut hooks = TelemetryHooks::default();
+        hooks.analytics_id = Some(self.analytics_id());
+        hooks.automation_id = Some(self.automation_id());
+
+        let render_channel = self.clone();
+        hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
+            render_channel.record(
+                "render",
+                format!(
+                    "component={} analytics={:?} automation={:?} attrs={:?}",
+                    context.component,
+                    context.analytics_id,
+                    context.automation_id,
+                    context
+                        .descriptor
+                        .as_ref()
+                        .map(|descriptor| descriptor.attributes.clone()),
+                ),
+            );
+        }));
+
+        let analytics_channel = self.clone();
+        hooks.on_analytics = Some(Arc::new(
+            move |context: TelemetryContext, payload: TelemetryAnalyticsPayload| {
+                analytics_channel.record(
+                    "analytics",
+                    format!(
+                        "component={} channel={} props={:?}",
+                        context.component, payload.channel, payload.properties
+                    ),
+                );
+            },
+        ));
+
+        let focus_channel = self.clone();
+        hooks.on_focus_transition = Some(Arc::new(
+            move |context: TelemetryContext, payload: TelemetryFocusPayload| {
+                focus_channel.record(
+                    "focus-transition",
+                    format!(
+                        "component={} focused={} props={:?}",
+                        context.component, payload.focused, payload.properties
+                    ),
+                );
+            },
+        ));
+
+        let state_channel = self.clone();
+        hooks.on_state_change = Some(Arc::new(
+            move |context: TelemetryContext, payload: TelemetryStateChangePayload| {
+                state_channel.record(
+                    "state-change",
+                    format!(
+                        "component={} previous={} next={} props={:?}",
+                        context.component, payload.previous, payload.next, payload.properties
+                    ),
+                );
+            },
+        ));
+
+        let commit_channel = self.clone();
+        hooks.on_commit_ack = Some(Arc::new(
+            move |context: TelemetryContext, payload: TelemetryCommitPayload| {
+                commit_channel.record(
+                    "commit",
+                    format!(
+                        "component={} correlation={:?} props={:?}",
+                        context.component, payload.correlation_id, payload.properties
+                    ),
+                );
+            },
+        ));
+
+        let error_channel = self.clone();
+        hooks.on_error = Some(Arc::new(
+            move |context: TelemetryContext, error: TelemetryError| {
+                error_channel.record(
+                    "error",
+                    format!("component={} message={}", context.component, error.message),
+                );
+            },
+        ));
+
+        hooks
+    }
+
+    /// Delegate that mirrors checkbox telemetry payloads into the recorder.
+    #[must_use]
+    pub fn checkbox_delegate(&self) -> Rc<dyn Fn(CheckboxTelemetryEvent)> {
+        let channel = self.clone();
+        Rc::new(move |event: CheckboxTelemetryEvent| {
+            channel.record("telemetry", format!("checkbox::{event:?}"));
+        })
+    }
+
+    /// Delegate that mirrors switch telemetry payloads into the recorder.
+    #[must_use]
+    pub fn switch_delegate(&self) -> Rc<dyn Fn(SwitchTelemetryEvent)> {
+        let channel = self.clone();
+        Rc::new(move |event: SwitchTelemetryEvent| {
+            channel.record("telemetry", format!("switch::{event:?}"));
+        })
+    }
+
+    /// Delegate that mirrors radio telemetry payloads into the recorder.
+    #[must_use]
+    pub fn radio_delegate(&self) -> Rc<dyn Fn(RadioTelemetryEvent)> {
+        let channel = self.clone();
+        Rc::new(move |event: RadioTelemetryEvent| {
+            channel.record("telemetry", format!("radio::{event:?}"));
+        })
+    }
+}
+
+/// Record a checkbox change event in the shared telemetry channel.
+pub fn record_checkbox_change(channel: &TelemetryChannel, event: &CheckboxChangeEvent) {
+    channel.record(
+        "change-handler",
+        format!(
+            "previous={:?} next={:?} disabled={} label={}",
+            event.previous, event.next, event.disabled, event.label
+        ),
+    );
+}
+
+/// Record a checkbox focus transition.
+pub fn record_checkbox_focus(channel: &TelemetryChannel, event: &CheckboxFocusEvent) {
+    let phase = if event.focused { "focus" } else { "blur" };
+    channel.record(
+        phase,
+        format!(
+            "checked={:?} disabled={} label={}",
+            event.checked, event.disabled, event.label
+        ),
+    );
+}
+
+/// Record a checkbox keyboard event.
+pub fn record_checkbox_key(channel: &TelemetryChannel, event: &CheckboxKeyEvent) {
+    channel.record(
+        "key",
+        format!(
+            "key={:?} previous={:?} next={:?} disabled={} label={}",
+            event.key, event.previous, event.next, event.disabled, event.label
+        ),
+    );
+}
+
+/// Record a switch change event in the shared telemetry channel.
+pub fn record_switch_change(channel: &TelemetryChannel, event: &SwitchChangeEvent) {
+    channel.record(
+        "change-handler",
+        format!(
+            "previous={} next={} disabled={} label={}",
+            event.previous, event.next, event.disabled, event.label
+        ),
+    );
+}
+
+/// Record a switch focus transition.
+pub fn record_switch_focus(channel: &TelemetryChannel, event: &SwitchFocusEvent) {
+    let phase = if event.focused { "focus" } else { "blur" };
+    channel.record(
+        phase,
+        format!(
+            "on={} disabled={} label={}",
+            event.on, event.disabled, event.label
+        ),
+    );
+}
+
+/// Record a radio telemetry change event.
+pub fn record_radio_change(channel: &TelemetryChannel, event: &RadioChangeEvent) {
+    channel.record(
+        "change-handler",
+        format!(
+            "previous={:?} next={} disabled={} label={}",
+            event.previous, event.next, event.disabled, event.label
+        ),
+    );
+}
+
+/// Record a radio focus transition.
+pub fn record_radio_focus(channel: &TelemetryChannel, event: &RadioFocusEvent) {
+    let phase = if event.focused { "focus" } else { "blur" };
+    channel.record(
+        phase,
+        format!(
+            "index={} disabled={} label={}",
+            event.index, event.disabled, event.label
+        ),
+    );
+}
+
+/// Record a radio keyboard interaction.
+pub fn record_radio_key(channel: &TelemetryChannel, event: &RadioKeyEvent) {
+    channel.record(
+        "key",
+        format!(
+            "key={:?} previous={:?} next={:?} disabled={} label={}",
+            event.key, event.previous, event.next, event.disabled, event.label
+        ),
+    );
+}
+
+fn checkbox_props(label: &str, channel: &TelemetryChannel) -> CheckboxProps {
+    CheckboxProps::new(label, channel.hooks())
+}
+
+fn switch_props(label: &str, channel: &TelemetryChannel) -> SwitchProps {
+    SwitchProps::new(label, channel.hooks())
+}
+
+fn radio_props(state: &RadioGroupState, channel: &TelemetryChannel) -> RadioGroupProps {
+    RadioGroupProps::from_state(state, channel.hooks())
+}
+
+fn checkbox_state_summary(state: &CheckboxState) -> String {
+    format!(
+        "checked={:?} disabled={} focus_visible={}",
+        state.checked(),
+        state.disabled(),
+        state.focus_visible()
+    )
+}
+
+fn switch_state_summary(state: &SwitchState) -> String {
+    format!(
+        "on={} disabled={} focus_visible={}",
+        state.on(),
+        state.disabled(),
+        state.focus_visible()
+    )
+}
+
+fn radio_state_summary(state: &RadioGroupState) -> String {
+    format!(
+        "selected={:?} focus_visible={:?} disabled={}",
+        state.selected_index(),
+        state.focus_visible_index(),
+        state.disabled()
+    )
+}
+
+/// Leptos component showcasing the selection controls with full telemetry wiring.
+#[component]
+pub fn SelectionControlsDemo(
+    /// Optional recorder used by unit tests/automation harnesses. When not
+    /// provided the component provisions its own recorder so integration
+    /// environments still capture deterministic traces.
+    #[prop(optional)]
+    recorder: Option<TelemetryRecorder>,
+) -> impl IntoView {
+    let recorder = recorder.unwrap_or_else(TelemetryRecorder::new);
+
+    // Dedicated telemetry channels per control + ownership mode. These are all
+    // cheap clones of the recorder and keep render instrumentation deterministic.
+    let checkbox_controlled_channel = recorder.channel("checkbox.controlled");
+    let checkbox_uncontrolled_channel = recorder.channel("checkbox.uncontrolled");
+    let switch_controlled_channel = recorder.channel("switch.controlled");
+    let switch_uncontrolled_channel = recorder.channel("switch.uncontrolled");
+    let radio_controlled_channel = recorder.channel("radio.controlled");
+    let radio_uncontrolled_channel = recorder.channel("radio.uncontrolled");
+
+    let checkbox_controlled =
+        create_rw_signal(CheckboxState::controlled(false, CheckboxValue::Off));
+    let checkbox_uncontrolled =
+        create_rw_signal(CheckboxState::uncontrolled(false, CheckboxValue::On));
+    let switch_controlled = create_rw_signal(SwitchState::controlled(false, false));
+    let switch_uncontrolled = create_rw_signal(SwitchState::uncontrolled(false, true));
+    let radio_controlled = create_rw_signal(RadioGroupState::controlled(
+        vec!["Email".into(), "SMS".into(), "Push".into()],
+        false,
+        RadioOrientation::Horizontal,
+        Some(0),
+    ));
+    let radio_uncontrolled = create_rw_signal(RadioGroupState::uncontrolled(
+        vec!["Daily".into(), "Weekly".into(), "Monthly".into()],
+        false,
+        RadioOrientation::Vertical,
+        Some(1),
+    ));
+
+    // Controlled checkbox handlers propagate telemetry before synchronising state.
+    let checkbox_controlled_change: Rc<dyn Fn(CheckboxChangeEvent)> = {
+        let channel = checkbox_controlled_channel.clone();
+        let state = checkbox_controlled;
+        Rc::new(move |event: CheckboxChangeEvent| {
+            record_checkbox_change(&channel, &event);
+            state.update(|state| {
+                *state = CheckboxState::controlled(event.disabled, event.next);
+                if event.disabled {
+                    state.set_disabled(true);
+                }
+            });
+        })
+    };
+    let checkbox_controlled_focus: Rc<dyn Fn(CheckboxFocusEvent)> = {
+        let channel = checkbox_controlled_channel.clone();
+        let state = checkbox_controlled;
+        Rc::new(move |event: CheckboxFocusEvent| {
+            record_checkbox_focus(&channel, &event);
+            state.update(|state| {
+                if event.focused {
+                    state.focus();
+                } else {
+                    state.blur();
+                }
+            });
+        })
+    };
+    let checkbox_controlled_key: Rc<dyn Fn(CheckboxKeyEvent)> = {
+        let channel = checkbox_controlled_channel.clone();
+        Rc::new(move |event: CheckboxKeyEvent| {
+            record_checkbox_key(&channel, &event);
+        })
+    };
+
+    // Uncontrolled checkbox owns its state and mutates through the headless API.
+    let checkbox_uncontrolled_change: Rc<dyn Fn(CheckboxChangeEvent)> = {
+        let channel = checkbox_uncontrolled_channel.clone();
+        let state = checkbox_uncontrolled;
+        Rc::new(move |event: CheckboxChangeEvent| {
+            record_checkbox_change(&channel, &event);
+            state.update(|state| {
+                state.sync_checked(event.next);
+            });
+        })
+    };
+    let checkbox_uncontrolled_focus: Rc<dyn Fn(CheckboxFocusEvent)> = {
+        let channel = checkbox_uncontrolled_channel.clone();
+        let state = checkbox_uncontrolled;
+        Rc::new(move |event: CheckboxFocusEvent| {
+            record_checkbox_focus(&channel, &event);
+            state.update(|state| {
+                if event.focused {
+                    state.focus();
+                } else {
+                    state.blur();
+                }
+            });
+        })
+    };
+    let checkbox_uncontrolled_key: Rc<dyn Fn(CheckboxKeyEvent)> = {
+        let channel = checkbox_uncontrolled_channel.clone();
+        Rc::new(move |event: CheckboxKeyEvent| {
+            record_checkbox_key(&channel, &event);
+        })
+    };
+
+    let switch_controlled_change: Rc<dyn Fn(SwitchChangeEvent)> = {
+        let channel = switch_controlled_channel.clone();
+        let state = switch_controlled;
+        Rc::new(move |event: SwitchChangeEvent| {
+            record_switch_change(&channel, &event);
+            state.update(|state| {
+                *state = SwitchState::controlled(event.disabled, event.next);
+                if event.disabled {
+                    state.set_disabled(true);
+                }
+            });
+        })
+    };
+    let switch_controlled_focus: Rc<dyn Fn(SwitchFocusEvent)> = {
+        let channel = switch_controlled_channel.clone();
+        let state = switch_controlled;
+        Rc::new(move |event: SwitchFocusEvent| {
+            record_switch_focus(&channel, &event);
+            state.update(|state| {
+                if event.focused {
+                    state.focus();
+                } else {
+                    state.blur();
+                }
+            });
+        })
+    };
+
+    let switch_uncontrolled_change: Rc<dyn Fn(SwitchChangeEvent)> = {
+        let channel = switch_uncontrolled_channel.clone();
+        let state = switch_uncontrolled;
+        Rc::new(move |event: SwitchChangeEvent| {
+            record_switch_change(&channel, &event);
+            state.update(|state| {
+                state.sync_on(event.next);
+            });
+        })
+    };
+    let switch_uncontrolled_focus: Rc<dyn Fn(SwitchFocusEvent)> = {
+        let channel = switch_uncontrolled_channel.clone();
+        let state = switch_uncontrolled;
+        Rc::new(move |event: SwitchFocusEvent| {
+            record_switch_focus(&channel, &event);
+            state.update(|state| {
+                if event.focused {
+                    state.focus();
+                } else {
+                    state.blur();
+                }
+            });
+        })
+    };
+
+    let radio_controlled_change: Rc<dyn Fn(RadioChangeEvent)> = {
+        let channel = radio_controlled_channel.clone();
+        let state = radio_controlled;
+        Rc::new(move |event: RadioChangeEvent| {
+            record_radio_change(&channel, &event);
+            state.update(|state| {
+                state.sync_selected(Some(event.next));
+            });
+        })
+    };
+    let radio_controlled_focus: Rc<dyn Fn(RadioFocusEvent)> = {
+        let channel = radio_controlled_channel.clone();
+        let state = radio_controlled;
+        Rc::new(move |event: RadioFocusEvent| {
+            record_radio_focus(&channel, &event);
+            state.update(|state| {
+                if event.focused {
+                    state.focus(event.index);
+                } else {
+                    state.blur();
+                }
+            });
+        })
+    };
+    let radio_controlled_key: Rc<dyn Fn(RadioKeyEvent)> = {
+        let channel = radio_controlled_channel.clone();
+        Rc::new(move |event: RadioKeyEvent| {
+            record_radio_key(&channel, &event);
+        })
+    };
+
+    let radio_uncontrolled_change: Rc<dyn Fn(RadioChangeEvent)> = {
+        let channel = radio_uncontrolled_channel.clone();
+        let state = radio_uncontrolled;
+        Rc::new(move |event: RadioChangeEvent| {
+            record_radio_change(&channel, &event);
+            state.update(|state| {
+                state.sync_selected(Some(event.next));
+            });
+        })
+    };
+    let radio_uncontrolled_focus: Rc<dyn Fn(RadioFocusEvent)> = {
+        let channel = radio_uncontrolled_channel.clone();
+        let state = radio_uncontrolled;
+        Rc::new(move |event: RadioFocusEvent| {
+            record_radio_focus(&channel, &event);
+            state.update(|state| {
+                if event.focused {
+                    state.focus(event.index);
+                } else {
+                    state.blur();
+                }
+            });
+        })
+    };
+    let radio_uncontrolled_key: Rc<dyn Fn(RadioKeyEvent)> = {
+        let channel = radio_uncontrolled_channel.clone();
+        Rc::new(move |event: RadioKeyEvent| {
+            record_radio_key(&channel, &event);
+        })
+    };
+
+    // Render instrumentation snapshot for deterministic logging in CI.
+    for (label, summary) in [
+        (
+            "checkbox.controlled",
+            checkbox_state_summary(&checkbox_controlled.get_untracked()),
+        ),
+        (
+            "checkbox.uncontrolled",
+            checkbox_state_summary(&checkbox_uncontrolled.get_untracked()),
+        ),
+        (
+            "switch.controlled",
+            switch_state_summary(&switch_controlled.get_untracked()),
+        ),
+        (
+            "switch.uncontrolled",
+            switch_state_summary(&switch_uncontrolled.get_untracked()),
+        ),
+        (
+            "radio.controlled",
+            radio_state_summary(&radio_controlled.get_untracked()),
+        ),
+        (
+            "radio.uncontrolled",
+            radio_state_summary(&radio_uncontrolled.get_untracked()),
+        ),
+    ] {
+        recorder.channel(label).record("initial-state", summary);
+    }
+
+    let checkbox_controlled_delegate = checkbox_controlled_channel.checkbox_delegate();
+    let checkbox_uncontrolled_delegate = checkbox_uncontrolled_channel.checkbox_delegate();
+    let switch_controlled_delegate = switch_controlled_channel.switch_delegate();
+    let switch_uncontrolled_delegate = switch_uncontrolled_channel.switch_delegate();
+    let radio_controlled_delegate = radio_controlled_channel.radio_delegate();
+    let radio_uncontrolled_delegate = radio_uncontrolled_channel.radio_delegate();
+
+    view! {
+        <main class="selection-controls-demo">
+            <section>
+                <h2>{"Checkboxes"}</h2>
+                <article>
+                    <h3>{"Controlled"}</h3>
+                    <p class="summary">{move || format!("State → {}", checkbox_state_summary(&checkbox_controlled.get()))}</p>
+                    <LeptosCheckbox
+                        LeptosCheckboxProps {
+                            checkbox: checkbox_props("Receive compliance updates", &checkbox_controlled_channel),
+                            state: checkbox_controlled.get_untracked(),
+                            on_change: Some(checkbox_controlled_change.clone()),
+                            on_focus: Some(checkbox_controlled_focus.clone()),
+                            on_blur: Some(checkbox_controlled_focus.clone()),
+                            on_key: Some(checkbox_controlled_key.clone()),
+                            telemetry_delegate: Some(checkbox_controlled_delegate.clone()),
+                        }
+                    />
+                </article>
+                <article>
+                    <h3>{"Uncontrolled"}</h3>
+                    <p class="summary">{move || format!("State → {}", checkbox_state_summary(&checkbox_uncontrolled.get()))}</p>
+                    <LeptosCheckbox
+                        LeptosCheckboxProps {
+                            checkbox: checkbox_props("Enable audit trail", &checkbox_uncontrolled_channel),
+                            state: checkbox_uncontrolled.get_untracked(),
+                            on_change: Some(checkbox_uncontrolled_change.clone()),
+                            on_focus: Some(checkbox_uncontrolled_focus.clone()),
+                            on_blur: Some(checkbox_uncontrolled_focus.clone()),
+                            on_key: Some(checkbox_uncontrolled_key.clone()),
+                            telemetry_delegate: Some(checkbox_uncontrolled_delegate.clone()),
+                        }
+                    />
+                </article>
+            </section>
+
+            <section>
+                <h2>{"Switches"}</h2>
+                <article>
+                    <h3>{"Controlled"}</h3>
+                    <p class="summary">{move || format!("State → {}", switch_state_summary(&switch_controlled.get()))}</p>
+                    <LeptosSwitch
+                        LeptosSwitchProps {
+                            switch: switch_props("Escalate incidents automatically", &switch_controlled_channel),
+                            state: switch_controlled.get_untracked(),
+                            on_change: Some(switch_controlled_change.clone()),
+                            on_focus: Some(switch_controlled_focus.clone()),
+                            on_blur: Some(switch_controlled_focus.clone()),
+                            telemetry_delegate: Some(switch_controlled_delegate.clone()),
+                        }
+                    />
+                </article>
+                <article>
+                    <h3>{"Uncontrolled"}</h3>
+                    <p class="summary">{move || format!("State → {}", switch_state_summary(&switch_uncontrolled.get()))}</p>
+                    <LeptosSwitch
+                        LeptosSwitchProps {
+                            switch: switch_props("Mirror preferences from mobile", &switch_uncontrolled_channel),
+                            state: switch_uncontrolled.get_untracked(),
+                            on_change: Some(switch_uncontrolled_change.clone()),
+                            on_focus: Some(switch_uncontrolled_focus.clone()),
+                            on_blur: Some(switch_uncontrolled_focus.clone()),
+                            telemetry_delegate: Some(switch_uncontrolled_delegate.clone()),
+                        }
+                    />
+                </article>
+            </section>
+
+            <section>
+                <h2>{"Radio groups"}</h2>
+                <article>
+                    <h3>{"Controlled"}</h3>
+                    <p class="summary">{move || format!("State → {}", radio_state_summary(&radio_controlled.get()))}</p>
+                    <LeptosRadioGroup
+                        LeptosRadioGroupProps {
+                            group: radio_props(&radio_controlled.get_untracked(), &radio_controlled_channel),
+                            state: radio_controlled.get_untracked(),
+                            telemetry: radio_controlled_channel.hooks(),
+                            on_change: Some(radio_controlled_change.clone()),
+                            on_focus: Some(radio_controlled_focus.clone()),
+                            on_blur: Some(radio_controlled_focus.clone()),
+                            on_key: Some(radio_controlled_key.clone()),
+                            telemetry_delegate: Some(radio_controlled_delegate.clone()),
+                        }
+                    />
+                </article>
+                <article>
+                    <h3>{"Uncontrolled"}</h3>
+                    <p class="summary">{move || format!("State → {}", radio_state_summary(&radio_uncontrolled.get()))}</p>
+                    <LeptosRadioGroup
+                        LeptosRadioGroupProps {
+                            group: radio_props(&radio_uncontrolled.get_untracked(), &radio_uncontrolled_channel),
+                            state: radio_uncontrolled.get_untracked(),
+                            telemetry: radio_uncontrolled_channel.hooks(),
+                            on_change: Some(radio_uncontrolled_change.clone()),
+                            on_focus: Some(radio_uncontrolled_focus.clone()),
+                            on_blur: Some(radio_uncontrolled_focus.clone()),
+                            on_key: Some(radio_uncontrolled_key.clone()),
+                            telemetry_delegate: Some(radio_uncontrolled_delegate.clone()),
+                        }
+                    />
+                </article>
+            </section>
+        </main>
+    }
+}
+
+fn themed_checkbox_style() -> Style {
+    Style::new(css!(
+        r#"
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+    "#
+    ))
+    .expect("checkbox style should compile")
+}
+
+fn themed_switch_style() -> Style {
+    Style::new(css!(
+        r#"
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+    "#
+    ))
+    .expect("switch style should compile")
+}
+
+fn themed_radio_group_style() -> Style {
+    Style::new(css!(
+        r#"
+        display: grid;
+        gap: 0.75rem;
+    "#
+    ))
+    .expect("radio group style should compile")
+}
+
+fn themed_radio_option_style() -> Style {
+    Style::new(css!(
+        r#"
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+    "#
+    ))
+    .expect("radio option style should compile")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn checkbox_descriptor(
+    state: &CheckboxState,
+    channel: &TelemetryChannel,
+    label: &str,
+) -> SelectionControlDescriptor {
+    SelectionControlDescriptor::from_headless(
+        label,
+        themed_checkbox_style(),
+        state,
+        &SelectionControlThemeTokens::material_defaults().with_data("variant", "checkbox"),
+        &SelectionControlTelemetry::from(channel.hooks()),
+    )
+    .expect("checkbox descriptor should merge telemetry")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn switch_descriptor(
+    state: &SwitchState,
+    channel: &TelemetryChannel,
+    label: &str,
+) -> SelectionControlDescriptor {
+    SelectionControlDescriptor::from_headless(
+        label,
+        themed_switch_style(),
+        state,
+        &SelectionControlThemeTokens::material_defaults().with_data("variant", "switch"),
+        &SelectionControlTelemetry::from(channel.hooks()),
+    )
+    .expect("switch descriptor should merge telemetry")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn radio_attributes(state: &RadioGroupState, channel: &TelemetryChannel) -> RadioGroupAttributes {
+    let mut builder = RadioGroupAttributes::builder(
+        state,
+        themed_radio_group_style(),
+        themed_radio_option_style(),
+    );
+    builder
+        .group_theme(SelectionControlThemeTokens::material_defaults().with_data("variant", "radio"))
+        .telemetry(SelectionControlTelemetry::from(channel.hooks()));
+
+    for (index, option) in state.options().iter().enumerate() {
+        builder = builder.option(
+            RadioOptionAttributes::builder(option)
+                .label(option)
+                .automation_id(format!("{}.{index}", channel.automation_id()))
+                .analytics_id(format!("{}.{index}", channel.analytics_id()))
+                .build(),
+        );
+    }
+
+    builder.build()
+}
+
+/// SSR snapshots covering each ownership model so CI can diff hydration-ready markup.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn ssr_snapshots() -> Vec<String> {
+    let recorder = TelemetryRecorder::new();
+    let checkbox_channel = recorder.channel("checkbox.ssr");
+    let switch_channel = recorder.channel("switch.ssr");
+    let radio_channel = recorder.channel("radio.ssr");
+
+    let checkbox_controlled = CheckboxState::controlled(false, CheckboxValue::Off);
+    let checkbox_uncontrolled = CheckboxState::uncontrolled(false, CheckboxValue::On);
+    let switch_controlled = SwitchState::controlled(false, false);
+    let switch_uncontrolled = SwitchState::uncontrolled(false, true);
+    let radio_controlled = RadioGroupState::controlled(
+        vec!["Email".into(), "SMS".into()],
+        false,
+        RadioOrientation::Horizontal,
+        Some(0),
+    );
+    let radio_uncontrolled = RadioGroupState::uncontrolled(
+        vec!["Daily".into(), "Weekly".into()],
+        false,
+        RadioOrientation::Horizontal,
+        Some(1),
+    );
+
+    vec![
+        checkbox_descriptor(
+            &checkbox_controlled,
+            &checkbox_channel,
+            "Controlled checkbox",
+        )
+        .into_attributes()
+        .to_ssr_html(),
+        checkbox_descriptor(
+            &checkbox_uncontrolled,
+            &checkbox_channel,
+            "Uncontrolled checkbox",
+        )
+        .into_attributes()
+        .to_ssr_html(),
+        switch_descriptor(&switch_controlled, &switch_channel, "Controlled switch")
+            .into_attributes()
+            .to_ssr_html(),
+        switch_descriptor(&switch_uncontrolled, &switch_channel, "Uncontrolled switch")
+            .into_attributes()
+            .to_ssr_html(),
+        radio_attributes(&radio_controlled, &radio_channel).to_ssr_html(),
+        radio_attributes(&radio_uncontrolled, &radio_channel).to_ssr_html(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn ssr_markup_contains_automation_ids() {
+        let fragments = ssr_snapshots();
+        assert!(fragments
+            .iter()
+            .all(|html| html.contains("data-automation-id")));
+    }
+
+    #[test]
+    fn checkbox_telemetry_precedes_change_handler() {
+        let recorder = TelemetryRecorder::new();
+        let channel = recorder.channel("checkbox.test");
+        let hooks = channel.hooks();
+        instrument_render(&hooks, TelemetryContext::new("test.checkbox"), || ());
+
+        let change_event = CheckboxChangeEvent {
+            previous: CheckboxValue::Off,
+            next: CheckboxValue::On,
+            disabled: false,
+            analytics_id: Some(channel.analytics_id()),
+            automation_id: Some(channel.automation_id()),
+            label: "Test checkbox".into(),
+        };
+
+        (channel.checkbox_delegate())(CheckboxTelemetryEvent::Change(change_event.clone()));
+        record_checkbox_change(&channel, &change_event);
+
+        let events = recorder.events();
+        assert_eq!(events[0].phase, "render");
+        assert_eq!(events[1].phase, "telemetry");
+        assert_eq!(events[2].phase, "change-handler");
+    }
+
+    #[test]
+    fn radio_keyboard_sequence_is_tracked() {
+        let recorder = TelemetryRecorder::new();
+        let channel = recorder.channel("radio.test");
+        let hooks = channel.hooks();
+        instrument_render(&hooks, TelemetryContext::new("test.radio"), || ());
+
+        let key_event = RadioKeyEvent {
+            key: rustic_ui_headless::interaction::ControlKey::ArrowRight,
+            previous: Some(0),
+            next: Some(1),
+            disabled: false,
+            analytics_id: Some(channel.analytics_id()),
+            automation_id: Some(channel.automation_id()),
+            label: "Email".into(),
+        };
+
+        (channel.radio_delegate())(RadioTelemetryEvent::Key(key_event.clone()));
+        record_radio_key(&channel, &key_event);
+
+        let events = recorder.events();
+        assert_eq!(events[0].phase, "render");
+        assert_eq!(events[1].phase, "telemetry");
+        assert_eq!(events[2].phase, "key");
+    }
+}

--- a/examples/selection-controls-leptos/src/main.rs
+++ b/examples/selection-controls-leptos/src/main.rs
@@ -1,0 +1,48 @@
+#[cfg(all(feature = "ssr", not(target_arch = "wasm32")))]
+#[tokio::main]
+async fn main() {
+    use leptos::prelude::*;
+    use leptos::ssr::render_to_string;
+    use selection_controls_leptos::{ssr_snapshots, SelectionControlsDemo, TelemetryRecorder};
+
+    let recorder = TelemetryRecorder::new();
+    let render_recorder = recorder.clone();
+    let html = render_to_string(move || {
+        view! { <SelectionControlsDemo recorder=Some(render_recorder.clone()) /> }
+    })
+    .into_owned();
+
+    println!("=== Hydration shell ===\n{html}\n");
+
+    for (index, fragment) in ssr_snapshots().iter().enumerate() {
+        println!("=== Descriptor fragment #{index} ===\n{fragment}\n");
+    }
+
+    println!(
+        "=== Telemetry sequence ===\n{}",
+        recorder
+            .events()
+            .iter()
+            .map(|event| event.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+#[cfg(all(target_arch = "wasm32", any(feature = "csr", feature = "hydrate")))]
+fn main() {
+    use leptos::prelude::*;
+    use selection_controls_leptos::SelectionControlsDemo;
+
+    leptos::mount_to_body(|| view! { <SelectionControlsDemo/> });
+}
+
+#[cfg(all(
+    not(feature = "ssr"),
+    not(all(target_arch = "wasm32", any(feature = "csr", feature = "hydrate")))
+))]
+fn main() {
+    eprintln!(
+        "selection-controls-leptos binary requires either `--features ssr` for server mode or `--features csr`/`--features hydrate` for wasm."
+    );
+}

--- a/examples/selection-controls-leptos/tests/wasm.rs
+++ b/examples/selection-controls-leptos/tests/wasm.rs
@@ -1,0 +1,65 @@
+#![cfg(target_arch = "wasm32")]
+
+use std::collections::HashMap;
+
+use leptos::prelude::*;
+use selection_controls_leptos::{SelectionControlsDemo, TelemetryRecorder};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn initial_state_events_precede_render_on_hydration() {
+    console_error_panic_hook::set_once();
+
+    let recorder = TelemetryRecorder::new();
+    let recorder_clone = recorder.clone();
+
+    leptos::mount_to_body(
+        move || view! { <SelectionControlsDemo recorder=Some(recorder_clone.clone())/> },
+    );
+
+    let mut first_phase: HashMap<String, String> = HashMap::new();
+    for event in recorder.events() {
+        first_phase
+            .entry(event.channel.clone())
+            .or_insert(event.phase.clone());
+        if event.phase == "render" {
+            assert_eq!(
+                first_phase.get(&event.channel),
+                Some(&"initial-state".to_string())
+            );
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+fn automation_attributes_exist_in_dom() {
+    console_error_panic_hook::set_once();
+
+    let recorder = TelemetryRecorder::new();
+    let recorder_clone = recorder.clone();
+
+    leptos::mount_to_body(
+        move || view! { <SelectionControlsDemo recorder=Some(recorder_clone.clone())/> },
+    );
+
+    let document = web_sys::window().unwrap().document().unwrap();
+    let selector = "[data-automation-id^=automation.selection-controls]";
+    let matches = document.query_selector_all(selector).unwrap();
+    assert!(
+        matches.length() > 0,
+        "expected automation attributes to render"
+    );
+
+    // Ensure telemetry events were emitted in order for at least one channel.
+    let events = recorder.events();
+    let checkbox_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.channel == "checkbox.controlled")
+        .map(|event| event.phase.clone())
+        .collect();
+    assert!(checkbox_events
+        .windows(2)
+        .any(|window| window == ["initial-state", "render"]));
+}


### PR DESCRIPTION
## Summary
- add a fully instrumented `selection-controls-leptos` example crate with telemetry recorder utilities, SSR helpers, and wasm tests
- wire workspace metadata, automation Justfile, and README guidance for building, serving, and testing the Leptos demo
- register the new crate in the workspace manifest and expose SSR snapshots for deterministic inspection

## Testing
- `cargo test -p selection-controls-leptos --features ssr` *(fails: upstream leptos 0.6.12 crate expects DynBindings trait from newer macro release)*
- `cargo check -p selection-controls-leptos --features ssr` *(fails for same reason as above)*

------
https://chatgpt.com/codex/tasks/task_e_68e1584b6664832e955015d275dfbd9f