### PR TITLE
Add Dioxus selection controls example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,8 +129,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling",
+ "rustix 0.37.28",
+ "slab",
+ "socket2",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -145,6 +186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +201,36 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "atk"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39991bc421ddf72f70159011b323ff49b0f783cc676a7287c59453da2e2531cf"
+dependencies = [
+ "atk-sys",
+ "bitflags 1.3.2",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ad703eb64dc058024f0e57ccfa069e15a413b98dbd50a1a950e743b7f11148"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attribute-derive"
@@ -208,6 +285,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -253,6 +336,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
@@ -261,12 +350,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "piper",
 ]
 
 [[package]]
@@ -353,6 +461,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
+name = "cairo-rs"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3125b15ec28b84c238f6f476c6034016a5f6cc0221cb514ca46c532139fc97d"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48f4af05fabdcfa9658178e1326efa061853f040ce7d72e33af6885196f421"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +505,33 @@ checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -445,7 +605,7 @@ version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -458,10 +618,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cocoa"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -478,7 +684,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
- "convert_case",
+ "convert_case 0.6.0",
  "nom",
  "pathdiff",
  "serde",
@@ -523,6 +729,12 @@ checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -531,10 +743,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "core_maths"
@@ -600,6 +846,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +893,33 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 0.4.8",
+ "matches",
+ "phf 0.8.0",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -760,6 +1042,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +1122,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
 
 [[package]]
+name = "dioxus-desktop"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3ea0b1f6e64157b43e73d7ec3985df904c89ecf313bff93e06ff7d3b40d1cb"
+dependencies = [
+ "async-trait",
+ "core-foundation",
+ "dioxus-core",
+ "dioxus-hot-reload",
+ "dioxus-html",
+ "dioxus-interpreter-js",
+ "dunce",
+ "futures-channel",
+ "futures-util",
+ "infer",
+ "objc",
+ "objc_id",
+ "rfd",
+ "serde",
+ "serde_json",
+ "slab",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "urlencoding",
+ "webbrowser",
+ "wry",
+]
+
+[[package]]
 name = "dioxus-hooks"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,12 +1166,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-hot-reload"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d8c9e89e866a6b84b8ad696f0ff2f6f6563d2235eb99acc6952f19e516cc09"
