### PR TITLE
chore: publish devcontainer and onboarding docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,80 @@
+# syntax=docker/dockerfile:1.7
+
+# ----------------------------------------------------------------------------
+# RusticUI managed development container
+# ----------------------------------------------------------------------------
+# The base Rust devcontainer image already includes the stable toolchain,
+# rustup, and common build dependencies. We extend it with browser libraries
+# required by Playwright/Chromium and pre-install the cross-compilation target
+# plus automation CLIs so Codespaces can execute `cargo xtask` flows without
+# any manual prep work.
+# ----------------------------------------------------------------------------
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
+
+# Reuse the default vscode user provided by the upstream devcontainer images so
+# bind-mount permissions line up with Codespaces expectations.
+ARG USERNAME=vscode
+
+# Centralise frequently reused caches so both local devcontainers and
+# GitHub Codespaces persist artefacts across rebuilds. The paths mirror the
+# guidance in CONTRIBUTING.md and docs/testing/quick-start.md so new engineers
+# inherit deterministic tooling behaviour out of the box.
+ENV CARGO_TARGET_DIR=/workspaces/.cargo-target \
+    PLAYWRIGHT_BROWSERS_PATH=/workspaces/.cache/ms-playwright \
+    PNPM_HOME=/usr/local/share/pnpm \
+    PATH="${PNPM_HOME}:${PATH}" \
+    RUST_LOG=info
+
+# Install system libraries Playwright needs for headless Chromium runs.
+# We intentionally keep the list explicit (instead of relying on install-deps)
+# so supply-chain scanners understand the package surface and enterprise teams
+# can mirror it in bespoke images.
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libcairo2 \
+        libdrm2 \
+        libgbm1 \
+        libgtk-3-0 \
+        libnss3 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxfixes3 \
+        libxkbcommon0 \
+        libxrandr2 \
+        xauth \
+        xvfb; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Pre-provision the wasm target plus the Rust-native automation helpers that
+# CONTRIBUTING.md calls out (mdBook, wasm-pack, cargo-deny, grcov, trunk, just).
+# Installing them here keeps the Codespaces bootstrap script fast because
+# cargo only needs to pull incremental updates.
+RUN set -eux; \
+    rustup target add wasm32-unknown-unknown; \
+    cargo install --locked \
+        cargo-deny \
+        grcov \
+        just \
+        mdbook \
+        trunk \
+        wasm-pack
+
+# Create directories for shared caches up front so volume mounts declared in
+# devcontainer.json do not need to create them as root on first run.
+RUN set -eux; \
+    mkdir -p /workspaces/.cargo-target; \
+    mkdir -p /workspaces/.cache/ms-playwright; \
+    mkdir -p /workspaces/.pnpm-store; \
+    chown -R "${USERNAME}:${USERNAME}" /workspaces/.cargo-target /workspaces/.cache /workspaces/.pnpm-store || true

