### PR TITLE
Document quick-start verification workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,27 @@ The root `Makefile` exposes matching entry points via `make docs-build`, `make d
 backward-compatible `make deploy-docs`). Invoke them locally before modifying Netlify/Vercel configuration so reviewers can
 inspect the staged output.
 
+### Quick-start scaffolds and verification
+
+RusticUI maintains automation-first quick-start blueprints across Yew, Leptos, Dioxus, Sycamore, and React so every framework
+shares the same telemetry, SSR snapshots, and automation selectors. The gallery in
+[`docs/src/pages/getting-started/quick-start.md`](docs/src/pages/getting-started/quick-start.md) maps each scaffold to its
+bootstrap script and follow-up smoke tests, keeping enterprise rollouts reproducible without bespoke glue code.【F:docs/src/pages/getting-started/quick-start.md†L1-L136】
+
+- Run `cargo xtask quick-start` before sending pull requests that touch the gallery, example bootstraps, or docs references. The
+  orchestration shells through every documented scaffold, executes the framework-specific checks, and writes transcripts to
+  `target/logs/quick-start.log` so reviewers can audit results without rerunning the suite.【F:crates/xtask/src/main.rs†L206-L233】【F:crates/xtask/src/main.rs†L3078-L3296】
+- Pass `--skip-checks` only when the target environment lacks optional toolchains (for example, when Playwright browsers or
+  npm-based headless harnesses are unavailable). Even then, note the limitation in the pull request summary so CI reruns the full
+  verification path.【F:crates/xtask/src/main.rs†L206-L233】
+- Cache heavy dependencies to minimise bootstrap time: export `PLAYWRIGHT_BROWSERS_PATH=0` (or a shared CI directory) so docs
+  specs reuse installed Chromium builds, share `CARGO_TARGET_DIR` across jobs to avoid recompiling scaffolds, and persist
+  `TRUNK_HOME`, `DX_CACHE_DIR`, or `DIOXUS_CONFIG_DIR` when working with Trunk/dx-powered examples.【F:CONTRIBUTING.md†L54-L87】【F:docs/src/pages/getting-started/quick-start.md†L9-L88】
+
+Document the command output in your changelog or pull request template when it influences review (for example, when refreshing a
+StackBlitz snapshot or updating automation IDs). Contributors are expected to keep the quick-start verification log alongside
+other CI evidence (fmt, clippy, deny, tests) so consumers inherit a proven automation baseline.
+
 ### Archived JavaScript workspace
 
 Legacy Material UI sources now live under `archives/mui-packages/`. Each folder is a symlink back to

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Run the Yew starter to confirm the crates integrate with framework tooling:
 cargo run --manifest-path examples/mui-yew/Cargo.toml --features csr
 ```
 
+Before submitting changes, follow the [quick-start automation verification playbook](docs/testing/quick-start.md) and run
+`cargo xtask quick-start` to exercise every scaffold documented in the getting-started guide. The harness keeps StackBlitz
+exports, docs CTAs, and Rust blueprints aligned while caching Playwright, Trunk, and dx assets to minimise repetitive setup for
+enterprise teams.【F:docs/testing/quick-start.md†L1-L96】【F:crates/xtask/src/main.rs†L206-L233】
+
 ## Legacy MUI compatibility shims
 
 The crates now ship under the `rustic_ui_*` namespace. To keep migrations predictable each crate exposes a

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,11 @@ Package managers other than pnpm (like npm or Yarn) are not supported and will n
    follow-up verification steps.
 3. Commit the generated files and update the appropriate page inside `docs/src/pages`.
 
+When editing those demos or the quick-start gallery, consult the
+[quick-start automation verification guide](testing/quick-start.md) and run `cargo xtask quick-start` so the docs site, StackBlitz
+snapshots, and Rust bootstraps stay aligned without manual interventions. The playbook also captures caching strategies for
+Playwright, Trunk, and dx so contributors avoid re-downloading browsers or recompiling scaffolds on every iteration.【F:docs/testing/quick-start.md†L1-L96】【F:crates/xtask/src/main.rs†L206-L233】
+
 ## How do I help to improve the translations?
 
 RusticUI translations are managed through the Apotheon.ai Crowdin workspace: <https://crowdin.com/project/rusticui-docs>.