+dependencies = [
+ "dioxus-core",
+ "dioxus-html",
+ "dioxus-rsx",
+ "interprocess-docfix",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dioxus-html"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "828a42a2d70688a2412a8538c8b5a5eceadf68f682f899dc4455a0169db39dfd"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-trait",
  "dioxus-core",
  "enumset",
@@ -856,6 +1195,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_repr",
+ "tokio",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -906,7 +1246,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fafaff75f50035078c2da45441ee61472fd0f335fa15b05170165eaf3479f0df"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-trait",
  "dioxus-core",
  "dioxus-html",
@@ -923,6 +1263,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "displaydoc"
@@ -946,6 +1292,27 @@ name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -1007,10 +1374,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "feedback-chips"
@@ -1040,6 +1446,16 @@ dependencies = [
  "rustic-ui-material",
  "rustic-ui-styled-engine",
  "rustic-ui-system",
+]
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1121,6 +1537,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1689,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1755,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "gdk"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9cb33da481c6c040404a11f8212d193889e9b435db2c14fd86987f630d3ce1"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3578c60dee9d029ad86593ed88cb40f35c1b83360e12498d055022385dd9a05"
+dependencies = [
+ "bitflags 1.3.2",
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3092cf797a5f1210479ea38070d9ae8a5b8e9f8f1be9f32f4643c529c7d70016"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76354f97a913e55b984759a997b693aa7dc71068c9e98bcce51aa167a0a5c5a"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkwayland-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4511710212ed3020b61a8622a37aa6f0dd2a84516575da92e9b96928dcbe83ba"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkx11-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa2bf8b5b8c414bc5d05e48b271896d0fd3ddb57464a3108438082da61de6af"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "libc",
+ "system-deps",
+ "x11",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1857,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1328,6 +1900,86 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gio"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1c84b4534a290a29160ef5c6eff2a9c95833111472e824fc5cb78b513dd092"
+dependencies = [
+ "bitflags 1.3.2",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b693b8e39d042a95547fc258a7b07349b1f0b48f4b2fa3108ba3c51c0b5229"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
+name = "glib"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16aa2475c9debed5a32832cb5ff2af5a3f9e1ab9e69df58eaadc1ab2004d6eba"
+dependencies = [
+ "bitflags 1.3.2",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1a9325847aa46f1e96ffea37611b9d51fc4827e67f79e7de502a297560a67b"
+dependencies = [
+ "anyhow",
+ "heck 0.4.1",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61a4f46316d06bfa33a7ac22df6f0524c8be58e3db2d9ca99ccb1f357b62a65"
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "glob"
@@ -1728,6 +2380,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3520bb9c07ae2a12c7f2fbb24d4efc11231c8146a86956413fb1a79bb760a0f1"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d3507d43908c866c805f74c9dd593c0ce7ba5c38e576e41846639cdcd4bee6"
+dependencies = [
+ "atk",
+ "bitflags 1.3.2",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "once_cell",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b5f8946685d5fe44497007786600c2f368ff6b1e61a16251c89f72a97520a3"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "096eb63c6fedf03bafe65e5924595785eaf1bcb7200dac0f2cbe9c9738f05ad8"
+dependencies = [
+ "anyhow",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,15 +2493,36 @@ checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "hstr"
@@ -1808,6 +2547,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,7 +2574,7 @@ checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.15",
 ]
 
 [[package]]
@@ -1832,7 +2585,7 @@ checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.15",
 ]
 
 [[package]]
@@ -1973,6 +2726,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+]
+
+[[package]]
 name = "imagesize"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2771,15 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+]
+
+[[package]]
+name = "infer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6c16b11a665b26aeeb9b1d7f954cdeb034be38dd00adab4f2ae921a8fee804"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]
@@ -2047,6 +2821,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "interprocess-docfix"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b84ee245c606aeb0841649a9288e3eae8c61b853a8cd5c0e14450e96d53d28f"
+dependencies = [
+ "blocking",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "intmap",
+ "libc",
+ "once_cell",
+ "rustc_version",
+ "spinning",
+ "thiserror",
+ "to_method",
+ "winapi",
+]
+
+[[package]]
+name = "intmap"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
+
+[[package]]
 name = "inventory"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,12 +2856,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -2072,7 +2883,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -2084,7 +2895,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -2118,9 +2929,74 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "javascriptcore-rs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110b9902c80c12bf113c432d0b71c7a94490b294a8234f326fd0abca2fac0b00"
+dependencies = [
+ "bitflags 1.3.2",
+ "glib",
+ "javascriptcore-rs-sys",
+]
+
+[[package]]
+name = "javascriptcore-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a216519a52cd941a733a0ad3f1023cfdb1cd47f3955e8e863ed56f558f916c"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "jni"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "joy-dioxus"
@@ -2156,7 +3032,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "heck",
+ "heck 0.5.0",
  "serde",
  "serde_json",
  "swc_common",
@@ -2217,9 +3093,21 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kuchiki"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
+dependencies = [
+ "cssparser",
+ "html5ever",
+ "matches",
+ "selectors",
 ]
 
 [[package]]
@@ -2365,7 +3253,7 @@ checksum = "4b13bc3db70715cd8218c4535a5af3ae3c0e5fea6f018531fc339377b36bc0e0"
 dependencies = [
  "attribute-derive",
  "cfg-if",
- "convert_case",
+ "convert_case 0.6.0",
  "html-escape",
  "itertools 0.12.1",
  "leptos_hot_reload",
@@ -2400,7 +3288,7 @@ version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4161acbf80f59219d8d14182371f57302bc7ff81ee41aba8ba1ff7295727f23"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cfg-if",
  "futures",
  "indexmap",
@@ -2488,7 +3376,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall",
 ]
@@ -2502,6 +3390,12 @@ dependencies = [
  "serde",
  "serde_test",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2574,6 +3468,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "manyhow"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,13 +3506,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+dependencies = [
+ "log",
+ "phf 0.8.0",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "material-parity"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "heck",
+ "heck 0.5.0",
  "serde",
  "serde_json",
  "swc_common",
@@ -2625,6 +3554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2650,6 +3588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2723,10 +3662,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
+dependencies = [
+ "bitflags 1.3.2",
+ "jni-sys",
+ "ndk-sys",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -2785,8 +3758,68 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -2836,6 +3869,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d80efc4b6721e8be2a10a5df21a30fa0b470f1539e53d8b4e6e75faf938b63"
 
 [[package]]
+name = "pango"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdff66b271861037b89d028656184059e03b0b6ccb36003820be19f7200b1e94"
+dependencies = [
+ "bitflags 1.3.2",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e134909a9a293e04d2cc31928aa95679c5e4df954d0b85483159bd20d8f047f"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,12 +3943,43 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_macros 0.8.0",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared 0.8.0",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -2892,8 +3988,22 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2902,11 +4012,20 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -2968,6 +4087,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.3.0",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,6 +4132,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +4183,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -3115,6 +4286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro-utils"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,7 +4360,7 @@ checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -3210,7 +4387,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "memchr",
  "unicase",
 ]
@@ -3260,6 +4437,20 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -3277,6 +4468,16 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3301,6 +4502,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -3318,6 +4528,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +4553,12 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
@@ -3352,7 +4586,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3383,6 +4617,31 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rfd"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe664af397d2b6a13a8ba1d172a2b5c87c6c5149039edbf8fa122b98c9ed96f"
+dependencies = [
+ "async-io",
+ "block",
+ "dispatch",
+ "futures-util",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows",
+]
 
 [[package]]
 name = "ring"
@@ -3441,6 +4700,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustic-ui-design-tokens"
@@ -3629,14 +4897,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.1",
 ]
 
@@ -3699,7 +4981,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "bytemuck",
  "core_maths",
  "log",
@@ -3739,10 +5021,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "selection-controls-dioxus"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+ "dioxus-desktop",
+ "dioxus-ssr",
+ "dioxus-web",
+ "rustic-ui-headless",
+ "rustic-ui-material",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "selection-controls-yew"
+version = "0.1.0"
+dependencies = [
+ "gloo-console 0.2.3",
+ "rustic-ui-headless",
+ "rustic-ui-material",
+ "rustic-ui-styled-engine",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "yew",
+]
+
+[[package]]
+name = "selectors"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
+dependencies = [
+ "bitflags 1.3.2",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "matches",
+ "phf 0.8.0",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+ "thin-slice",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "send_wrapper"
@@ -3827,7 +5161,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "itoa",
+ "itoa 1.0.15",
  "memchr",
  "ryu",
  "serde",
@@ -3901,7 +5235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.15",
  "ryu",
  "serde",
 ]
@@ -3943,7 +5277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faaaf648c6967aef78177c0610478abb5a3455811f401f3c62d10ae9bd3901a1"
 dependencies = [
  "const_format",
- "convert_case",
+ "convert_case 0.6.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -3958,6 +5292,16 @@ checksum = "7f2aa8119b558a17992e0ac1fd07f080099564f24532858811ce04f742542440"
 dependencies = [
  "server_fn_macro",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+dependencies = [
+ "nodrop",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3983,6 +5327,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
@@ -4072,6 +5422,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "soup3"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82bc46048125fefd69d30b32b9d263d6556c9ffe82a7a7df181a86d912da5616"
+dependencies = [
+ "bitflags 1.3.2",
+ "futures-channel",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "soup3-sys",
+]
+
+[[package]]
+name = "soup3-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014bbeb1c4cdb30739dc181e8d98b7908f124d9555843afa89b5570aaf4ec62b"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "spinning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,6 +5500,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp 0.9.0",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -4228,11 +5650,11 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c25af97d53cf8aab66a6c68f3418663313fc969ad267fc2a4d19402c329be1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "is-macro",
  "num-bigint",
  "once_cell",
- "phf",
+ "phf 0.11.3",
  "rustc-hash 2.1.1",
  "serde",
  "string_enum",
@@ -4249,10 +5671,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c3bd958a5a67e2cc3f74abdd41fda688e54e7a25b866569260ef7018b67972"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 2.9.4",
  "either",
  "num-bigint",
- "phf",
+ "phf 0.11.3",
  "rustc-hash 2.1.1",
  "seq-macro",
  "serde",
@@ -4442,6 +5864,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
+name = "tao"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746ae5d0ca57ae275a792f109f6e992e0b41a443abdf3f5c6eff179ef5b3443a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-rs",
+ "cc",
+ "cocoa",
+ "core-foundation",
+ "core-graphics",
+ "crossbeam-channel",
+ "dispatch",
+ "gdk",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gdkwayland-sys",
+ "gdkx11-sys",
+ "gio",
+ "glib",
+ "glib-sys",
+ "gtk",
+ "image",
+ "instant",
+ "jni 0.20.0",
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "objc",
+ "once_cell",
+ "parking_lot",
+ "png",
+ "raw-window-handle",
+ "scopeguard",
+ "serde",
+ "tao-macros",
+ "unicode-segmentation",
+ "uuid",
+ "windows",
+ "windows-implement 0.44.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,6 +5943,12 @@ dependencies = [
  "filetime",
  "libc",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-triple"
@@ -4463,11 +5962,22 @@ version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "fastrand",
+ "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -4484,6 +5994,12 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thin-slice"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
@@ -4512,7 +6028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
- "itoa",
+ "itoa 1.0.15",
  "num-conv",
  "powerfmt",
  "serde",
@@ -4583,12 +6099,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "to_method"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
+ "bytes",
  "io-uring",
  "libc",
  "mio",
@@ -4891,7 +6414,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "log",
  "once_cell",
  "rustls",
@@ -4924,7 +6447,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
@@ -4944,6 +6467,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-width"
@@ -5022,6 +6551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5037,6 +6572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5045,6 +6586,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -5190,6 +6737,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
+dependencies = [
+ "core-foundation",
+ "home",
+ "jni 0.21.1",
+ "log",
+ "ndk-context",
+ "objc",
+ "raw-window-handle",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "webkit2gtk"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eea819afe15eb8dcdff4f19d8bfda540bae84d874c10e6f4b8faf2d6704bd1"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-rs",
+ "gdk",
+ "gdk-sys",
+ "gio",
+ "gio-sys",
+ "glib",
+ "glib-sys",
+ "gobject-sys",
+ "gtk",
+ "gtk-sys",
+ "javascriptcore-rs",
+ "libc",
+ "once_cell",
+ "soup3",
+ "webkit2gtk-sys",
+]
+
+[[package]]
+name = "webkit2gtk-sys"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ac7a95ddd3fdfcaf83d8e513b4b1ad101b95b413b6aa6662ed95f284fc3d5b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-sys-rs",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "javascriptcore-rs-sys",
+ "libc",
+ "pkg-config",
+ "soup3-sys",
+ "system-deps",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,6 +6816,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "webview2-com"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11296e5daf3a653b79bf47d66c380e4143d5b9c975818871179a3bda79499562"
+dependencies = [
+ "webview2-com-macros",
+ "webview2-com-sys",
+ "windows",
+ "windows-implement 0.44.0",
+]
+
+[[package]]
+name = "webview2-com-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaebe196c01691db62e9e4ca52c5ef1e4fd837dcae27dae3ada599b5a8fd05ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "webview2-com-sys"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde542bed28058a5b028d459689ee57f1d06685bb6c266da3b91b1be6703952f"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "windows",
+ "windows-bindgen",
+ "windows-metadata",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5217,16 +6879,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-implement 0.44.0",
+ "windows-interface 0.44.0",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-bindgen"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222204ecf46521382a4d88b4a1bbefca9f8855697b4ab7d20803901425e061a3"
+dependencies = [
+ "windows-metadata",
+ "windows-tokens",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.1",
+ "windows-interface 0.59.2",
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce87ca8e3417b02dc2a8a22769306658670ec92d78f1bd420d6310a67c245c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5238,6 +6938,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853f69a591ecd4f810d29f17e902d40e349fb05b0b11fff63b08b826bfe39c7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5258,6 +6969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
+name = "windows-metadata"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78911e3f4ce32c1ad9d3c7b0bd95389662ad8d8f1a3155688fed70bd96e2b6"
+
+[[package]]
 name = "windows-result"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5273,6 +6990,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5313,6 +7048,36 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -5345,6 +7110,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-tokens"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4251900975a0d10841c5d4bde79c56681543367ef811f3fabb8d1803b0959b"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5358,6 +7141,18 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5367,6 +7162,18 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5394,6 +7201,18 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5403,6 +7222,18 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5418,6 +7249,18 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5427,6 +7270,18 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5469,6 +7324,66 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wry"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d15f9f827d537cefe6d047be3930f5d89b238dfb85e08ba6a319153217635aa"
+dependencies = [
+ "base64 0.13.1",
+ "block",
+ "cocoa",
+ "core-graphics",
+ "crossbeam-channel",
+ "dunce",
+ "gdk",
+ "gio",
+ "glib",
+ "gtk",
+ "html5ever",
+ "http 0.2.12",
+ "javascriptcore-rs",
+ "kuchiki",
+ "libc",
+ "log",
+ "objc",
+ "objc_id",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "sha2",
+ "soup3",
+ "tao",
+ "thiserror",
+ "url",
+ "webkit2gtk",
+ "webkit2gtk-sys",
+ "webview2-com",
+ "windows",
+ "windows-implement 0.44.0",
+]
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "examples/navigation-speed-dial-dioxus",
     "examples/inputs-slider-yew",
     "examples/feedback-progress-leptos",
+    "examples/selection-controls-dioxus",
     "examples/selection-controls-yew",
     "examples/forms-input-base-shared",
     "examples/forms-input-base-yew",

--- a/examples/select-menu-leptos/Cargo.lock
+++ b/examples/select-menu-leptos/Cargo.lock
@@ -1716,6 +1716,8 @@ dependencies = [
  "serde",
  "serde_json",
  "stylist",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/examples/select-menu-shared/Cargo.lock
+++ b/examples/select-menu-shared/Cargo.lock
@@ -922,6 +922,8 @@ dependencies = [
  "serde",
  "serde_json",
  "stylist",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/examples/select-menu-yew/Cargo.lock
+++ b/examples/select-menu-yew/Cargo.lock
@@ -928,6 +928,8 @@ dependencies = [
  "serde",
  "serde_json",
  "stylist",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/examples/selection-controls-dioxus/Cargo.toml
+++ b/examples/selection-controls-dioxus/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "selection-controls-dioxus"
+version = "0.1.0"
+edition = "2021"
+description = "Enterprise-grade selection controls instrumented with Rustic UI and Dioxus"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+name = "selection_controls_dioxus"
+path = "src/lib.rs"
+
+[[bin]]
+name = "selection-controls"
+path = "src/main.rs"
+
+[features]
+default = []
+desktop = ["dioxus-desktop"]
+web = ["wasm-bindgen-test", "dioxus-web"]
+ssr = ["dioxus-ssr"]
+
+[dependencies]
+dioxus = { workspace = true, features = ["macro", "hooks", "html"] }
+dioxus-web = { workspace = true, optional = true, features = ["hydrate"] }
+dioxus-ssr = { workspace = true, optional = true }
+dioxus-desktop = { version = "0.4", optional = true }
+rustic-ui-headless = { path = "../../crates/rustic-ui-headless", features = ["forms"] }
+rustic-ui-material = { path = "../../crates/rustic-ui-material", default-features = false, features = ["forms"] }
+wasm-bindgen-test = { workspace = true, optional = true }
+
+[dev-dependencies]
+dioxus-ssr = { workspace = true }
+wasm-bindgen-test = { workspace = true }

--- a/examples/selection-controls-dioxus/Justfile
+++ b/examples/selection-controls-dioxus/Justfile
@@ -1,0 +1,39 @@
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+example_dir := invocation_directory()
+repo_root := example_dir + "/../.."
+manifest := example_dir + "/Cargo.toml"
+toolchain := repo_root + "/examples/scripts/ensure-example-toolchain.sh"
+
+default := run-desktop
+
+alias run := run-desktop
+alias serve := run-web
+
+run-desktop:
+{{toolchain}} "Selection Controls (Dioxus)" --ssr
+cargo run --manifest-path {{manifest}} --features desktop
+
+run-web:
+{{toolchain}} "Selection Controls (Dioxus)" --wasm
+dx serve --config {{example_dir}}/dx.json
+
+build-web:
+{{toolchain}} "Selection Controls (Dioxus)" --wasm
+dx build --config {{example_dir}}/dx.json
+
+build-desktop:
+cargo build --manifest-path {{manifest}} --features desktop
+
+check:
+cargo check --manifest-path {{manifest}} --all-targets
+
+fmt:
+cargo fmt --manifest-path {{manifest}} --all
+
+test-host:
+cargo test --manifest-path {{manifest}}
+
+test-wasm:
+{{toolchain}} "Selection Controls (Dioxus)" --wasm
+cd {{example_dir}} && wasm-pack test --headless --chrome -- --features web

--- a/examples/selection-controls-dioxus/README.md
+++ b/examples/selection-controls-dioxus/README.md
@@ -1,127 +1,86 @@
 # Selection Controls with Dioxus
 
-Use the typed Dioxus components so hydration stays deterministic, telemetry is
-attached up-front, and automation suites can reuse the same patterns that power
-the full design system.
+This example turns the README snippet into a fully instrumented Dioxus
+crate. The showcase renders the checkbox, switch, and radio group in the
+same order as the documentation while bolting Rustic UI telemetry hooks
+into both the render lifecycle and the structured delegates exposed by
+`rustic-ui-material`.
 
-```rust
-use dioxus::prelude::*;
-use rustic_ui_headless::{
-    checkbox::CheckboxState,
-    radio::{RadioGroupState, RadioOrientation},
-    switch::SwitchState,
-};
-use rustic_ui_material::{TelemetryContext, TelemetryHooks};
-use rustic_ui_material::checkbox::{
-    CheckboxChangeEvent, CheckboxProps, CheckboxTelemetryEvent,
-    dioxus::{DioxusCheckbox, DioxusCheckboxProps},
-};
-use rustic_ui_material::radio::{
-    RadioChangeEvent, RadioGroupProps, RadioTelemetryEvent,
-    dioxus::{DioxusRadioGroup, DioxusRadioGroupProps},
-};
-use rustic_ui_material::switch::{
-    SwitchChangeEvent, SwitchProps, SwitchTelemetryEvent,
-    dioxus::{DioxusSwitch, DioxusSwitchProps},
-};
-use std::{rc::Rc, sync::Arc};
+The library exports helper functions that:
 
-fn telemetry(channel: &'static str) -> TelemetryHooks {
-    let mut hooks = TelemetryHooks::default();
-    hooks.analytics_id = Some(format!("selection-controls.dioxus.{channel}"));
-    hooks.automation_id = Some(format!("automation.selection-controls.{channel}"));
-    let channel_label = format!("selection_controls::{channel}");
-    hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
-        println!(
-            "telemetry::render channel={} component={} analytics={:?} automation={:?}",
-            channel_label,
-            context.component,
-            context.analytics_id,
-            context.automation_id,
-        );
-    }));
-    hooks
-}
+* construct a `VirtualDom` with deterministic telemetry recording so host
+  and WebAssembly tests can validate hydration ordering.
+* expose smoke-test helpers that emit a canonical telemetry cycle without
+  duplicating event wiring logic.
+* launch desktop and web runners so automation suites execute the same
+  instrumentation pipeline the design system expects in production.
+* render the checkbox, switch, and radio controls directly via `rsx!`
+  using the headless state machines, keeping the example compatible while
+  the upstream Dioxus adapters continue to evolve.
 
-pub fn selection_controls(cx: Scope) -> Element {
-    let checkbox_state = CheckboxState::uncontrolled(false, false);
-    let switch_state = SwitchState::uncontrolled(false, true);
-    let radio_state = RadioGroupState::uncontrolled(
-        vec!["Cash".into(), "Card".into(), "Invoice".into()],
-        false,
-        RadioOrientation::Horizontal,
-        Some(2),
-    );
+## Developer workflows
 
-    let checkbox_props = CheckboxProps {
-        label: "Accept terms".into(),
-        telemetry: telemetry("checkbox"),
-    };
-    let switch_props = SwitchProps {
-        label: "Enable quick checkout".into(),
-        telemetry: telemetry("switch"),
-    };
-    let radio_props = RadioGroupProps::from_state(&radio_state)
-        .with_telemetry(telemetry("radio"));
+The `Justfile` centralises the commands developers and CI runners need.
+All recipes call `examples/scripts/ensure-example-toolchain.sh` so the
+Rust targets and supporting tools are present before any build starts.
 
-    let checkbox_telemetry: Rc<dyn Fn(CheckboxTelemetryEvent)> = Rc::new(|event| {
-        println!("checkbox telemetry::{event:?}");
-    });
-    let switch_telemetry: Rc<dyn Fn(SwitchTelemetryEvent)> = Rc::new(|event| {
-        println!("switch telemetry::{event:?}");
-    });
-    let radio_telemetry: Rc<dyn Fn(RadioTelemetryEvent)> = Rc::new(|event| {
-        println!("radio telemetry::{event:?}");
-    });
-
-    let checkbox_component = DioxusCheckboxProps {
-        checkbox: checkbox_props.clone(),
-        state: checkbox_state.clone(),
-        on_change: Some(Rc::new(|event: CheckboxChangeEvent| {
-            println!("checkbox::change next={} disabled={}", event.next, event.disabled);
-        })),
-        on_focus: None,
-        on_blur: None,
-        on_key: None,
-        telemetry_delegate: Some(checkbox_telemetry.clone()),
-    };
-    let switch_component = DioxusSwitchProps {
-        switch: switch_props.clone(),
-        state: switch_state.clone(),
-        on_change: Some(Rc::new(|event: SwitchChangeEvent| {
-            println!("switch::change next={} disabled={}", event.next, event.disabled);
-        })),
-        on_focus: None,
-        on_blur: None,
-        on_key: None,
-        telemetry_delegate: Some(switch_telemetry.clone()),
-    };
-    let radio_component = DioxusRadioGroupProps {
-        group: radio_props.clone(),
-        state: radio_state.clone(),
-        on_change: Some(Rc::new(|event: RadioChangeEvent| {
-            println!(
-                "radio::change previous={:?} next={} label={}",
-                event.previous,
-                event.next,
-                event.label,
-            );
-        })),
-        on_focus: None,
-        on_blur: None,
-        on_key: None,
-        telemetry_delegate: Some(radio_telemetry.clone()),
-        telemetry: Some(telemetry("radio.component")),
-    };
-
-    cx.render(rsx! {
-        DioxusCheckbox { ..checkbox_component }
-        DioxusSwitch { ..switch_component }
-        DioxusRadioGroup { ..radio_component }
-    })
-}
+```shell
+just run-desktop     # build + launch the native window with telemetry logging
+just run-web         # serve the wasm build via the Dioxus CLI
+just build-desktop   # compile without launching (handy for CI cache priming)
+just build-web       # emit the wasm bundle for static hosting
+just test-host       # run the native telemetry smoke tests
+just test-wasm       # execute wasm-bindgen tests in headless Chrome
 ```
 
-> **Compile-time note:** Enable the `dioxus` feature when pulling `rustic-ui-material`
-> into an example crate: `cargo add rustic-ui-material --features dioxus` and
-> `cargo add rustic-ui-headless --features forms` before running `cargo check`.
+> **Tip:** the `scripts/bootstrap.sh` helper powers CI smoke tests. It
+> checks both the host and wasm pipelines, mirroring what the
+> documentation recommends for local validation.
+
+## Telemetry wiring
+
+The Rust module in `src/lib.rs` encapsulates the telemetry wiring inside
+a reusable harness:
+
+* `TelemetryHooks` emit render events with analytics and automation IDs
+  per control (`checkbox`, `switch`, `radio`, and the nested
+  `radio.component`).
+* Console logging mirrors the structured delegates so operators can tail
+  stdout while the recorder stores the same payloads for assertions.
+* `simulate_telemetry_cycle` replays a representative change cycle,
+  making it trivial for tests—or other examples—to verify that the
+  logging contract remains intact.
+
+Host tests assert the render order via `VirtualDom::rebuild` while wasm
+smoke tests validate that hydration triggers the nested radio telemetry.
+Both suites reuse the same `TelemetryRecorder`, guaranteeing parity
+across execution environments.
+
+## Building for WebAssembly
+
+The Dioxus CLI reads `dx.json` to discover how to compile the wasm
+artifacts. Running `dx build --config dx.json` produces bundles in
+`dist/`; `dx serve --config dx.json` spins up a local dev server using
+hydration. The `web` Cargo feature ensures the crate pulls in
+`dioxus-web`, `wasm-bindgen`, and the associated tests.
+
+## Desktop execution
+
+Desktop builds enable the `desktop` feature which activates the
+`dioxus-desktop` renderer. `run_desktop` boots the virtual DOM through
+`dioxus_desktop::launch::launch_virtual_dom`, applying the same telemetry
+hooks used elsewhere. Developers can run the binary directly via
+`cargo run --manifest-path Cargo.toml --features desktop` or lean on the
+`just run-desktop` recipe.
+
+## Testing strategy
+
+* `tests/desktop.rs` covers hydration ordering and verifies that all
+  telemetry delegates fire with change payloads.
+* `tests/web.rs` (gated behind `wasm_bindgen_test`) exercises the wasm
+  path to assert that hydration captures the nested radio component
+  telemetry. Execute it via `just test-wasm`.
+
+The README’s original snippet now lives as executable code with exhaustive
+inline commentary in `src/lib.rs`, ensuring engineers can read, run, and
+extend the instrumentation without searching through multiple files.

--- a/examples/selection-controls-dioxus/dx.json
+++ b/examples/selection-controls-dioxus/dx.json
@@ -1,0 +1,32 @@
+{
+  "application": {
+    "name": "selection-controls-dioxus",
+    "default_platform": "x86_64-unknown-linux-gnu"
+  },
+  "web": {
+    "renderer": {
+      "target": "wasm32-unknown-unknown",
+      "features": ["web"],
+      "output_dir": "dist"
+    },
+    "serve": {
+      "proxy": null,
+      "asset_dir": "public",
+      "open": false
+    }
+  },
+  "desktop": {
+    "runner": {
+      "features": ["desktop"],
+      "command": "cargo run --manifest-path Cargo.toml --features desktop"
+    }
+  },
+  "testing": {
+    "host": {
+      "command": "cargo test --manifest-path Cargo.toml"
+    },
+    "wasm": {
+      "command": "wasm-pack test --headless --chrome -- --features web"
+    }
+  }
+}

--- a/examples/selection-controls-dioxus/scripts/bootstrap.sh
+++ b/examples/selection-controls-dioxus/scripts/bootstrap.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+EXAMPLE_ROOT="$REPO_ROOT/examples/selection-controls-dioxus"
+
+"$REPO_ROOT/examples/scripts/ensure-example-toolchain.sh" "Selection Controls (Dioxus)" --wasm --ssr
+
+pushd "$EXAMPLE_ROOT" >/dev/null
+cargo check --all-targets
+wasm-pack test --headless --chrome -- --features web
+popd >/dev/null
+
+echo "[selection-controls-dioxus] host and wasm pipelines validated"

--- a/examples/selection-controls-dioxus/src/lib.rs
+++ b/examples/selection-controls-dioxus/src/lib.rs
@@ -1,0 +1,573 @@
+//! Enterprise grade selection control showcase rendered via Dioxus.
+//!
+//! The example converts the README snippet into an executable crate with
+//! extensive inline documentation, telemetry recording, and automation-
+//! friendly smoke tests. Instead of depending on the unfinished
+//! `rustic-ui-material` Dioxus adapters, the crate renders lightweight
+//! controls directly with Dioxus primitives while reusing the shared
+//! headless state machines and telemetry schemas from Rustic UI.
+
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use dioxus::prelude::*;
+use rustic_ui_headless::checkbox::{CheckboxState, CheckboxValue};
+use rustic_ui_headless::radio::{RadioGroupState, RadioOrientation};
+use rustic_ui_headless::switch::SwitchState;
+use rustic_ui_material::checkbox::{CheckboxChangeEvent, CheckboxTelemetryEvent};
+use rustic_ui_material::radio::{RadioChangeEvent, RadioTelemetryEvent};
+use rustic_ui_material::switch::{SwitchChangeEvent, SwitchTelemetryEvent};
+use rustic_ui_material::{TelemetryContext, TelemetryHooks};
+
+/// Human friendly telemetry channels reused across logging sinks.
+const CHECKBOX_CHANNEL: &str = "checkbox";
+const SWITCH_CHANNEL: &str = "switch";
+const RADIO_CHANNEL: &str = "radio";
+const RADIO_COMPONENT_CHANNEL: &str = "radio.component";
+
+/// Structured telemetry emitted by the selection control showcase.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TelemetrySignal {
+    /// Lifecycle event captured by [`TelemetryHooks::on_render`].
+    Render {
+        channel: &'static str,
+        component: &'static str,
+        analytics_id: Option<String>,
+        automation_id: Option<String>,
+    },
+    /// Plain text message mirrored to stdout/stderr for manual tracing.
+    Console {
+        channel: &'static str,
+        message: String,
+    },
+    /// Structured payload raised by the checkbox telemetry delegate.
+    Checkbox(CheckboxTelemetryEvent),
+    /// Structured payload raised by the switch telemetry delegate.
+    Switch(SwitchTelemetryEvent),
+    /// Structured payload raised by the radio telemetry delegate.
+    Radio(RadioTelemetryEvent),
+}
+
+impl fmt::Display for TelemetrySignal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Render {
+                channel,
+                component,
+                analytics_id,
+                automation_id,
+            } => write!(
+                f,
+                "render channel={channel} component={component} analytics={analytics_id:?} automation={automation_id:?}",
+            ),
+            Self::Console { channel, message } => {
+                write!(f, "console channel={channel} message={message}")
+            }
+            Self::Checkbox(event) => write!(f, "checkbox telemetry::{event:?}"),
+            Self::Switch(event) => write!(f, "switch telemetry::{event:?}"),
+            Self::Radio(event) => write!(f, "radio telemetry::{event:?}"),
+        }
+    }
+}
+
+/// Thread-safe collector shared between the runtime component and the
+/// test harness.
+#[derive(Clone, Default)]
+pub struct TelemetryRecorder {
+    inner: Arc<Mutex<Vec<TelemetrySignal>>>,
+}
+
+impl PartialEq for TelemetryRecorder {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl TelemetryRecorder {
+    /// Record a telemetry signal and mirror it to stdout for developers.
+    pub fn record(&self, signal: TelemetrySignal) {
+        println!("telemetry::{}", signal);
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.push(signal);
+        }
+    }
+
+    /// Convenience helper for console-only signals.
+    pub fn record_console(&self, channel: &'static str, message: String) {
+        self.record(TelemetrySignal::Console { channel, message });
+    }
+
+    /// Drain the collected signals for assertion driven tests.
+    #[must_use]
+    pub fn drain(&self) -> Vec<TelemetrySignal> {
+        if let Ok(mut guard) = self.inner.lock() {
+            let drained = guard.clone();
+            guard.clear();
+            drained
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// Dioxus properties passed to [`selection_controls_app`].
+#[derive(Clone, PartialEq, Props)]
+pub struct SelectionControlsProps {
+    /// Shared recorder so hydration, desktop, and web runners observe the
+    /// same telemetry sequence during smoke tests.
+    pub recorder: TelemetryRecorder,
+}
+
+/// Helper that fabricates [`TelemetryHooks`] for the supplied channel.
+fn build_telemetry_hooks(channel: &'static str, recorder: TelemetryRecorder) -> TelemetryHooks {
+    let mut hooks = TelemetryHooks::default();
+    hooks.analytics_id = Some(format!("selection-controls.dioxus.{channel}"));
+    hooks.automation_id = Some(format!("automation.selection-controls.{channel}"));
+    hooks.on_render = Some(Arc::new(move |context: TelemetryContext| {
+        recorder.record(TelemetrySignal::Render {
+            channel,
+            component: context.component,
+            analytics_id: context.analytics_id.clone(),
+            automation_id: context.automation_id.clone(),
+        });
+    }));
+    hooks
+}
+
+/// Internal harness holding the headless state machines and telemetry
+/// configuration. The harness keeps `Rc<RefCell<...>>` handles so event
+/// closures can mutate state without rebuilding the entire component tree.
+struct SelectionControlHarness {
+    recorder: TelemetryRecorder,
+    checkbox_state: Rc<RefCell<CheckboxState>>,
+    switch_state: Rc<RefCell<SwitchState>>,
+    radio_state: Rc<RefCell<RadioGroupState>>,
+    checkbox_label: String,
+    switch_label: String,
+    radio_telemetry: TelemetryHooks,
+    checkbox_telemetry: TelemetryHooks,
+    switch_telemetry: TelemetryHooks,
+    radio_component_hooks: TelemetryHooks,
+}
+
+impl SelectionControlHarness {
+    fn new(recorder: TelemetryRecorder) -> Self {
+        let checkbox_state = Rc::new(RefCell::new(CheckboxState::uncontrolled(false, false)));
+        let switch_state = Rc::new(RefCell::new(SwitchState::uncontrolled(false, true)));
+        let radio_state = Rc::new(RefCell::new(RadioGroupState::uncontrolled(
+            vec!["Cash".into(), "Card".into(), "Invoice".into()],
+            false,
+            RadioOrientation::Horizontal,
+            Some(2),
+        )));
+
+        let checkbox_telemetry = build_telemetry_hooks(CHECKBOX_CHANNEL, recorder.clone());
+        let switch_telemetry = build_telemetry_hooks(SWITCH_CHANNEL, recorder.clone());
+        let radio_telemetry = build_telemetry_hooks(RADIO_CHANNEL, recorder.clone());
+        let radio_component_hooks =
+            build_telemetry_hooks(RADIO_COMPONENT_CHANNEL, recorder.clone());
+
+        Self {
+            recorder,
+            checkbox_state,
+            switch_state,
+            radio_state,
+            checkbox_label: "Accept terms".into(),
+            switch_label: "Enable quick checkout".into(),
+            radio_telemetry,
+            checkbox_telemetry,
+            switch_telemetry,
+            radio_component_hooks,
+        }
+    }
+
+    /// Replay a representative interaction cycle for tests.
+    fn emit_smoke_events(&self) {
+        self.emit_checkbox_change();
+        self.emit_switch_change();
+        self.emit_radio_change();
+    }
+
+    fn emit_checkbox_change(&self) {
+        let state = self.checkbox_state.borrow();
+        let previous = state.checked();
+        let next = if state.disabled() {
+            previous
+        } else {
+            match previous {
+                CheckboxValue::On => CheckboxValue::Off,
+                CheckboxValue::Off => CheckboxValue::On,
+                CheckboxValue::Indeterminate => CheckboxValue::On,
+            }
+        };
+        let change = CheckboxChangeEvent {
+            previous,
+            next,
+            disabled: state.disabled(),
+            analytics_id: self.checkbox_telemetry.analytics_id.clone(),
+            automation_id: self.checkbox_telemetry.automation_id.clone(),
+            label: self.checkbox_label.clone(),
+        };
+        drop(state);
+        self.recorder.record_console(
+            CHECKBOX_CHANNEL,
+            format!(
+                "checkbox::change next={:?} disabled={}",
+                change.next, change.disabled
+            ),
+        );
+        self.recorder
+            .record(TelemetrySignal::Checkbox(CheckboxTelemetryEvent::Change(
+                change,
+            )));
+    }
+
+    fn emit_switch_change(&self) {
+        let state = self.switch_state.borrow();
+        let change = SwitchChangeEvent {
+            previous: state.on(),
+            next: if state.disabled() {
+                state.on()
+            } else {
+                !state.on()
+            },
+            disabled: state.disabled(),
+            analytics_id: self.switch_telemetry.analytics_id.clone(),
+            automation_id: self.switch_telemetry.automation_id.clone(),
+            label: self.switch_label.clone(),
+        };
+        drop(state);
+        self.recorder.record_console(
+            SWITCH_CHANNEL,
+            format!(
+                "switch::change next={} disabled={}",
+                change.next, change.disabled
+            ),
+        );
+        self.recorder
+            .record(TelemetrySignal::Switch(SwitchTelemetryEvent::Change(
+                change,
+            )));
+    }
+
+    fn emit_radio_change(&self) {
+        let state = self.radio_state.borrow();
+        let selected = state.selected_index().unwrap_or(0);
+        let label = state
+            .options()
+            .get(selected)
+            .cloned()
+            .unwrap_or_else(|| "Cash".into());
+        let change = RadioChangeEvent {
+            previous: state.selected_index(),
+            next: selected,
+            disabled: state.disabled(),
+            analytics_id: self.radio_telemetry.analytics_id.clone(),
+            automation_id: self.radio_telemetry.automation_id.clone(),
+            label,
+        };
+        drop(state);
+        self.recorder.record_console(
+            RADIO_CHANNEL,
+            format!(
+                "radio::change previous={:?} next={} label={}",
+                change.previous, change.next, change.label
+            ),
+        );
+        self.recorder
+            .record(TelemetrySignal::Radio(RadioTelemetryEvent::Change(change)));
+    }
+}
+
+fn record_render(hooks: &TelemetryHooks, component: &'static str) {
+    if let Some(callback) = hooks.on_render.as_ref() {
+        let context = TelemetryContext::new(component)
+            .with_analytics(hooks.analytics_id.clone())
+            .with_automation(hooks.automation_id.clone());
+        callback(context);
+    }
+}
+
+fn checkbox_markup<'a>(
+    _cx: Scope<'a, SelectionControlsProps>,
+    harness: &SelectionControlHarness,
+) -> LazyNodes<'a, 'a> {
+    record_render(
+        &harness.checkbox_telemetry,
+        "selection_controls_dioxus::CheckboxControl",
+    );
+    let recorder = harness.recorder.clone();
+    let state_handle = harness.checkbox_state.clone();
+    let label = harness.checkbox_label.clone();
+    let analytics = harness.checkbox_telemetry.analytics_id.clone();
+    let automation = harness.checkbox_telemetry.automation_id.clone();
+    let telemetry_recorder = harness.recorder.clone();
+    let (checked, disabled, indeterminate) = {
+        let state = state_handle.borrow();
+        (
+            state.is_checked(),
+            state.disabled(),
+            state.is_indeterminate(),
+        )
+    };
+    let aria_checked = if indeterminate {
+        "mixed"
+    } else if checked {
+        "true"
+    } else {
+        "false"
+    };
+    let tabindex = if disabled { "-1" } else { "0" };
+
+    rsx! {
+        label { class: "control checkbox", style: "display:flex;align-items:center;gap:12px;",
+            input {
+                r#type: "checkbox",
+                checked: checked,
+                disabled: disabled,
+                aria_checked: aria_checked,
+                tabindex: tabindex,
+                oninput: move |_| {
+                    let mut state = state_handle.borrow_mut();
+                    let previous = state.checked();
+                    let disabled = state.disabled();
+                    let next = if disabled {
+                        previous
+                    } else {
+                        match previous {
+                            CheckboxValue::On => CheckboxValue::Off,
+                            CheckboxValue::Off => CheckboxValue::On,
+                            CheckboxValue::Indeterminate => CheckboxValue::On,
+                        }
+                    };
+                    let change = CheckboxChangeEvent {
+                        previous,
+                        next,
+                        disabled,
+                        analytics_id: analytics.clone(),
+                        automation_id: automation.clone(),
+                        label: label.clone(),
+                    };
+                    recorder.record_console(
+                        CHECKBOX_CHANNEL,
+                        format!("checkbox::change next={:?} disabled={}", change.next, change.disabled),
+                    );
+                    telemetry_recorder.record(TelemetrySignal::Checkbox(
+                        CheckboxTelemetryEvent::Change(change.clone()),
+                    ));
+                    if !disabled {
+                        state.sync_checked(next);
+                    }
+                }
+            }
+            span { label.clone() }
+        }
+    }
+}
+
+fn switch_markup<'a>(
+    _cx: Scope<'a, SelectionControlsProps>,
+    harness: &SelectionControlHarness,
+) -> LazyNodes<'a, 'a> {
+    record_render(
+        &harness.switch_telemetry,
+        "selection_controls_dioxus::SwitchControl",
+    );
+    let state_handle = harness.switch_state.clone();
+    let label = harness.switch_label.clone();
+    let analytics = harness.switch_telemetry.analytics_id.clone();
+    let automation = harness.switch_telemetry.automation_id.clone();
+    let recorder = harness.recorder.clone();
+    let (checked, disabled) = {
+        let state = state_handle.borrow();
+        (state.on(), state.disabled())
+    };
+
+    rsx! {
+        label { class: "control switch", style: "display:flex;align-items:center;gap:12px;",
+            input {
+                r#type: "checkbox",
+                role: "switch",
+                checked: checked,
+                disabled: disabled,
+                oninput: move |_| {
+                    let mut state = state_handle.borrow_mut();
+                    let previous = state.on();
+                    let disabled = state.disabled();
+                    let next = if disabled { previous } else { !previous };
+                    let change = SwitchChangeEvent {
+                        previous,
+                        next,
+                        disabled,
+                        analytics_id: analytics.clone(),
+                        automation_id: automation.clone(),
+                        label: label.clone(),
+                    };
+                    recorder.record_console(
+                        SWITCH_CHANNEL,
+                        format!("switch::change next={} disabled={}", change.next, change.disabled),
+                    );
+                    recorder.record(TelemetrySignal::Switch(
+                        SwitchTelemetryEvent::Change(change.clone()),
+                    ));
+                    if !disabled {
+                        state.sync_on(next);
+                    }
+                }
+            }
+            span { label.clone() }
+        }
+    }
+}
+
+fn radio_markup<'a>(
+    _cx: Scope<'a, SelectionControlsProps>,
+    harness: &SelectionControlHarness,
+) -> LazyNodes<'a, 'a> {
+    record_render(
+        &harness.radio_telemetry,
+        "selection_controls_dioxus::RadioGroupControl",
+    );
+    record_render(
+        &harness.radio_component_hooks,
+        "selection_controls_dioxus::RadioGroupShell",
+    );
+    let state_handle = harness.radio_state.clone();
+    let options = harness.radio_state.borrow().options().to_vec();
+    let analytics = harness.radio_telemetry.analytics_id.clone();
+    let automation = harness.radio_telemetry.automation_id.clone();
+    let recorder = harness.recorder.clone();
+
+    rsx! {
+        fieldset { class: "control radio-group", style: "display:flex;gap:16px;align-items:center;",
+            legend { "Payment method" }
+            {options.iter().enumerate().map(|(index, option)| {
+                let state_handle = state_handle.clone();
+                let label = option.clone();
+                let analytics = analytics.clone();
+                let automation = automation.clone();
+                let recorder = recorder.clone();
+                let (is_selected, disabled) = {
+                    let state = state_handle.borrow();
+                    (state.selected_index() == Some(index), state.disabled())
+                };
+                rsx! {
+                    label { style: "display:flex;align-items:center;gap:8px;",
+                        input {
+                            r#type: "radio",
+                            name: "checkout-method",
+                            value: "{label}",
+                            checked: is_selected,
+                            disabled: disabled,
+                            oninput: move |_| {
+                                let mut state = state_handle.borrow_mut();
+                                let disabled = state.disabled();
+                                let previous = state.selected_index();
+                                if disabled {
+                                    return;
+                                }
+                                state.select(index, |_| {});
+                                let change = RadioChangeEvent {
+                                    previous,
+                                    next: index,
+                                    disabled,
+                                    analytics_id: analytics.clone(),
+                                    automation_id: automation.clone(),
+                                    label: label.clone(),
+                                };
+                                recorder.record_console(
+                                    RADIO_CHANNEL,
+                                    format!(
+                                        "radio::change previous={:?} next={} label={}",
+                                        change.previous, change.next, change.label
+                                    ),
+                                );
+                                recorder.record(TelemetrySignal::Radio(
+                                    RadioTelemetryEvent::Change(change),
+                                ));
+                            }
+                        }
+                        span { label.clone() }
+                    }
+                }
+            })}
+        }
+    }
+}
+
+/// Top-level Dioxus component that renders the checkbox, switch, and radio
+/// group in the README order with comprehensive inline documentation.
+#[allow(clippy::too_many_lines)]
+pub fn selection_controls_app(cx: Scope<SelectionControlsProps>) -> Element {
+    let recorder = cx.props.recorder.clone();
+    let harness = use_ref(cx, || SelectionControlHarness::new(recorder));
+    let harness_snapshot = harness.read();
+    let checkbox = checkbox_markup(cx, &harness_snapshot);
+    let switch = switch_markup(cx, &harness_snapshot);
+    let radio = radio_markup(cx, &harness_snapshot);
+
+    cx.render(rsx! {
+        main {
+            class: "selection-controls-shell",
+            style: "display:flex;flex-direction:column;gap:24px;padding:32px;font-family:Inter,system-ui,sans-serif;",
+            h1 { "RusticUI Selection Controls – Dioxus" }
+            p {
+                style: "max-width:72ch;color:#94a3b8;",
+                "Telemetry hooks mirror the Rust headless state machines so analytics, automation, and hydration stay deterministic."
+            }
+            {checkbox}
+            {switch}
+            {radio}
+        }
+    })
+}
+
+/// Build a [`VirtualDom`] configured with telemetry recording. Desktop
+/// smoke tests rely on this helper to assert hydration ordering.
+#[must_use]
+pub fn build_virtual_dom(recorder: TelemetryRecorder) -> VirtualDom {
+    VirtualDom::new_with_props(selection_controls_app, SelectionControlsProps { recorder })
+}
+
+/// Generate a fresh harness and emit the telemetry smoke cycle for tests.
+#[must_use]
+pub fn simulate_telemetry_cycle(recorder: TelemetryRecorder) -> Vec<TelemetrySignal> {
+    let harness = SelectionControlHarness::new(recorder.clone());
+    harness.emit_smoke_events();
+    recorder.drain()
+}
+
+/// Launch the desktop runner when the `desktop` feature is enabled.
+#[cfg(all(feature = "desktop", not(target_arch = "wasm32")))]
+pub fn run_desktop() {
+    use dioxus_desktop::{launch::launch_virtual_dom, Config};
+
+    let recorder = TelemetryRecorder::default();
+    let dom = build_virtual_dom(recorder);
+    let config = Config::default().with_window(|builder| {
+        builder
+            .with_title("RusticUI – Selection Controls (Dioxus)")
+            .with_resizable(true)
+    });
+    launch_virtual_dom(dom, config);
+}
+
+/// Launch the web runner when compiled for WebAssembly.
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+pub fn run_web() {
+    use dioxus_web::Config;
+
+    let recorder = TelemetryRecorder::default();
+    dioxus_web::launch_with_props(
+        selection_controls_app,
+        SelectionControlsProps { recorder },
+        Config::new().hydrate(true),
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn test_harness(recorder: TelemetryRecorder) -> SelectionControlHarness {
+    SelectionControlHarness::new(recorder)
+}

--- a/examples/selection-controls-dioxus/src/main.rs
+++ b/examples/selection-controls-dioxus/src/main.rs
@@ -1,0 +1,20 @@
+//! Binary entry point forwarding to the library helpers so both desktop
+//! and web pipelines share the same telemetry wiring.
+
+#[cfg(all(feature = "desktop", not(target_arch = "wasm32")))]
+fn main() {
+    selection_controls_dioxus::run_desktop();
+}
+
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+fn main() {
+    selection_controls_dioxus::run_web();
+}
+
+#[cfg(not(any(
+    all(feature = "desktop", not(target_arch = "wasm32")),
+    all(feature = "web", target_arch = "wasm32")
+),))]
+fn main() {
+    panic!("enable either the `desktop` or `web` feature to launch the example");
+}

--- a/examples/selection-controls-dioxus/tests/desktop.rs
+++ b/examples/selection-controls-dioxus/tests/desktop.rs
@@ -1,0 +1,68 @@
+use selection_controls_dioxus::{
+    build_virtual_dom, simulate_telemetry_cycle, TelemetryRecorder, TelemetrySignal,
+};
+
+#[test]
+fn hydration_order_matches_render_sequence() {
+    let recorder = TelemetryRecorder::default();
+    let mut dom = build_virtual_dom(recorder.clone());
+    let _ = dom.rebuild();
+    let signals = recorder.drain();
+    let render_channels: Vec<&'static str> = signals
+        .iter()
+        .filter_map(|signal| match signal {
+            TelemetrySignal::Render { channel, .. } => Some(*channel),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        render_channels,
+        vec!["checkbox", "switch", "radio", "radio.component"],
+        "render telemetry should follow the README component order",
+    );
+}
+
+#[test]
+fn telemetry_cycle_emits_structured_events() {
+    let recorder = TelemetryRecorder::default();
+    let signals = simulate_telemetry_cycle(recorder);
+    let mut console_channels = Vec::new();
+    let mut has_checkbox = false;
+    let mut has_switch = false;
+    let mut has_radio = false;
+
+    for signal in &signals {
+        match signal {
+            TelemetrySignal::Console { channel, .. } => console_channels.push(*channel),
+            TelemetrySignal::Checkbox(event) => {
+                has_checkbox = true;
+                assert!(matches!(
+                    event,
+                    rustic_ui_material::checkbox::CheckboxTelemetryEvent::Change(_)
+                ));
+            }
+            TelemetrySignal::Switch(event) => {
+                has_switch = true;
+                assert!(matches!(
+                    event,
+                    rustic_ui_material::switch::SwitchTelemetryEvent::Change(_)
+                ));
+            }
+            TelemetrySignal::Radio(event) => {
+                has_radio = true;
+                assert!(matches!(
+                    event,
+                    rustic_ui_material::radio::RadioTelemetryEvent::Change(_)
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        console_channels,
+        vec!["checkbox", "switch", "radio"],
+        "console telemetry should be emitted for each control",
+    );
+    assert!(has_checkbox && has_switch && has_radio);
+}

--- a/examples/selection-controls-dioxus/tests/web.rs
+++ b/examples/selection-controls-dioxus/tests/web.rs
@@ -1,0 +1,21 @@
+#![cfg(target_arch = "wasm32")]
+
+use selection_controls_dioxus::{build_virtual_dom, TelemetryRecorder, TelemetrySignal};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn web_hydration_collects_render_hooks() {
+    let recorder = TelemetryRecorder::default();
+    let mut dom = build_virtual_dom(recorder.clone());
+    let _ = dom.rebuild();
+    let signals = recorder.drain();
+    let has_radio_component = signals.iter().any(|signal| {
+        matches!(signal, TelemetrySignal::Render { channel, .. } if *channel == "radio.component")
+    });
+    assert!(
+        has_radio_component,
+        "radio component telemetry should hydrate in the browser"
+    );
+}


### PR DESCRIPTION
## Summary
- add a `selection-controls-dioxus` example crate that renders checkbox, switch, and radio controls with a reusable telemetry harness
- wire developer tooling (Justfile, dx.json, bootstrap script) plus README guidance covering desktop and wasm workflows
- add smoke tests for hydration order and telemetry events across the desktop runner and wasm bindgen harness

## Testing
- cargo test -p selection-controls-dioxus

------
https://chatgpt.com/codex/tasks/task_e_68e169173b88832eaea0b7e5866d2193