### PR TITLE
Add phased improvement roadmap for RusticUI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,15 @@ introduces dedicated coverage for the automation utilities (click-away
 listeners, focus traps, telemetry streams) plus the Material renderers and
 examples that exercise them end-to-end.
 
+## Strategic improvement program
+
+We are incrementally delivering the enterprise hardening efforts outlined in
+[`improvement-plan.md`](./improvement-plan.md). Start there for a phased roadmap
+spanning discovery work, developer experience enhancements, reliability
+initiatives, ecosystem investments, and long-term evolution tracks. Each phase
+is designed to minimize manual toil through automation-first tooling, thorough
+documentation, and scalable architectural guardrails.
+
 To start the docs site in development mode, from the project root, run:
 
 ```bash

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -1,0 +1,73 @@
+# RusticUI Improvement Program Overview
+
+> **Purpose:** Establish a staged execution plan for elevating RusticUI to an enterprise-grade, pre-production ready design system with a relentless focus on automation, documentation clarity, and massively scalable architecture.
+
+## Guiding Principles
+
+1. **Automate Repetitive Tasks** – Prefer generator tooling, shared pipelines, and reusable primitives over manual workflows.
+2. **Codify Knowledge** – Every change must land with inline comments, doc updates, and runnable examples to accelerate onboarding.
+3. **Scale by Design** – Optimize for multi-framework compatibility, performance, and fault tolerance from the outset.
+
+## Phase 0 – Discovery & Foundations (Current Step)
+
+- [ ] Catalog headless state machine complexity (collapsible region, focus trap) and draft formal state diagrams.
+- [ ] Audit type-safety patterns to identify candidates for typestate or compile-time builders.
+- [ ] Assemble current testing coverage report (snapshot, unit, integration, accessibility, visual).
+- [ ] Inventory automation gaps in `cargo xtask` suite (scaffolding, dev servers, a11y audits).
+
+### Deliverables
+- Centralized documentation index linking to architecture, testing, and migration guides.
+- Contributor experience survey capturing current pain points.
+
+## Phase 1 – Developer Experience Enhancements
+
+1. **Quick Start Overhaul**
+   - Produce a five-minute `Quick Start` doc that bootstraps a material-themed button across supported frameworks.
+   - Embed a visual gallery powered by a live playground (hosted Storybook or Sandpack-driven docs page).
+
+2. **Scaffolding & Automation**
+   - Extend `cargo xtask` with `new-component` generator supporting material/headless templates.
+   - Ship `cargo xtask dev` for hot-reloading example gallery.
+   - Publish Devcontainer + Codespaces configs for consistent onboarding.
+
+3. **Documentation Quality**
+   - Introduce component decision guides (e.g., `Box` vs `Container` vs `Grid`).
+   - Add inline usage snippets across API docs and surface cross-adapter parity tables.
+
+## Phase 2 – Quality & Reliability
+
+- **Testing Upgrades**
+  - Integrate `proptest` suites for state machines.
+  - Stand up visual regression testing pipeline (Chromatic/Playwright) for adapters.
+  - Automate axe-core accessibility scans within CI.
+
+- **Error Handling Modernization**
+  - Unify error modeling with shared crate leveraging `thiserror`.
+  - Ensure public APIs consistently return contextualized `Result` types.
+
+- **Performance Instrumentation**
+  - Bench key rendering paths using `criterion`.
+  - Track bundle-size budgets and expose feature flag cost matrix.
+
+## Phase 3 – Ecosystem & Governance
+
+- Publish complete example applications (dashboard, form wizard, e-commerce).
+- Document SSR/hydration troubleshooting playbooks per adapter.
+- Create CONTRIBUTING, SECURITY, and issue templates if gaps remain after audit.
+- Stand up roadmap board with component stability badges.
+
+## Phase 4 – Continuous Evolution
+
+- Schedule automated dependency updates (Dependabot) with CI cache tuning.
+- Formalize telemetry integration examples with privacy considerations.
+- Plan deprecation strategy for legacy `mui_*`/`compat-mui` artifacts.
+
+## Next Actions
+
+1. Validate scope with maintainers and align on sequencing.
+2. Begin Phase 0 tasks: diagramming state machines and inventorying automation gaps.
+3. Prepare RFCs for xtask tooling upgrades and testing modernization.
+
+---
+
+_This document will evolve alongside delivery milestones; update checklists and add architecture diagrams as tasks progress._


### PR DESCRIPTION
## Summary
- add an improvement-plan document capturing phased enterprise hardening initiatives for RusticUI
- link the docs README to the new roadmap so contributors can find the strategic program quickly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31929becc832e9d6c8acdffdeadd3