--- a/docs/src/pages/examples/quick-start-gallery.md
+++ b/docs/src/pages/examples/quick-start-gallery.md
@@ -16,8 +16,12 @@ playground and published bundles depend on the same packages.【F:docs/src/compo
   changes so the checked-in data stays deterministic for reviews and follow-on automation.【F:docs/scripts/quickStartButtonSandbox.ts†L1-L43】【F:docs/data/examples/quick-start-button-sandbox.json†L1-L179】
 - The snapshot lives at `docs/data/examples/quick-start-button-sandbox.json`, making it trivial to
   audit edits and feed other tooling that wants to mirror the same sandbox files.【F:docs/data/examples/quick-start-button-sandbox.json†L1-L179】
+- Pair the docs snapshot check with the repository-wide [`cargo xtask quick-start`](../../../docs/testing/quick-start.md) harness
+  so every framework scaffold in the getting-started guide stays in sync with the gallery CTA and automation IDs.【F:docs/testing/quick-start.md†L1-L74】
 
 ## Next steps
 
 - Review the broader [example gallery](./index.md) to see how the quick-start CTA links into the
   multi-framework scaffolds and automation suites.【F:docs/src/pages/examples/index.md†L1-L211】
+- Follow the [quick-start automation verification playbook](../../../docs/testing/quick-start.md) for prerequisites, caching
+  strategies, and log interpretation tips before updating scaffolds or CTA copy.【F:docs/testing/quick-start.md†L1-L96】

--- a/docs/src/pages/getting-started/quick-start.md
+++ b/docs/src/pages/getting-started/quick-start.md
@@ -19,6 +19,8 @@ you can stand up a reference experience in minutes.【F:docs/src/pages/examples/
   shells through every bootstrap command below, captures transcripts in
   `target/logs/quick-start.log`, and reuses the same workflow that
   `cargo xtask docs-test` executes in CI.【F:crates/xtask/src/main.rs†L150-L233】【F:crates/xtask/src/main.rs†L2100-L2222】
+- Review the [quick-start automation verification guide](../../testing/quick-start.md) for detailed prerequisites, caching tips,
+  and log interpretation guidance before modifying any scaffold or gallery CTA.【F:docs/testing/quick-start.md†L1-L96】
 
 ## Yew
 