--- a/.devcontainer/codespaces.json
+++ b/.devcontainer/codespaces.json
@@ -1,0 +1,33 @@
+{
+  // Codespaces-specific hooks that complement devcontainer.json. GitHub ignores
+  // this file when developers open the workspace locally, but it lets us align
+  // the default tasks palette with the cargo xtask automation routines.
+  "postAttachCommand": {
+    // Launch the unified docs + gallery harness as soon as the Codespace starts
+    // so reviewers land directly in a hot-reload loop. Developers can stop the
+    // task if they prefer to run the processes manually.
+    "cargo xtask dev": "cargo xtask dev"
+  },
+  "portsAttributes": {
+    "3000": {
+      "label": "Rustic gallery (Leptos SSR)",
+      "onAutoForward": "openBrowser"
+    },
+    "3100": {
+      "label": "Docs (Next.js)",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  // Expose a task shortcut that replays the bootstrap validation without
+  // rebuilding the container.
+  "tasks": {
+    "verify-toolchain": {
+      "command": "cargo xtask verify-toolchain",
+      "label": "RusticUI · verify toolchain"
+    },
+    "dev-dry-run": {
+      "command": "cargo xtask dev --dry-run",
+      "label": "RusticUI · dry-run dev harness"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,74 @@
+{
+  // RusticUI devcontainer tuned for cargo xtask workflows and docs/gallery hot reload.
+  "name": "RusticUI automation workspace",
+  "build": {
+    // Keep the build context scoped to the devcontainer folder so Docker only
+    // invalidates layers when tooling metadata changes.
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  // Features install Node.js 20 and pnpm so `cargo xtask dev` can drive the Next.js docs.
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/pnpm:1": {
+      "version": "8"
+    }
+  },
+  // Ensure the workspace user matches the Dockerfile chown commands.
+  "remoteUser": "vscode",
+  "runArgs": [
+    "--init"
+  ],
+  // Persist heavy caches between container restarts to keep automation snappy.
+  "mounts": [
+    "source=rusticui-cargo,target=/workspaces/.cargo-target,type=volume",
+    "source=rusticui-playwright,target=/workspaces/.cache/ms-playwright,type=volume",
+    "source=rusticui-pnpm,target=/workspaces/.pnpm-store,type=volume"
+  ],
+  // Environment defaults align with CONTRIBUTING.md guidance so local, CI, and
+  // Codespaces flows share the same directory conventions without extra exports.
+  "containerEnv": {
+    "CARGO_TARGET_DIR": "/workspaces/.cargo-target",
+    "PLAYWRIGHT_BROWSERS_PATH": "/workspaces/.cache/ms-playwright",
+    "PNPM_HOME": "/usr/local/share/pnpm",
+    "RUST_LOG": "info",
+    // Disable pnpm lockfile generation because the root workspace intentionally
+    // relies on cargo/xtask automation and quarantines historical Node manifests.
+    "PNPM_DISABLE_LOCKFILE": "true"
+  },
+  // Pre-create the docs + gallery tooling so contributors can iterate immediately.
+  "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",
+  // Forward ports used by the docs (Next.js) and gallery (Leptos) dev servers.
+  "forwardPorts": [3000, 3100],
+  "portsAttributes": {
+    "3000": {
+      "label": "Rustic gallery (Leptos SSR)",
+      "onAutoForward": "openBrowser"
+    },
+    "3100": {
+      "label": "Docs (Next.js)",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  // Provide quick access to the automation handbook directly inside VS Code.
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "files.watcherExclude": {
+          "**/target/**": true,
+          "**/.pnpm-store/**": true,
+          "**/.cache/ms-playwright/**": true
+        }
+      },
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "serayuzgur.crates",
+        "vadimcn.vscode-lldb"
+      ]
+    }
+  }
+}

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# RusticUI post-create bootstrap
+# ----------------------------------------------------------------------------
+# This script executes inside the devcontainer/Codespace immediately after the
+# image is built. It wires pnpm to a shared store, installs the docs workspace
+# dependencies, provisions Playwright browsers, and runs the xtask toolchain
+# guardrails so every contributor starts from a verified baseline.
+# ----------------------------------------------------------------------------
+
+log_step() {
+  printf '\n[devcontainer] %s\n' "$1"
+}
+
+log_step "Configuring pnpm global store for deterministic caching"
+pnpm config set store-dir /workspaces/.pnpm-store --global
+
+log_step "Bootstrapping docs workspace dependencies via pnpm"
+# PNPM_DISABLE_LOCKFILE is exported in devcontainer.json so the install avoids
+# writing a lockfile into the repo. The docs workspace maintains its own
+# manifests under docs/ without touching the Rust-first root workspace.
+pnpm --dir docs install --recursive
+
+log_step "Installing Playwright Chromium bundle for wasm smoke tests"
+pnpm --dir docs exec playwright install --with-deps chromium
+
+log_step "Verifying Rust + docs toolchain alignment"
+cargo xtask verify-toolchain
+
+log_step "Dry-running cargo xtask dev to confirm automation hooks"
+cargo xtask dev --dry-run
+
+log_step "Post-create bootstrap completed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,32 @@ Before starting large efforts, open a GitHub discussion or issue so the maintain
 
 ## Development setup
 
+### Managed devcontainer and Codespaces workflow
+
+The `.devcontainer` configuration bootstraps a ready-to-ship environment with
+Rust, Node 20, pnpm, Playwright dependencies, and the `cargo xtask` CLI suite
+preinstalled. Opening the repository in GitHub Codespaces or a local VS Code
+Dev Container automatically:
+
+- Mounts persistent caches for Cargo, Playwright, and pnpm so rebuilds reuse the
+  same directories across sessions (`/workspaces/.cargo-target`,
+  `/workspaces/.cache/ms-playwright`, `/workspaces/.pnpm-store`).【F:.devcontainer/devcontainer.json†L24-L44】【F:.devcontainer/Dockerfile†L15-L60】
+- Runs `.devcontainer/scripts/post-create.sh` to install docs dependencies,
+  provision Chromium via Playwright, and execute both `cargo xtask
+  verify-toolchain` and `cargo xtask dev --dry-run` for a smoke check.【F:.devcontainer/devcontainer.json†L46-L49】【F:.devcontainer/scripts/post-create.sh†L1-L38】
+- Launches the unified docs + gallery harness (`cargo xtask dev`) after attach
+  so you land in a live hot-reload loop with ports 3000 (Leptos gallery) and
+  3100 (Next.js docs) forwarded automatically.【F:.devcontainer/codespaces.json†L5-L23】
+
+You can rerun the validation routines at any time from the integrated tasks
+palette—`RusticUI · verify toolchain` invokes `cargo xtask verify-toolchain`
+while `RusticUI · dry-run dev harness` replays the combined docs/gallery
+bootstrap without starting long-running processes.【F:.devcontainer/codespaces.json†L24-L34】 Capture the output in pull request
+summaries to demonstrate parity with the managed environment when iterating on
+tooling or docs.
+
+### Manual setup (fallback)
+
 1. Install the latest stable Rust toolchain and ensure `wasm32-unknown-unknown` is available via `rustup target add`.
 2. Install supporting CLI tools with Cargo: `cargo install mdbook grcov wasm-pack cargo-deny` (the automation will leverage
    them when present).

--- a/README.md
+++ b/README.md
@@ -226,6 +226,25 @@ acknowledgements, and panic reporting) regardless of renderer.
 
 Automation is consolidated in the root `Makefile` and `cargo xtask` binary so teams can wire CI once and scale confidently.
 
+### Managed development environment
+
+Open the repository inside the published devcontainer (local VS Code) or GitHub
+Codespaces instance to inherit a fully provisioned toolchain. The container
+image installs the stable Rust toolchain, wasm target, mdBook, wasm-pack,
+Playwright prerequisites, and pnpm + Node 20. It also mounts shared caches for
+Cargo, Playwright, and pnpm to keep hot reload cycles fast across sessions, then
+executes `.devcontainer/scripts/post-create.sh` to install docs dependencies,
+run `cargo xtask verify-toolchain`, and dry-run `cargo xtask dev` before you
+start coding.【F:.devcontainer/Dockerfile†L1-L73】【F:.devcontainer/devcontainer.json†L1-L52】【F:.devcontainer/scripts/post-create.sh†L1-L38】
+
+When the Codespace attaches, the workspace automatically starts `cargo xtask
+dev` so the Leptos gallery (port 3000) and Next.js docs (port 3100) hot reload
+immediately. Task palette entries labelled "RusticUI" let you re-run the
+verification commands or replay a dry-run of the harness without leaving the
+editor.【F:.devcontainer/codespaces.json†L1-L34】 Attach the resulting logs to pull
+requests whenever you touch automation or docs to prove the managed environment
+remains green.
+
 ```bash
 make build        # compile every crate
 make test         # run workspace tests

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -28,7 +28,7 @@
 2. **Scaffolding & Automation**
    - [x] Extend `cargo xtask` with `new-component` generator supporting material/headless templates (Rust + TypeScript + docs stubs).
    - [x] Ship `cargo xtask dev` for hot-reloading example gallery and docs site with shared logs.
-   - [ ] Publish Devcontainer + Codespaces configs for consistent onboarding.
+   - [x] Publish Devcontainer + Codespaces configs for consistent onboarding (see `.devcontainer/`).【F:.devcontainer/devcontainer.json†L1-L52】【F:.devcontainer/codespaces.json†L1-L34】
 
 3. **Documentation Quality**
    - Introduce component decision guides (e.g., `Box` vs `Container` vs `Grid`).

--- a/docs/src/pages/getting-started/quick-start.md
+++ b/docs/src/pages/getting-started/quick-start.md
@@ -8,6 +8,10 @@ you can stand up a reference experience in minutes.【F:docs/src/pages/examples/
 
 ## Global prerequisites
 
+- Prefer the managed devcontainer or GitHub Codespace when onboarding. The
+  configuration wires shared caches, installs docs dependencies, and runs both
+  `cargo xtask verify-toolchain` and a dry-run of `cargo xtask dev` so you land
+  in a verified hot-reload loop on first attach.【F:.devcontainer/devcontainer.json†L1-L52】【F:.devcontainer/scripts/post-create.sh†L1-L38】【F:.devcontainer/codespaces.json†L5-L34】
 - Install the Rust toolchain (stable) and add the `wasm32-unknown-unknown`
   target: `rustup target add wasm32-unknown-unknown`.
 - Install [Trunk](https://trunkrs.dev/), [Dioxus CLI](https://dioxuslabs.com),

--- a/docs/testing/quick-start.md
+++ b/docs/testing/quick-start.md
@@ -13,6 +13,12 @@ before sign-off.【F:docs/testing/coverage-overview.md†L1-L72】
 
 ## Prerequisites
 
+> **Managed option:** Opening the repository in the RusticUI devcontainer or a
+> GitHub Codespace provisions everything in this list automatically—Rust,
+> Node 20 + pnpm, Playwright Chromium bundles, and the xtask verification
+> guards. Review `.devcontainer/devcontainer.json` for the cache layout and
+> post-create automation sequence before mirroring custom environments.【F:.devcontainer/devcontainer.json†L1-L52】【F:.devcontainer/scripts/post-create.sh†L1-L38】
+
 1. Install the latest stable Rust toolchain and add the `wasm32-unknown-unknown`
    target: `rustup target add wasm32-unknown-unknown`.
 2. Install framework launchers used by the scaffolds you plan to touch:
@@ -52,6 +58,9 @@ before sign-off.【F:docs/testing/coverage-overview.md†L1-L72】
 - When iterating on docs or gallery content, launch `cargo xtask dev`. The harness boots the Next.js docs site and Leptos
   example gallery together, writing live output to `target/logs/dev.log` so reviewers can inspect hot-reload sessions alongside
   code changes.
+- Codespaces automatically starts the harness after attach. Re-run `cargo xtask
+  dev --dry-run` from the `RusticUI · dry-run dev harness` task palette entry if
+  you need to capture a transcript without long-running processes.【F:.devcontainer/codespaces.json†L5-L34】
 
 2. Inspect `target/logs/quick-start.log` after the run completes. Each scaffold
    prints a bounded header, the exact commands executed, and a success/failure


### PR DESCRIPTION
## Summary
- add a managed devcontainer image with post-create automation and Codespaces metadata that launches `cargo xtask dev`
- document the new environment across CONTRIBUTING, README, and onboarding guides, including updated improvement-plan checklist

## Testing
- cargo xtask dev --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e4762cd498832ebf5794a057699490