### PR TITLE
docs: document docs xtask pipeline dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,19 +40,23 @@ All repetitive chores are encapsulated inside the `Makefile` or `cargo xtask`. P
 
 ### Documentation hosting pipeline
 
-The documentation site, API reference, and wasm demos ship through the new docs subcommands exposed by `cargo xtask`. The
+The documentation site, API reference, and wasm demos ship through the docs subcommands exposed by `cargo xtask`. The
 pipeline splits into explicit `docs-build`, `docs-test`, and `docs-package` phases so contributors and CI can validate each
 stage independently before staging artifacts in `target/deploy/docs`. Hosting integrations (Netlify, Vercel, GitHub Pages,
-internal CDNs) point at that directory without invoking pnpm or bespoke shell scripts.
+internal CDNs) point at that directory without invoking pnpm or bespoke shell scripts. All orchestration code lives in
+[`crates/xtask-docs`](crates/xtask-docs/README.md), with the Leptos/SSR implementation residing in [`crates/rustic-docs`](crates/rustic-docs/README.md) for deeper context.
 
-Key flags and environment variables:
+Key commands and required tooling:
 
-- `cargo xtask docs-build` – Compiles the docs server binary and wasm bundle in parallel, reusing the shared `CARGO_TARGET_DIR`.
-- `cargo xtask docs-test` – Runs the wasm smoke tests in headless Chromium via Playwright. Ensure `npx playwright install --with-deps chromium` and `wasm-pack` are available locally.
-- `cargo xtask docs-package --dry-run` – Executes the release packaging flow without mutating the canonical export directory. Useful in CI pull requests and local spot checks.
-- `RUSTIC_DOCS_EXPORT_DIR` – Override the default staging directory (`target/deploy/docs`).
-- `RUSTIC_UI_DEPLOY_PROFILE` / `RUSTIC_UI_DEPLOY_GROUPS` – Remain available when invoking the legacy `cargo xtask deploy-docs`
-  wrapper for teams that have not yet migrated bespoke automation.
+- `cargo xtask docs-build` – Compiles the docs server binary and wasm bundle in parallel, reusing the shared `CARGO_TARGET_DIR` cache. Install [`mdBook`](https://rust-lang.github.io/mdBook/) and [`wasm-bindgen-cli`](https://rustwasm.github.io/wasm-bindgen/reference/cli.html) via Cargo so the helper can render the Rust book and run `wasm-bindgen` without fallback scripts.
+- `cargo xtask docs-test` – Runs the wasm smoke tests in headless Chromium via Playwright. Ensure `npx playwright install --with-deps chromium` and [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) are available locally. Cache the browsers by exporting `PLAYWRIGHT_BROWSERS_PATH=0` (the repository default) or pointing the variable at a shared directory in CI to avoid repeated downloads.
+- `cargo xtask docs-package --dry-run` – Executes the release packaging flow without mutating the canonical export directory. Useful in CI pull requests and local spot checks. Drop `--dry-run` once the staged payload looks correct to mirror production deploys.
+
+Environment overrides:
+
+- `RUSTIC_DOCS_EXPORT_DIR` – Override the default staging directory (`target/deploy/docs`) when CI needs a dedicated artifact volume.
+- `RUSTIC_DOCS_TRACING_ENDPOINT` – Surface SSR/CSR telemetry destinations to the `rustic-docs` binaries without recompiling.
+- `RUSTIC_UI_DEPLOY_PROFILE` / `RUSTIC_UI_DEPLOY_GROUPS` – Remain available when invoking the legacy `cargo xtask deploy-docs` wrapper for teams that have not yet migrated bespoke automation.
 
 The root `Makefile` exposes matching entry points via `make docs-build`, `make docs-test`, and `make docs-package` (alongside the
 backward-compatible `make deploy-docs`). Invoke them locally before modifying Netlify/Vercel configuration so reviewers can

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ make build        # compile every crate
 make test         # run workspace tests
 make doc          # generate API docs
 make docs-build   # build the docs host binary + wasm bundle
-make docs-test    # exercise the wasm smoke tests backing the docs site
+make docs-test    # exercise the Playwright-driven wasm smoke tests
 make docs-package # stage deploy-ready docs artifacts under target/deploy/docs
 ```
 
@@ -238,11 +238,17 @@ cargo xtask icon-update           # pull the latest Rustic icon sets
 cargo xtask update-components     # emit the Rust-native component metadata manifest
 cargo xtask accessibility-audit   # lint Markdown docs for accessibility regressions
 cargo xtask docs-build            # build the docs host binary + wasm bundle
-cargo xtask docs-test             # run the wasm smoke tests powering the docs site
+cargo xtask docs-test             # run the Playwright/Chromium wasm smoke tests
 cargo xtask docs-package          # assemble deploy-ready SSR + wasm assets
 ```
 
-Each task emits verbose logs and returns a non-zero exit code on failure so it can be safely wired into CI pipelines.
+Each task emits verbose logs and returns a non-zero exit code on failure so it can be safely wired into CI pipelines. Provision the following shared dependencies once per runner to keep the docs workflow reproducible:
+
+- [`mdBook`](https://rust-lang.github.io/mdBook/) (`cargo install mdbook`) for the Rust-first guide under `docs/rust-book/`.
+- [`wasm-bindgen-cli`](https://rustwasm.github.io/wasm-bindgen/reference/cli.html) (`cargo install wasm-bindgen-cli`) which powers the wasm smoke tests and `wasm-bindgen-test` runners.
+- [Playwright](https://playwright.dev/docs/intro) with Chromium support (`npx playwright install --with-deps chromium`) so `cargo xtask docs-test` can launch headless browsers without bespoke scripts.
+
+> **Automation tip:** cache the Playwright browser install (`PLAYWRIGHT_BROWSERS_PATH=0`) and share Cargo's `target/` directory across CI jobs to avoid rebuilding the SSR binary and wasm bundle on every run.
 
 `cargo xtask update-components` parses the upstream TypeScript declarations without invoking pnpm. The generated manifest now
 records the RusticUI crate identifiers under a `packages` array while preserving the historical npm names under
@@ -258,17 +264,17 @@ dry runs without editing the repository.
 The documentation site ships through a single Rust entrypoint:
 
 ```bash
-cargo xtask docs-package          # stage mdBook, API docs, and wasm bundles into target/deploy/docs
+cargo xtask docs-build             # compile the SSR server + wasm bundle for local preview
+cargo xtask docs-test              # execute the Playwright/Chromium wasm harness against the fresh bundle
+cargo xtask docs-package           # stage mdBook, API docs, and wasm bundles into target/deploy/docs
 cargo xtask docs-package --dry-run # execute the same pipeline without touching the deploy directory
 ```
 
-The command performs the following steps:
+The split commands let CI fan out work (build → test → package) while keeping local flows ergonomic:
 
-1. Runs `cargo doc --workspace --all-features` so API documentation stays in sync with the published crates.
-2. Invokes `mdbook build docs/rust-book` to render the Rust-first guide.
-3. Compiles the curated example groups for both the host and `wasm32-unknown-unknown` targets, copying the resulting `.wasm`
-   bundles into `target/deploy/docs/wasm`.
-4. Emits `target/deploy/docs/deploy-summary.json` describing every staged artifact so hosting pipelines can audit the payload.
+1. `cargo xtask docs-build` compiles the SSR binary, Leptos static renderer, and wasm bundle in one pass so subsequent steps reuse the cached artifacts.
+2. `cargo xtask docs-test` boots the wasm harness inside headless Chromium via Playwright, replaying the docs site's integration tests without pnpm.
+3. `cargo xtask docs-package` runs `cargo doc --workspace --all-features`, invokes `mdbook build docs/rust-book`, compiles the curated example groups for both the host and `wasm32-unknown-unknown` targets, copies the resulting `.wasm` bundles into `target/deploy/docs/wasm`, and emits `target/deploy/docs/deploy-summary.json` for downstream auditing.
 
 Tune the behaviour via environment variables when integrating with bespoke CI/CD stacks:
 

--- a/crates/rustic-docs/README.md
+++ b/crates/rustic-docs/README.md
@@ -50,6 +50,42 @@ The project assumes infrastructure-as-code from day one:
   emit a screenshot manifest that CI tooling can consume without reaching for
   `pnpm`.
 
+## Xtask orchestration
+
+`cargo xtask` wraps the crate so CI and local workflows can drive each
+deployment phase independently:
+
+- `cargo xtask docs-build` calls into `xtask_docs::docs_build`, compiling the
+  `rustic-docs-server` binary with the `ssr` feature, the browser-focused
+  `rustic-docs` wasm target, and the supporting `wasm-bindgen` glue code in
+  parallel. The helper respects `CARGO_TARGET_DIR`, so share that directory
+  across jobs to avoid duplicate compilation.
+- `cargo xtask docs-test` executes the Playwright-powered wasm harness. The
+  command shells through `wasm-pack test --headless --chrome`, which expects the
+  Chromium bundle installed via `npx playwright install --with-deps chromium`.
+  Set `PLAYWRIGHT_BROWSERS_PATH` when caching browsers in CI runners.
+- `cargo xtask docs-package` invokes `xtask_docs::docs_package`, exporting SSR
+  snapshots via `render_static_snapshot`, copying wasm bundles, and mirroring
+  mdBook output into `RUSTIC_DOCS_EXPORT_DIR` (defaults to
+  `target/deploy/docs`). Pass `--dry-run` to rehearse the pipeline without
+  mutating the staging directory.
+
+### Troubleshooting build + test orchestration
+
+- **Stale wasm bundles** – Delete `target/rustic-docs-wasm` (or the custom
+  directory under `CARGO_TARGET_DIR`) if the wasm artifacts fail to refresh
+  after switching Rust toolchains. The `docs-build` helper will rehydrate the
+  directory on the next run.
+- **Playwright launch errors** – Ensure Chromium is installed in the location
+  advertised by `PLAYWRIGHT_BROWSERS_PATH`. When running inside containers,
+  propagate `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1` if the base image
+  already bundles the necessary system libraries.
+- **Concurrent build contention** – When multiple CI jobs share a single
+  network-mounted cache, the parallel host/wasm build may exhaust the default
+  file-descriptor limit. Set `CARGO_BUILD_JOBS=4` (or lower) and re-run
+  `cargo xtask docs-build` to reduce peak concurrency without disabling the
+  shared cache.
+
 ## Running locally
 
 ```bash

--- a/docs/migrations/npm-to-rust.md
+++ b/docs/migrations/npm-to-rust.md
@@ -224,9 +224,18 @@ jobs:
         run: cargo xtask icons-bundle --compat
       - name: Accessibility smoke test
         run: cargo xtask accessibility-audit
-      - name: Build docs
-        run: cargo xtask docs-package
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Build docs artifacts
+        run: cargo xtask docs-build
+      - name: Run docs wasm smoke tests
+        run: cargo xtask docs-test
+      - name: Stage docs (dry-run)
+        run: cargo xtask docs-package --dry-run
 ```
+
+Splitting the workflow keeps cache hits high: `docs-build` reuses the shared `CARGO_TARGET_DIR`, `docs-test` exercises the Playwright-powered wasm harness against the freshly compiled bundle, and `docs-package --dry-run` validates the static export manifest without mutating the canonical `RUSTIC_DOCS_EXPORT_DIR` directory used by production deploys.
+
 
 ## 7. Audit the Rust supply chain
 

--- a/docs/rust-ci.md
+++ b/docs/rust-ci.md
@@ -8,6 +8,9 @@ This document outlines the automation used in our Rust workspace CI and how to r
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/) for WebAssembly tests
 - Latest Chrome or Chromium for headless browser execution (Firefox is optional for local debugging)
 - [`wasm-bindgen-test`](https://rustwasm.github.io/docs/wasm-bindgen/reference/wasm-bindgen-test/introduction.html) (already listed as a dev-dependency in the crates, add it when authoring new suites)
+- [`mdBook`](https://rust-lang.github.io/mdBook/) for the Rust-first guide rendered during docs packaging
+- [`wasm-bindgen-cli`](https://rustwasm.github.io/wasm-bindgen/reference/cli.html) for bundling the docs wasm artifacts
+- [Playwright](https://playwright.dev/docs/intro) with Chromium support so docs wasm tests can execute without pnpm
 - [grcov](https://github.com/mozilla/grcov) for coverage reports
 
 Install prerequisites:
@@ -16,6 +19,9 @@ rustup component add rustfmt clippy llvm-tools-preview
 rustup target add wasm32-unknown-unknown
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 cargo install wasm-bindgen-cli # provides wasm-bindgen-test runners if you extend the suites
+cargo install mdbook
+npm install -g pnpm@9 # optional: required only when touching archived tooling manifests
+npx playwright install --with-deps chromium
 cargo install grcov
 ```
 
@@ -135,6 +141,20 @@ CI relies on this command to build and run WebAssembly tests for both `rustic-ui
 ```
 
 The `--no-default-features` flag mirrors CI by ensuring optional adapters declare their dependencies explicitly. When a run fails because Chrome cannot be located, set `CHROME` or `CHROMIUM` to the browser executable path. Browser console output is captured automatically, so rerun with `-- --nocapture` to view detailed logs.
+
+### Documentation pipeline
+
+CI builds, tests, and stages the documentation site using dedicated `cargo xtask` subcommands. Run the same flow locally to verify mdBook content, the Leptos SSR binary, and Playwright-driven wasm smoke tests:
+
+```bash
+cargo xtask docs-build
+cargo xtask docs-test
+cargo xtask docs-package --dry-run
+```
+
+- `docs-build` compiles the SSR binary, static renderer, and wasm bundle in parallel, reusing `CARGO_TARGET_DIR` caches.
+- `docs-test` launches Playwright's Chromium bundle against the freshly built wasm assets. Install the browsers once via `npx playwright install --with-deps chromium` or point `PLAYWRIGHT_BROWSERS_PATH` at a cached directory.
+- `docs-package --dry-run` validates the static export manifest without mutating the canonical staging directory. Drop the flag when you need to refresh production artifacts in `RUSTIC_DOCS_EXPORT_DIR`.
 
 ### Overlay automation suites
 The click-away detector and focus-trap state machines now back every modal, drawer and menu overlay. To keep telemetry hooks and accessibility metadata aligned across frameworks, CI exercises a dedicated set of suites:

--- a/docs/src/pages/examples/index.md
+++ b/docs/src/pages/examples/index.md
@@ -23,7 +23,9 @@ shipping changes.
    checks.【F:crates/xtask/src/main.rs†L59-L70】【F:crates/xtask/src/main.rs†L439-L576】
 4. **Document the flow.** Extend this gallery and the example README with any
    bespoke analytics requirements or parity notes before running
-   `cargo xtask docs-package` to refresh the docs site for review.【F:crates/xtask/src/main.rs†L150-L200】
+   `cargo xtask docs-build`, `cargo xtask docs-test`, and
+   `cargo xtask docs-package --dry-run` to refresh the docs site for review
+   without mutating the canonical export directory.【F:crates/xtask/src/main.rs†L150-L200】
 
 ## Marketing microsite suite (`examples/mui-*`)
 

--- a/docs/testing/selection-controls.md
+++ b/docs/testing/selection-controls.md
@@ -27,8 +27,8 @@ This sequence mirrors CI without shelling through pnpm:
 2. `cargo xtask clippy` denies warnings so lint regressions surface immediately.
 3. `cargo xtask selection-controls --skip-web` exercises the Material headless suites and the example smoke harness while skipping the new Chromium automation layer. Drop `--skip-web` to execute the Rust-driven browser harness that replaced the historical Node pipeline.【F:crates/xtask/src/main.rs†L1-L120】【F:crates/xtask/src/selection_controls_web.rs†L1-L420】
 4. `cargo xtask docs-build` rebuilds the docs server binary plus wasm bundle so downstream packaging has fresh artifacts.
-5. `cargo xtask docs-test` drives the Playwright-powered wasm smoke tests in headless Chromium.
-6. `cargo xtask docs-package --dry-run` validates the release packaging contract without mutating the canonical export directory.
+5. `cargo xtask docs-test` drives the Playwright-powered wasm smoke tests in headless Chromium. Install the browser bundle once via `npx playwright install --with-deps chromium` (or point `PLAYWRIGHT_BROWSERS_PATH` at a cached directory) so the harness can launch reliably.
+6. `cargo xtask docs-package --dry-run` validates the release packaging contract without mutating the canonical export directory, exercising the static export pipeline wired through `RUSTIC_DOCS_EXPORT_DIR`.
 
 The historical pnpm aggregator lives in [`archives/tooling/node-workspace/`](../../archives/tooling/node-workspace/README.md) for reference. Keep it archived—`cargo xtask verify-toolchain` fails builds if a replacement manifest escapes the quarantine.【F:archives/tooling/node-workspace/README.md†L1-L11】【F:crates/xtask/src/main.rs†L1-L120】【F:crates/xtask/src/main.rs†L240-L330】
 


### PR DESCRIPTION
## Summary
- document mdBook, wasm-bindgen, and Playwright prerequisites for the docs workflows in the root README and contributor guide
- map the new docs-build/docs-test/docs-package split into developer docs, migration guides, and the examples gallery
- expand the rustic-docs README with orchestration guidance, environment overrides, and troubleshooting tips for caching and concurrency

## Testing
- `cargo xtask docs-build` *(fails: leptos_dom compile error when building wasm bundle)*
- `cargo xtask docs-test` *(fails: wasm-pack build hits upstream mio compilation failure under wasm target)*
- `cargo xtask docs-package --dry-run` *(not run due to preceding failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e6b698f8832eaf5049359e55458b