### PR TITLE
Add reusable docs automation helper crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,32 @@ name = "camino"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "cast"
@@ -2696,6 +2722,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -5454,6 +5486,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -5740,6 +5776,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -6597,6 +6642,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
  "tokio-macros",
@@ -8030,9 +8076,26 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "tempfile",
+ "tokio",
  "toml 0.8.23",
  "ureq",
  "walkdir",
+ "xtask-docs",
+]
+
+[[package]]
+name = "xtask-docs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "hex",
+ "rustic-docs",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "crates/rustic-ui-design-tokens",
     "crates/rustic-ui-utils",
     "crates/rustic-docs",
+    "crates/xtask-docs",
     "crates/xtask",
     "tools/material-parity",
     "tools/joy-parity",
@@ -138,6 +139,9 @@ heck = "0.5"
 tar = { version = "0.4", default-features = false }
 flate2 = "1.0"
 insta = { version = "1.39", features = ["json"], default-features = false }
+camino = "1.1"
+cargo_metadata = "0.18"
+hex = "0.4"
 
 [profile.dev]
 # Development builds prioritize compile time over runtime performance.

--- a/crates/xtask-docs/Cargo.toml
+++ b/crates/xtask-docs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xtask-docs"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+camino.workspace = true
+cargo_metadata.workspace = true
+tokio = { workspace = true, features = ["process", "fs", "io-util", "signal"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
+hex.workspace = true
+rustic-docs = { path = "../rustic-docs", features = ["ssr"] }

--- a/crates/xtask-docs/src/lib.rs
+++ b/crates/xtask-docs/src/lib.rs
@@ -1,0 +1,499 @@
+#![doc = r#"
+Enterprise-grade automation primitives powering the RusticUI documentation
+pipeline.
+
+This crate exists so `cargo xtask` (and CI workflows) can drive the Leptos
+showcase without bespoke shell scripts. The helpers exposed here intentionally
+speak in terms of reusable building blocks—build, test, and package—so future
+workflows (nightly smoke tests, multi-tenant doc deployments, etc.) can compose
+these primitives instead of re-implementing orchestration logic.
+
+# Web testing prerequisites
+
+`docs_test()` shells out to `wasm-pack test --headless --chrome`, which requires
+Playwright's Chromium bundle. Ensure `wasm-pack` is installed and `npx
+playwright install --with-deps chromium` (or an equivalent offline mirror) has
+been executed on the host running these tasks. Without the Playwright binaries
+the test harness will fail before the compiled WASM bundle is even exercised.
+"#]
+
+use anyhow::{anyhow, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use cargo_metadata::MetadataCommand;
+use hex::ToHex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::env;
+use std::fmt::Write as _;
+use std::process::Stdio;
+use tokio::fs;
+use tokio::process::Command;
+
+/// Build the RusticUI docs host binary and its WASM bundle.
+///
+/// The helper reuses `CARGO_TARGET_DIR` when provided to ensure CI caches are
+/// respected and executes the host+wasm compilation in parallel via
+/// `tokio::try_join!`.
+pub async fn docs_build() -> Result<()> {
+    let ctx = WorkspaceContext::detect()?;
+    build_artifacts(&ctx, BuildProfile::Debug).await.map(|_| ())
+}
+
+/// Execute the docs WebAssembly smoke tests using `wasm-pack`.
+///
+/// Failures are captured and recorded in `target/logs/docs-test.log` with the
+/// invoked command line so CI operators can diagnose why Chrome/Playwright
+/// exited with a specific status.
+pub async fn docs_test() -> Result<()> {
+    let ctx = WorkspaceContext::detect()?;
+    run_wasm_tests(&ctx).await
+}
+
+/// Produce a deploy-ready documentation payload containing SSR + WASM assets.
+///
+/// The export directory defaults to `target/deploy/docs` but can be overridden
+/// through `RUSTIC_DOCS_EXPORT_DIR` for environments that persist artifacts
+/// elsewhere (e.g., Bazel or containerized CI runners).
+pub async fn docs_package() -> Result<()> {
+    let ctx = WorkspaceContext::detect()?;
+    let artifacts = build_artifacts(&ctx, BuildProfile::Release).await?;
+    package_release(&ctx, &artifacts).await
+}
+
+struct WorkspaceContext {
+    workspace_root: Utf8PathBuf,
+    rustic_docs_crate: Utf8PathBuf,
+    target_dir: Utf8PathBuf,
+    wasm_staging: Utf8PathBuf,
+}
+
+impl WorkspaceContext {
+    fn detect() -> Result<Self> {
+        let metadata = MetadataCommand::new()
+            .no_deps()
+            .exec()
+            .context("failed to query workspace metadata")?;
+        let workspace_root =
+            Utf8PathBuf::from_path_buf(metadata.workspace_root.into_std_path_buf())
+                .map_err(|_| anyhow!("workspace path was not valid UTF-8"))?;
+        let rustic_docs_crate = workspace_root.join("crates").join("rustic-docs");
+        let target_dir = env::var("CARGO_TARGET_DIR")
+            .map(Utf8PathBuf::from)
+            .unwrap_or_else(|_| workspace_root.join("target"));
+        let wasm_staging = target_dir.join("rustic-docs-wasm");
+        Ok(Self {
+            workspace_root,
+            rustic_docs_crate,
+            target_dir,
+            wasm_staging,
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum BuildProfile {
+    Debug,
+    Release,
+}
+
+impl BuildProfile {
+    fn cargo_flag(self) -> Option<&'static str> {
+        match self {
+            BuildProfile::Debug => None,
+            BuildProfile::Release => Some("--release"),
+        }
+    }
+
+    fn artifact_dir(self) -> &'static str {
+        match self {
+            BuildProfile::Debug => "debug",
+            BuildProfile::Release => "release",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DocsBuildArtifacts {
+    wasm_js: Utf8PathBuf,
+    wasm_bg: Utf8PathBuf,
+    server_binary: Utf8PathBuf,
+}
+
+async fn build_artifacts(
+    ctx: &WorkspaceContext,
+    profile: BuildProfile,
+) -> Result<DocsBuildArtifacts> {
+    let host_build = build_host(ctx, profile);
+    let wasm_build = build_wasm(ctx, profile);
+
+    // Building the host binary and wasm bundle concurrently keeps the overall
+    // wall-clock time low while still letting both targets benefit from the
+    // shared Cargo target directory cache.
+    tokio::try_join!(host_build, wasm_build)?;
+
+    let wasm_artifacts = run_wasm_bindgen(ctx, profile).await?;
+    let server_binary = ctx
+        .target_dir
+        .join(profile.artifact_dir())
+        .join(format!("rustic-docs-server{}", env::consts::EXE_SUFFIX));
+
+    Ok(DocsBuildArtifacts {
+        wasm_js: wasm_artifacts.js,
+        wasm_bg: wasm_artifacts.wasm,
+        server_binary,
+    })
+}
+
+async fn build_host(ctx: &WorkspaceContext, profile: BuildProfile) -> Result<()> {
+    let mut display = CommandDisplay::new("cargo");
+    display.push("build");
+    display.push("-p");
+    display.push("rustic-docs");
+    display.push("--bin");
+    display.push("rustic-docs-server");
+    display.push("--features");
+    display.push("ssr");
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&ctx.workspace_root)
+        .arg("build")
+        .arg("-p")
+        .arg("rustic-docs")
+        .arg("--bin")
+        .arg("rustic-docs-server")
+        .arg("--features")
+        .arg("ssr");
+    if let Some(flag) = profile.cargo_flag() {
+        display.push(flag);
+        cmd.arg(flag);
+    }
+    cmd.env("CARGO_TARGET_DIR", &ctx.target_dir);
+    let status = cmd
+        .status()
+        .await
+        .with_context(|| format!("failed to execute {}", display.render()))?;
+    if !status.success() {
+        return Err(anyhow!(
+            "cargo build for rustic-docs-server failed with status {status}"
+        ));
+    }
+    Ok(())
+}
+
+async fn build_wasm(ctx: &WorkspaceContext, profile: BuildProfile) -> Result<()> {
+    let mut display = CommandDisplay::new("cargo");
+    display.push("build");
+    display.push("-p");
+    display.push("rustic-docs");
+    display.push("--bin");
+    display.push("rustic-docs");
+    display.push("--target");
+    display.push("wasm32-unknown-unknown");
+    display.push("--no-default-features");
+    display.push("--features");
+    display.push("hydrate");
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&ctx.workspace_root)
+        .arg("build")
+        .arg("-p")
+        .arg("rustic-docs")
+        .arg("--bin")
+        .arg("rustic-docs")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .arg("--no-default-features")
+        .arg("--features")
+        .arg("hydrate");
+    if let Some(flag) = profile.cargo_flag() {
+        display.push(flag);
+        cmd.arg(flag);
+    }
+    cmd.env("CARGO_TARGET_DIR", &ctx.target_dir);
+    let status = cmd
+        .status()
+        .await
+        .with_context(|| format!("failed to execute {}", display.render()))?;
+    if !status.success() {
+        return Err(anyhow!("cargo build for rustic-docs wasm bundle failed"));
+    }
+    Ok(())
+}
+
+struct WasmBindgenArtifacts {
+    js: Utf8PathBuf,
+    wasm: Utf8PathBuf,
+}
+
+async fn run_wasm_bindgen(
+    ctx: &WorkspaceContext,
+    profile: BuildProfile,
+) -> Result<WasmBindgenArtifacts> {
+    let input_wasm = ctx
+        .target_dir
+        .join("wasm32-unknown-unknown")
+        .join(profile.artifact_dir())
+        .join("rustic_docs.wasm");
+    let output_dir = ctx.wasm_staging.join(profile.artifact_dir());
+    fs::create_dir_all(&output_dir)
+        .await
+        .with_context(|| format!("failed to create wasm staging dir {output_dir}"))?;
+
+    let mut display = CommandDisplay::new("wasm-bindgen");
+    display.push(input_wasm.as_str());
+    display.push("--out-dir");
+    display.push(output_dir.as_str());
+    display.push("--target");
+    display.push("web");
+    display.push("--no-typescript");
+    display.push("--omit-default-module-path");
+    let mut cmd = Command::new("wasm-bindgen");
+    cmd.arg(&input_wasm)
+        .arg("--out-dir")
+        .arg(&output_dir)
+        .arg("--target")
+        .arg("web")
+        .arg("--no-typescript")
+        .arg("--omit-default-module-path")
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let status = cmd
+        .status()
+        .await
+        .with_context(|| format!("failed to execute {}", display.render()))?;
+    if !status.success() {
+        return Err(anyhow!("wasm-bindgen returned non-zero exit status"));
+    }
+
+    let js = output_dir.join("rustic_docs.js");
+    let wasm = output_dir.join("rustic_docs_bg.wasm");
+    Ok(WasmBindgenArtifacts { js, wasm })
+}
+
+async fn run_wasm_tests(ctx: &WorkspaceContext) -> Result<()> {
+    let mut display = CommandDisplay::new("wasm-pack");
+    display.push("test");
+    display.push("--headless");
+    display.push("--chrome");
+    display.push("--release");
+    display.push("--");
+    display.push("--features");
+    display.push("hydrate");
+    let mut cmd = Command::new("wasm-pack");
+    cmd.current_dir(&ctx.rustic_docs_crate)
+        .arg("test")
+        .arg("--headless")
+        .arg("--chrome")
+        .arg("--release")
+        .arg("--")
+        .arg("--features")
+        .arg("hydrate")
+        .env("CARGO_TARGET_DIR", &ctx.target_dir);
+
+    let output = cmd
+        .output()
+        .await
+        .with_context(|| format!("failed to execute {}", display.render()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let logs_dir = ctx.target_dir.join("logs");
+    fs::create_dir_all(&logs_dir)
+        .await
+        .context("failed to create target/logs for wasm-pack output")?;
+    let log_path = logs_dir.join("docs-test.log");
+    let mut log = String::new();
+    writeln!(&mut log, "command: {}", display.render())?;
+    writeln!(&mut log, "status: {}", output.status)?;
+    writeln!(
+        &mut log,
+        "\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    )?;
+    writeln!(
+        &mut log,
+        "\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    )?;
+    fs::write(&log_path, log)
+        .await
+        .with_context(|| format!("failed to persist wasm-pack output to {log_path}"))?;
+
+    Err(anyhow!(
+        "wasm-pack smoke tests failed. Inspect {:?} for the detailed log.",
+        log_path
+    ))
+}
+
+async fn package_release(ctx: &WorkspaceContext, artifacts: &DocsBuildArtifacts) -> Result<()> {
+    let export_dir = env::var("RUSTIC_DOCS_EXPORT_DIR")
+        .map(Utf8PathBuf::from)
+        .unwrap_or_else(|_| ctx.target_dir.join("deploy").join("docs"));
+    fs::create_dir_all(&export_dir)
+        .await
+        .with_context(|| format!("failed to create export directory {export_dir}"))?;
+
+    let wasm_out = export_dir.join("wasm");
+    fs::create_dir_all(&wasm_out)
+        .await
+        .context("failed to create wasm export directory")?;
+    let wasm_js_dest = wasm_out.join(
+        artifacts
+            .wasm_js
+            .file_name()
+            .ok_or_else(|| anyhow!("missing wasm-bindgen js artifact name"))?,
+    );
+    let wasm_bg_dest = wasm_out.join(
+        artifacts
+            .wasm_bg
+            .file_name()
+            .ok_or_else(|| anyhow!("missing wasm-bindgen wasm artifact name"))?,
+    );
+
+    fs::copy(&artifacts.wasm_js, &wasm_js_dest)
+        .await
+        .context("failed to copy wasm-bindgen js glue into export dir")?;
+    fs::copy(&artifacts.wasm_bg, &wasm_bg_dest)
+        .await
+        .context("failed to copy wasm-bindgen wasm into export dir")?;
+
+    let bin_dir = export_dir.join("bin");
+    fs::create_dir_all(&bin_dir)
+        .await
+        .context("failed to create bin export directory")?;
+    let server_dest = bin_dir.join(format!("rustic-docs-server{}", env::consts::EXE_SUFFIX));
+    fs::copy(&artifacts.server_binary, &server_dest)
+        .await
+        .context("failed to copy server binary into export dir")?;
+
+    let snapshot_path = export_dir.join("index.html");
+    let snapshot = rustic_docs::render_static_snapshot();
+    fs::write(&snapshot_path, snapshot)
+        .await
+        .context("failed to write static snapshot")?;
+
+    let contract_path = export_dir.join("static-manifest.json");
+    let contract = rustic_docs::static_manifest_contract();
+    fs::write(
+        &contract_path,
+        serde_json::to_vec_pretty(&contract).context("failed to serialize static manifest")?,
+    )
+    .await
+    .context("failed to write static manifest contract")?;
+
+    let manifest = BuildManifest::from_paths(
+        ctx,
+        &export_dir,
+        &wasm_js_dest,
+        &wasm_bg_dest,
+        &server_dest,
+        &snapshot_path,
+        &contract_path,
+    )
+    .await?;
+    let manifest_path = export_dir.join("docs-bundle-manifest.json");
+    let manifest_bytes =
+        serde_json::to_vec_pretty(&manifest).context("failed to serialize docs bundle manifest")?;
+    fs::write(&manifest_path, manifest_bytes)
+        .await
+        .context("failed to write docs bundle manifest")?;
+
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct BuildManifestEntry {
+    path: String,
+    sha256: String,
+}
+
+#[derive(Serialize)]
+struct BuildManifest {
+    wasm_js: BuildManifestEntry,
+    wasm_bg: BuildManifestEntry,
+    server_binary: BuildManifestEntry,
+    static_snapshot: BuildManifestEntry,
+    static_manifest: BuildManifestEntry,
+}
+
+impl BuildManifest {
+    async fn from_paths(
+        ctx: &WorkspaceContext,
+        export_dir: &Utf8Path,
+        wasm_js: &Utf8Path,
+        wasm_bg: &Utf8Path,
+        server: &Utf8Path,
+        snapshot: &Utf8Path,
+        contract: &Utf8Path,
+    ) -> Result<Self> {
+        Ok(Self {
+            wasm_js: manifest_entry(ctx, export_dir, wasm_js).await?,
+            wasm_bg: manifest_entry(ctx, export_dir, wasm_bg).await?,
+            server_binary: manifest_entry(ctx, export_dir, server).await?,
+            static_snapshot: manifest_entry(ctx, export_dir, snapshot).await?,
+            static_manifest: manifest_entry(ctx, export_dir, contract).await?,
+        })
+    }
+}
+
+async fn manifest_entry(
+    ctx: &WorkspaceContext,
+    export_dir: &Utf8Path,
+    path: &Utf8Path,
+) -> Result<BuildManifestEntry> {
+    let bytes = fs::read(path)
+        .await
+        .with_context(|| format!("failed to read {path} for hashing"))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let sha256 = hasher.finalize().encode_hex::<String>();
+    let relative = path
+        .strip_prefix(&ctx.workspace_root)
+        .or_else(|_| path.strip_prefix(export_dir))
+        .unwrap_or(path)
+        .to_string();
+    Ok(BuildManifestEntry {
+        path: relative,
+        sha256,
+    })
+}
+
+struct CommandDisplay {
+    program: String,
+    args: Vec<String>,
+}
+
+impl CommandDisplay {
+    fn new(program: &str) -> Self {
+        Self {
+            program: program.to_string(),
+            args: Vec::new(),
+        }
+    }
+
+    fn push<S>(&mut self, arg: S)
+    where
+        S: AsRef<str>,
+    {
+        self.args.push(arg.as_ref().to_string());
+    }
+
+    fn render(&self) -> String {
+        let mut repr = quote_segment(&self.program);
+        for arg in &self.args {
+            repr.push(' ');
+            repr.push_str(&quote_segment(arg));
+        }
+        repr
+    }
+}
+
+fn quote_segment(segment: &str) -> String {
+    if segment.is_empty()
+        || segment.contains(|c: char| c.is_whitespace() || matches!(c, '"' | '\''))
+    {
+        format!("\"{}\"", segment.replace('"', "\\\""))
+    } else {
+        segment.to_string()
+    }
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -23,6 +23,8 @@ swc_ecma_ast = { version = "15.0.0", features = ["serde"] }
 swc_ecma_parser = { version = "24.0.1", features = ["typescript"] }
 headless_chrome = { version = "1.0.18" }
 ureq = { version = "2.9", features = ["json"] }
+xtask-docs = { path = "../xtask-docs" }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -28,9 +28,12 @@ use std::collections::BTreeSet;
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tokio::runtime::Builder;
 use walkdir::WalkDir;
+use xtask_docs::{docs_build, docs_package, docs_test};
 
 mod docs_assets;
 mod selection_controls_web;
@@ -111,6 +114,27 @@ enum Commands {
     },
     /// Replace the legacy Node docs scripts with Rust-first automation.
     DocsAssets(DocsAssetsArgs),
+    /// Build the Rustic docs binaries and wasm bundle without packaging.
+    #[command(
+        name = "docs-build",
+        about = "Build the Rustic docs host binary and wasm bundle in parallel.",
+        long_about = "Build the Rustic docs host binary and wasm bundle in parallel while reusing CARGO_TARGET_DIR so local and CI caches stay hot. The helper also runs wasm-bindgen to stage artifacts under target/rustic-docs-wasm, eliminating the need for contributors to remember the exact CLI flags."
+    )]
+    DocsBuild,
+    /// Run the Rustic docs wasm smoke tests in headless Chrome.
+    #[command(
+        name = "docs-test",
+        about = "Execute wasm-pack smoke tests for the Rustic docs bundle.",
+        long_about = "Execute wasm-pack smoke tests for the Rustic docs bundle. Ensure Playwright's Chromium runtime is installed (e.g. via `npx playwright install --with-deps chromium`) before invoking this command locally or in CI. Logs are captured in target/logs/docs-test.log to streamline debugging when headless Chrome fails to start."
+    )]
+    DocsTest,
+    /// Produce a deployable docs payload with SSR + wasm artifacts.
+    #[command(
+        name = "docs-package",
+        about = "Assemble deploy-ready Rustic docs assets.",
+        long_about = "Assemble deploy-ready Rustic docs assets by exporting the SSR snapshot, wasm-bindgen output, and server binary into target/deploy/docs (override via RUSTIC_DOCS_EXPORT_DIR). A JSON manifest describing file hashes is generated so CD pipelines can validate integrity before publishing."
+    )]
+    DocsPackage,
     /// Generate an `lcov.info` report using grcov.
     Coverage,
     /// Execute Criterion benchmarks. Succeeds even if none exist.
@@ -198,6 +222,9 @@ fn main() -> Result<()> {
         Commands::RefreshIcons => refresh_icons(),
         Commands::IconsBundle { compat, out_dir } => icons_bundle(out_dir, compat),
         Commands::DocsAssets(args) => docs_assets(args),
+        Commands::DocsBuild => run_async_task("docs::build", docs_build()),
+        Commands::DocsTest => run_async_task("docs::test", docs_test()),
+        Commands::DocsPackage => run_async_task("docs::package", docs_package()),
         Commands::Coverage => coverage(),
         Commands::Bench => bench(),
         Commands::UpdateComponents => update_components(),
@@ -220,6 +247,28 @@ fn main() -> Result<()> {
         Commands::MaterialParity => material_parity(),
         Commands::JoyParity => joy_parity(),
         Commands::SelectionControls(args) => selection_controls(args),
+    }
+}
+
+fn run_async_task<F>(label: &str, fut: F) -> Result<()>
+where
+    F: Future<Output = Result<()>>,
+{
+    eprintln!("[{label}] starting");
+    let runtime = Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to initialize Tokio runtime for docs automation")?;
+    let result = runtime.block_on(fut);
+    match result {
+        Ok(()) => {
+            eprintln!("[{label}] completed");
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("[{label}] failed: {err:?}");
+            Err(err)
+        }
     }
 }
 

--- a/crates/xtask/tests/cli_help.rs
+++ b/crates/xtask/tests/cli_help.rs
@@ -142,6 +142,68 @@ fn examples_help_highlights_layout_group() -> Result<()> {
 }
 
 #[test]
+fn docs_build_help_mentions_cache_hint() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("run")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .arg("docs-build")
+        .arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("target/rustic-docs-wasm"))
+        .stdout(predicate::str::contains("CARGO_TARGET_DIR"));
+
+    Ok(())
+}
+
+#[test]
+fn docs_test_help_mentions_playwright() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("run")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .arg("docs-test")
+        .arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("wasm-pack"))
+        .stdout(predicate::str::contains("Playwright"))
+        .stdout(predicate::str::contains("docs-test.log"));
+
+    Ok(())
+}
+
+#[test]
+fn docs_package_help_mentions_export_dir() -> Result<()> {
+    let workspace = workspace_root();
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(&workspace)
+        .arg("run")
+        .arg("-p")
+        .arg("xtask")
+        .arg("--")
+        .arg("docs-package")
+        .arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("deploy-ready Rustic docs"))
+        .stdout(predicate::str::contains("RUSTIC_DOCS_EXPORT_DIR"))
+        .stdout(predicate::str::contains("hashes"));
+
+    Ok(())
+}
+
+#[test]
 fn deploy_docs_help_mentions_env_overrides() -> Result<()> {
     let workspace = workspace_root();
     let mut cmd = Command::new("cargo");


### PR DESCRIPTION
## Summary
- add the new `xtask-docs` helper crate that orchestrates building, testing, and packaging the Rustic docs bundles, including wasm-bindgen staging and manifest generation
- wire the helper into `cargo xtask` via new `docs-build`, `docs-test`, and `docs-package` subcommands with asynchronous execution scaffolding and CLI help coverage
- expand the xtask CLI tests to assert the new documentation automation entry points and their guidance

## Testing
- `cargo fmt`
- `cargo check -p xtask-docs`
- `cargo test -p xtask --tests`
- `cargo xtask docs-build` *(fails: upstream leptos_dom 0.6.12 expects ElementChildren fields while compiling for wasm32; command currently requires additional Leptos configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c4b0abb4832eac225197cd774f6a