### PR TITLE
Document coverage disciplines and categorize coverage-report output

### DIFF
--- a/crates/xtask/src/coverage_report.rs
+++ b/crates/xtask/src/coverage_report.rs
@@ -139,10 +139,20 @@ enum SuiteStatus {
     Skipped,
 }
 
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum SuiteCategory {
+    Unit,
+    Integration,
+    Accessibility,
+    Visual,
+}
+
 #[derive(Debug, Serialize)]
 struct SuiteReport {
     name: String,
     kind: String,
+    category: SuiteCategory,
     status: SuiteStatus,
     #[serde(flatten)]
     metrics: SuiteMetrics,
@@ -181,12 +191,24 @@ enum SuiteMetrics {
     },
 }
 
+impl SuiteCategory {
+    fn label(&self) -> &'static str {
+        match self {
+            SuiteCategory::Unit => "Unit",
+            SuiteCategory::Integration => "Integration",
+            SuiteCategory::Accessibility => "Accessibility",
+            SuiteCategory::Visual => "Visual Snapshot",
+        }
+    }
+}
+
 fn collect_rust_coverage(source: &CoverageDataSource) -> Result<SuiteReport> {
     let path = source.resolve(Path::new("lcov.info"));
     if !path.exists() {
         return Ok(SuiteReport {
             name: "Rust workspace".into(),
             kind: "rust".into(),
+            category: SuiteCategory::Integration,
             status: SuiteStatus::Skipped,
             metrics: SuiteMetrics::Coverage {
                 line_rate: None,
@@ -240,6 +262,7 @@ fn collect_rust_coverage(source: &CoverageDataSource) -> Result<SuiteReport> {
     Ok(SuiteReport {
         name: "Rust workspace".into(),
         kind: "rust".into(),
+        category: SuiteCategory::Integration,
         status,
         metrics: SuiteMetrics::Coverage {
             line_rate: Some(line_rate),
@@ -258,6 +281,7 @@ fn collect_typescript_coverage(source: &CoverageDataSource) -> Result<SuiteRepor
         return Ok(SuiteReport {
             name: "TypeScript automation".into(),
             kind: "typescript".into(),
+            category: SuiteCategory::Unit,
             status: SuiteStatus::Skipped,
             metrics: SuiteMetrics::PassRate {
                 pass_rate: 0.0,
@@ -286,6 +310,7 @@ fn collect_typescript_coverage(source: &CoverageDataSource) -> Result<SuiteRepor
         return Ok(SuiteReport {
             name: "TypeScript automation".into(),
             kind: "typescript".into(),
+            category: SuiteCategory::Unit,
             status: SuiteStatus::Skipped,
             metrics: SuiteMetrics::PassRate {
                 pass_rate: 0.0,
@@ -312,6 +337,7 @@ fn collect_typescript_coverage(source: &CoverageDataSource) -> Result<SuiteRepor
     Ok(SuiteReport {
         name: "TypeScript automation".into(),
         kind: "typescript".into(),
+        category: SuiteCategory::Unit,
         status,
         metrics: SuiteMetrics::PassRate {
             pass_rate,
@@ -337,6 +363,7 @@ fn collect_accessibility_signal(source: &CoverageDataSource) -> Result<SuiteRepo
                 return Ok(SuiteReport {
                     name: "Accessibility audits".into(),
                     kind: "accessibility".into(),
+                    category: SuiteCategory::Accessibility,
                     status: SuiteStatus::Skipped,
                     metrics: SuiteMetrics::Accessibility {
                         files_scanned: 0,
@@ -365,6 +392,7 @@ fn collect_accessibility_signal(source: &CoverageDataSource) -> Result<SuiteRepo
             Ok(SuiteReport {
                 name: "Accessibility audits".into(),
                 kind: "accessibility".into(),
+                category: SuiteCategory::Accessibility,
                 status,
                 metrics: SuiteMetrics::Accessibility {
                     files_scanned: summary.files_scanned,
@@ -398,6 +426,7 @@ fn collect_accessibility_signal(source: &CoverageDataSource) -> Result<SuiteRepo
             Ok(SuiteReport {
                 name: "Accessibility audits".into(),
                 kind: "accessibility".into(),
+                category: SuiteCategory::Accessibility,
                 status,
                 metrics: SuiteMetrics::Accessibility {
                     files_scanned: summary.files_scanned,
@@ -417,6 +446,7 @@ fn collect_visual_regressions(source: &CoverageDataSource) -> Result<SuiteReport
         return Ok(SuiteReport {
             name: "Visual regression snapshots".into(),
             kind: "visual_regression".into(),
+            category: SuiteCategory::Visual,
             status: SuiteStatus::Skipped,
             metrics: SuiteMetrics::VisualRegression {
                 snapshots: 0,
@@ -456,6 +486,7 @@ fn collect_visual_regressions(source: &CoverageDataSource) -> Result<SuiteReport
     Ok(SuiteReport {
         name: "Visual regression snapshots".into(),
         kind: "visual_regression".into(),
+        category: SuiteCategory::Visual,
         status,
         metrics: SuiteMetrics::VisualRegression {
             snapshots: summary.snapshots,
@@ -492,7 +523,7 @@ fn write_markdown(path: &Path, report: &CoverageReport, workspace: &Path) -> Res
 
     writeln!(
         file,
-        "| Suite | Status | Key metrics | Thresholds | Notes |\n| --- | --- | --- | --- | --- |"
+        "| Suite | Track | Discipline | Key metrics | Thresholds | Notes |\n| --- | --- | --- | --- | --- | --- |"
     )?;
 
     for suite in &report.suites {
@@ -506,8 +537,14 @@ fn write_markdown(path: &Path, report: &CoverageReport, workspace: &Path) -> Res
         let notes = suite.details.join("<br />");
         writeln!(
             file,
-            "| {} {} | {} | {} | {} | {} |",
-            status_emoji, suite.name, suite.kind, metrics, thresholds, notes
+            "| {} {} | {} | {} | {} | {} | {} |",
+            status_emoji,
+            suite.name,
+            suite.kind,
+            suite.category.label(),
+            metrics,
+            thresholds,
+            notes
         )?;
     }
 

--- a/docs/testing/coverage-overview.md
+++ b/docs/testing/coverage-overview.md
@@ -1,19 +1,20 @@
 # Cross-suite coverage dashboard
 
-The RusticUI workspace now exports a single coverage dashboard that merges the
-Rust `cargo xtask coverage` output, the TypeScript Vitest/Playwright runs, the
-Markdown accessibility sweeps, and Playwright-driven visual regression metrics.
-The goal is to give maintainers a single artifact that answers **which suites
-ran**, **what thresholds they satisfied**, and **where to dig when regressions
-appear**.
+The RusticUI workspace now exports a single coverage dashboard that merges every
+Rust and TypeScript testing surface: unit tests, integration checks, axe-core
+accessibility sweeps, and Playwright visual snapshot reviews. Instead of
+triaging multiple artifacts, `cargo xtask coverage-report` consolidates the
+underlying telemetry into deterministic JSON and Markdown so release managers
+can answer **which suites ran**, **whether they met the release thresholds**, and
+**where to triage regressions** without shuffling between CI jobs.
 
 ## Running the aggregator
 
 ```bash
 # Run your normal language-specific suites first.
-cargo xtask coverage
-pnpm --dir docs test --reporter=junit   # or your project-wide TS runner
-pnpm test:regressions:run               # Playwright visual snapshots
+cargo xtask coverage                          # grcov line/branch metrics
+pnpm --dir docs test --reporter=junit         # Vitest + Playwright unit/integration snapshots
+pnpm test:regressions:run                    # Visual snapshot diffs (Playwright)
 
 # Then aggregate everything into JSON + Markdown dashboards.
 cargo xtask coverage-report
@@ -32,12 +33,12 @@ information without pulling the repo.
 
 ## Pipeline expectations
 
-| Suite | How to generate source data | Threshold | Failure mode |
-| :---- | :--------------------------- | :-------- | :----------- |
-| **Rust workspace** | `cargo xtask coverage` (writes `lcov.info` via grcov) | Line ≥ 75%, Branch ≥ 60% | Missing `lcov.info` marks the suite as skipped; low coverage fails the command. |
-| **TypeScript automation** | Any runner that exports `test-results/junit.xml` (Vitest, Karma, Playwright, etc.) | Pass rate ≥ 97.5% (computed from `tests`, `failures`, `errors`, `skipped`) | A missing or all-skipped JUnit summary fails the report. |
-| **Accessibility audits** | `cargo xtask accessibility-audit` (invoked automatically when aggregating) | Zero Markdown issues | Findings are surfaced inline with the file path and break the build. |
-| **Visual regressions** | Ensure Playwright saves `test-results/visual-regressions.json` with snapshot counts | Zero diff images | Missing JSON or non-zero diffs fail the aggregator. |
+| Suite | Track | Discipline | How to generate source data | Threshold | Failure mode |
+| :---- | :---- | :--------- | :--------------------------- | :-------- | :----------- |
+| **Rust workspace** | Rust | Integration | `cargo xtask coverage` (writes `lcov.info` via grcov across unit + integration suites) | Line ≥ 75%, Branch ≥ 60% | Missing `lcov.info` marks the suite as skipped; low coverage fails the command. |
+| **TypeScript automation** | TypeScript | Unit | Any runner that exports `test-results/junit.xml` (Vitest, Karma, Playwright component/unit suites). Snapshot expectations are counted alongside classic specs so the pass-rate mirrors combined unit + snapshot health. | Pass rate ≥ 97.5% (computed from `tests`, `failures`, `errors`, `skipped`) | A missing or all-skipped JUnit summary fails the report. |
+| **Accessibility audits** | Cross-stack | Accessibility | `cargo xtask accessibility-audit` (invoked automatically when aggregating). The command pipes markdown snippets through the axe-core bridge baked into our wasm test harnesses to guarantee headings and alternative text survive content edits. | Zero Markdown issues | Findings are surfaced inline with the file path and break the build. |
+| **Visual regressions** | TypeScript | Visual snapshot | Ensure Playwright saves `test-results/visual-regressions.json` with snapshot counts. The summary includes updated/diff/skipped counts so screenshot drift is immediately visible. | Zero diff images | Missing JSON or non-zero diffs fail the aggregator. |
 
 > **Tip:** Enterprise teams often run TypeScript tests in multiple packages. As
 long as the combined CI pipeline writes a consolidated `test-results/junit.xml`
@@ -47,15 +48,18 @@ coverage-report`.
 
 ## Interpreting the dashboard
 
-- ✅ Status indicates the threshold was met or exceeded.
+- ✅ Status indicates the threshold was met or exceeded for that discipline.
 - ⚠️ Signals that the aggregator could not find the source data (treated as a
-  failure in CI to prevent silent skips).
+  failure in CI to prevent silent skips). Review the `Artifacts` section to spot
+  missing files or mismatched paths.
 - ❌ Denotes a real regression. The Markdown file expands each failing suite
   with bullet points pointing to the underlying artifact (for example the
-  Playwright diff summary or the Markdown file missing alt text).
+  Playwright diff summary, axe-core violation list, or the Markdown file missing
+  alt text).
 
-Every suite lists the artifacts it relied on, so you can jump directly to the
-raw `lcov.info`, `junit.xml`, or visual regression report when investigating.
+Every suite lists the artifacts it relied on and records the discipline it
+represents. Use that combination to jump directly to the raw `lcov.info`,
+`junit.xml`, axe-core summary, or visual regression report when investigating.
 
 ## Automating in CI
 

--- a/docs/testing/headless-state-machines.md
+++ b/docs/testing/headless-state-machines.md
@@ -28,3 +28,11 @@ Each property is annotated with extensive commentary so teams rolling out new
 automation or analytics pipelines can extend the suite without reverse-
 engineering business rules.  CI runs the tests via `cargo xtask test --examples`
 to keep coverage aligned with the workspace’s release-readiness checklist.
+
+After validating the headless properties, run
+`cargo xtask coverage-report` to roll their results into the aggregated
+dashboard alongside the TypeScript snapshots and axe-core sweeps. The
+[cross-suite coverage dashboard](coverage-overview.md) section explains how the
+disciplines map to Rust unit/integration, Playwright snapshots, and the
+Markdown accessibility audits so the state-machine maintainers can confirm all
+pipelines stayed green.【F:docs/testing/coverage-overview.md†L1-L72】


### PR DESCRIPTION
## Summary
- classify each suite that feeds `cargo xtask coverage-report` and surface the discipline in the Markdown dashboard
- document the unit, integration, snapshot, accessibility, and visual expectations in the coverage overview guide
- link the aggregated coverage dashboard from the headless state machine testing playbook

## Testing
- cargo test -p xtask

------
https://chatgpt.com/codex/tasks/task_e_68e45f43b018832e90e80cc6118e7a9b