--- a/docs/testing/quick-start.md
+++ b/docs/testing/quick-start.md
@@ -1,0 +1,69 @@
+# Quick-start automation verification
+
+The quick-start gallery and getting-started guide ship automation-ready scaffolds
+for every supported framework. This playbook documents the prerequisites,
+commands, and caching strategies required to exercise the verification harness
+before submitting changes.
+
+## Prerequisites
+
+1. Install the latest stable Rust toolchain and add the `wasm32-unknown-unknown`
+   target: `rustup target add wasm32-unknown-unknown`.
+2. Install framework launchers used by the scaffolds you plan to touch:
+   - [Trunk](https://trunkrs.dev/) for the Yew, Leptos, and Sycamore flows.
+   - [`dx`](https://dioxuslabs.com/learn/0.4/cli) or the Dioxus CLI for Dioxus
+     demos.
+   - Node.js 20+ plus pnpm for the React selection controls harness.
+3. Provision optional tooling that enables the deeper smoke checks triggered by
+   the harness—`wasm-pack`, Playwright (Chromium + dependencies), and the
+   workspace `just` command—so the verification steps can run without falling
+   back to `--skip-checks` mode.【F:docs/src/pages/getting-started/quick-start.md†L9-L136】
+
+> Tip: export `CARGO_TARGET_DIR`, `TRUNK_HOME`, `DX_CACHE_DIR`, and
+> `PLAYWRIGHT_BROWSERS_PATH` to shared cache directories (or rely on the
+> repository defaults). Persisting those paths in CI and on development
+> workstations avoids rebuilding the same scaffolds and browser binaries on every
+> iteration.【F:CONTRIBUTING.md†L54-L87】【F:docs/src/pages/getting-started/quick-start.md†L9-L88】
+
+## Run the automated checks
+
+1. From the repository root execute:
+
+   ```bash
+   cargo xtask quick-start
+   ```
+
+   The command shells through each scaffold published in the quick-start guide,
+   runs the documented follow-up checks (for example, `just test` or
+   `trunk test`), and writes transcripts to
+   `target/logs/quick-start.log`.【F:crates/xtask/src/main.rs†L206-L233】【F:crates/xtask/src/main.rs†L3078-L3296】
+
+2. Inspect `target/logs/quick-start.log` after the run completes. Each scaffold
+   prints a bounded header, the exact commands executed, and a success/failure
+   trailer so reviewers can audit changes without rehydrating the environment.
+   Attach the relevant excerpts to your pull request when the output informs the
+   review (for example, when updating StackBlitz snapshots or adjusting
+   automation IDs).【F:crates/xtask/src/main.rs†L3097-L3288】
+
+3. If you encounter a missing dependency (for example, Playwright browsers are
+   unavailable on an air-gapped workstation), rerun the command with
+   `--skip-checks` to confirm the bootstrap scripts still provision the
+   workspace. Document the limitation in your pull request summary so CI reruns
+   the full verification path.【F:crates/xtask/src/main.rs†L206-L233】
+
+## Interpreting failures
+
+- **Bootstrap errors** typically indicate a missing prerequisite or stale cache.
+  Re-run the scaffold command printed in the log to reproduce locally, then
+  update the getting-started guide if new prerequisites emerged.
+- **Check failures** surface when downstream smoke tests (for example, Playwright
+  suites or `cargo test`) detect behavioural drift. Apply fixes in the
+  corresponding example, re-run `cargo xtask quick-start`, and commit the log
+  excerpt alongside code changes when it clarifies reviewer expectations.
+- **Timeouts** often stem from cold Playwright caches or first-time Trunk
+  compilations. Prime the caches noted above, then re-run the harness to confirm
+  the issue disappears.
+
+Keep this playbook close to the quick-start gallery when updating docs or
+scaffolds—following the automation-first workflow ensures enterprise adopters can
+bootstrap production-ready experiences with repeatable guardrails.【F:docs/src/pages/examples/quick-start-gallery.md†L1-L24】【F:docs/src/pages/getting-started/quick-start.md†L1-L136】

--- a/test/e2e-website/README.md
+++ b/test/e2e-website/README.md
@@ -12,6 +12,7 @@
 
 - `quick-start-gallery.spec.ts` drives the `/examples/quick-start-gallery` page, waits for the Sandpack iframe to hydrate, and asserts that the rendered call-to-action exposes `data-rustic-app-action="app-quick-start-primary"`, `data-rustic-analytics="docs.quick-start.button"`, and the visible label text from `QuickStartButtonGenerator.ts`.
 - The scenario ensures docs, StackBlitz, and Rust quick-start flows continue sharing the same analytics hooks; failures surface under `target/logs/docs-playwright.log` when invoked via `cargo xtask docs-test`.
+- Contributors updating the gallery or its scaffolds should run `cargo xtask quick-start` and follow the [quick-start automation verification guide](../../docs/testing/quick-start.md) so Playwright caches, StackBlitz snapshots, and docs CTA copy stay aligned across environments.【F:docs/testing/quick-start.md†L1-L96】【F:crates/xtask/src/main.rs†L206-L233】
 
 ## CI
 


### PR DESCRIPTION
## Summary
- add contributor guidance for running `cargo xtask quick-start` and caching prerequisites ahead of reviews
- author a dedicated quick-start testing guide with automation workflows and failure triage notes
- cross-link the new verification guide from quick-start docs, gallery pages, and testing readmes for easy discovery

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3da205420832eb0279dba22f1c5a9