### PR TITLE
Add docs quick-start CTA Playwright smoke coverage

### DIFF
--- a/crates/xtask-docs/src/lib.rs
+++ b/crates/xtask-docs/src/lib.rs
@@ -15,6 +15,12 @@ Playwright's Chromium bundle. Ensure `wasm-pack` is installed and `npx
 playwright install --with-deps chromium` (or an equivalent offline mirror) has
 been executed on the host running these tasks. Without the Playwright binaries
 the test harness will fail before the compiled WASM bundle is even exercised.
+
+The command also runs the docs `quick-start-gallery` Playwright spec using
+`pnpm --dir docs exec -- playwright test`. Provide a running docs host (for
+example via `pnpm --dir docs dev`) and set `PLAYWRIGHT_TEST_BASE_URL` to the
+corresponding URL so the iframe-based Sandpack preview can hydrate before the
+assertions execute.
 "#]
 
 use anyhow::{anyhow, Context, Result};
@@ -39,14 +45,19 @@ pub async fn docs_build() -> Result<()> {
     build_artifacts(&ctx, BuildProfile::Debug).await.map(|_| ())
 }
 
-/// Execute the docs WebAssembly smoke tests using `wasm-pack`.
+/// Execute the docs smoke tests.
 ///
-/// Failures are captured and recorded in `target/logs/docs-test.log` with the
-/// invoked command line so CI operators can diagnose why Chrome/Playwright
-/// exited with a specific status.
+/// The workflow now covers two surfaces: the legacy wasm-pack smoke test that
+/// validates the Leptos bundle and a Playwright scenario that asserts the docs
+/// quick-start gallery renders the shared CTA with the correct automation
+/// hooks. Failures are captured and recorded in `target/logs/docs-test.log` and
+/// `target/logs/docs-playwright.log` respectively with the invoked command line
+/// so CI operators can diagnose why Chrome/Playwright exited with a specific
+/// status.
 pub async fn docs_test() -> Result<()> {
     let ctx = WorkspaceContext::detect()?;
-    run_wasm_tests(&ctx).await
+    run_wasm_tests(&ctx).await?;
+    run_playwright_quick_start_smoke(&ctx).await
 }
 
 /// Produce a deploy-ready documentation payload containing SSR + WASM assets.
@@ -327,6 +338,67 @@ async fn run_wasm_tests(ctx: &WorkspaceContext) -> Result<()> {
 
     Err(anyhow!(
         "wasm-pack smoke tests failed. Inspect {:?} for the detailed log.",
+        log_path
+    ))
+}
+
+async fn run_playwright_quick_start_smoke(ctx: &WorkspaceContext) -> Result<()> {
+    let mut display = CommandDisplay::new("pnpm");
+    display.push("--dir");
+    display.push("docs");
+    display.push("exec");
+    display.push("--");
+    display.push("playwright");
+    display.push("test");
+    display.push("--config");
+    display.push("test/e2e-website/playwright.config.ts");
+    display.push("test/e2e-website/quick-start-gallery.spec.ts");
+
+    let mut cmd = Command::new("pnpm");
+    cmd.current_dir(&ctx.workspace_root)
+        .arg("--dir")
+        .arg("docs")
+        .arg("exec")
+        .arg("--")
+        .arg("playwright")
+        .arg("test")
+        .arg("--config")
+        .arg("test/e2e-website/playwright.config.ts")
+        .arg("test/e2e-website/quick-start-gallery.spec.ts")
+        .env("CARGO_TARGET_DIR", &ctx.target_dir);
+
+    let output = cmd
+        .output()
+        .await
+        .with_context(|| format!("failed to execute {}", display.render()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let logs_dir = ctx.target_dir.join("logs");
+    fs::create_dir_all(&logs_dir)
+        .await
+        .context("failed to create target/logs for Playwright output")?;
+    let log_path = logs_dir.join("docs-playwright.log");
+    let mut log = String::new();
+    writeln!(&mut log, "command: {}", display.render())?;
+    writeln!(&mut log, "status: {}", output.status)?;
+    writeln!(
+        &mut log,
+        "\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    )?;
+    writeln!(
+        &mut log,
+        "\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    )?;
+    fs::write(&log_path, log)
+        .await
+        .with_context(|| format!("failed to persist Playwright output to {log_path}"))?;
+
+    Err(anyhow!(
+        "Playwright docs smoke tests failed. Inspect {:?} for the detailed log.",
         log_path
     ))
 }

--- a/test/e2e-website/README.md
+++ b/test/e2e-website/README.md
@@ -2,10 +2,16 @@
 
 ## Running locally
 
-1. Run `pnpm docs:dev` to start the development docs server.
-2. Run `pnpm test:e2e-website` in a separate terminal to run the test suites (`*.spec.ts`) inside `test/e2e-website` folder.
+1. Run `pnpm --dir docs dev` to start the development docs server. The Playwright suites rely on a fully hydrated docs instance so the embedded Sandpack previews can boot.
+2. Export `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:3000` (or whichever host/port your docs server prints) before launching Playwright. CI pipelines typically inject a Netlify deploy preview URL into this variable.
+3. Run `pnpm --dir docs exec -- playwright test --config test/e2e-website/playwright.config.ts` in a separate terminal to execute the smoke suites (`*.spec.ts`) inside `test/e2e-website`.
 
-> use --headed to run tests in headed browsers, check out [Playwright CLI](https://playwright.dev/docs/intro#command-line) for more options
+> Pass `--headed` to run tests in headed browsers, check out [Playwright CLI](https://playwright.dev/docs/intro#command-line) for more options.
+
+### Quick-start gallery coverage
+
+- `quick-start-gallery.spec.ts` drives the `/examples/quick-start-gallery` page, waits for the Sandpack iframe to hydrate, and asserts that the rendered call-to-action exposes `data-rustic-app-action="app-quick-start-primary"`, `data-rustic-analytics="docs.quick-start.button"`, and the visible label text from `QuickStartButtonGenerator.ts`.
+- The scenario ensures docs, StackBlitz, and Rust quick-start flows continue sharing the same analytics hooks; failures surface under `target/logs/docs-playwright.log` when invoked via `cargo xtask docs-test`.
 
 ## CI
 

--- a/test/e2e-website/quick-start-gallery.spec.ts
+++ b/test/e2e-website/quick-start-gallery.spec.ts
@@ -1,0 +1,39 @@
+import { test as base, expect } from '@playwright/test';
+import { TestFixture } from './playwright.config';
+
+const test = base.extend<TestFixture>({});
+
+test.describe('Quick-start gallery docs smoke test', () => {
+  test('Sandpack preview hydrates the shared quick-start CTA with analytics hooks', async ({ page }) => {
+    // Navigate directly via baseURL-relative path so CI and local runs can point PLAYWRIGHT_TEST_BASE_URL
+    // at either a Netlify deploy preview or a `pnpm docs:dev` server without further edits.
+    await page.goto('/examples/quick-start-gallery');
+
+    // Sandpack streams markup through an iframe; use a wildcard title selector to stay resilient against
+    // upstream title casing tweaks while we wait for the React preview to hydrate.
+    const previewFrame = page.frameLocator('iframe[title*="Sandpack"]');
+
+    // The generator renders an H1 immediately once hydration finishes. Waiting on the heading makes sure the
+    // iframe finished booting the React tree before we assert on the CTA attributes.
+    await expect(
+      previewFrame.getByRole('heading', { name: 'RusticUI quick-start CTA' }),
+    ).toBeVisible();
+
+    // The shared QuickStartButton component always renders a Material <Button component="a"> anchor so the
+    // accessible role resolves to "link". Assert against the deterministic label to guarantee the Sandpack
+    // preview pulled data from `QuickStartButtonGenerator.ts` instead of stale markup.
+    const primaryCta = previewFrame.getByRole('link', {
+      name: 'Bootstrap the shared Material shell',
+    });
+    await expect(primaryCta).toBeVisible();
+
+    // Downstream automation relies on the analytics and app-action attributes. Matching the generator output
+    // here prevents regressions if the component ever changes its props or default analytics identifier.
+    await expect(primaryCta).toHaveAttribute('data-rustic-app-action', 'app-quick-start-primary');
+    await expect(primaryCta).toHaveAttribute('data-rustic-analytics', 'docs.quick-start.button');
+
+    // Double-check the rendered text to catch situations where translations or markup changes accidentally
+    // strip the human-facing label that doc copy references.
+    await expect(primaryCta).toHaveText('Bootstrap the shared Material shell');
+  });
+});


### PR DESCRIPTION
## Summary
- add a docs Playwright spec that drives the quick-start gallery and asserts the shared CTA exposes the expected automation and analytics metadata
- extend `cargo xtask docs-test` to launch the new Playwright scenario alongside the existing wasm smoke tests, capturing logs on failure
- document the additional local setup and coverage details in the docs e2e README so contributors can hydrate Sandpack previews before running the suite

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68e3c0affb0c832eb5c8e3004c218510