### PR TITLE
Add adapter parity reporting and layout decision documentation

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -151,6 +151,11 @@ jobs:
       # Capture the Joy UI component inventory so regressions surface quickly in diffs
       - name: Generate Joy component parity report
         run: cargo xtask joy-inventory
+      # Refresh the cross-adapter parity dashboard used by docs navigation
+      - name: Generate adapter parity report
+        run: cargo xtask parity-report
+      - name: Ensure adapter parity report committed
+        run: git diff --exit-code docs/architecture/adapter-parity.md
       # Persist the generated markdown so subsequent jobs (and workflow runs) can diff it cheaply
       - name: Cache Joy parity report
         uses: actions/cache@v4

--- a/crates/xtask/src/adapter_parity.rs
+++ b/crates/xtask/src/adapter_parity.rs
@@ -1,0 +1,206 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{SecondsFormat, Utc};
+use regex::Regex;
+use walkdir::WalkDir;
+
+use crate::workspace_root;
+
+const FRAMEWORKS: [(&str, &str); 5] = [
+    ("react", "React"),
+    ("yew", "Yew"),
+    ("leptos", "Leptos"),
+    ("dioxus", "Dioxus"),
+    ("sycamore", "Sycamore"),
+];
+
+#[derive(Debug, Clone)]
+struct ComponentCoverage {
+    name: String,
+    frameworks: BTreeSet<String>,
+}
+
+pub fn adapter_parity_report(output: Option<PathBuf>) -> Result<()> {
+    let workspace = workspace_root();
+    let material_components = collect_material_components(&workspace)?;
+    let joy_components = collect_joy_components(&workspace)?;
+
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let mut doc = String::new();
+    doc.push_str("# Adapter Parity\n\n");
+    doc.push_str(&format!(
+        "_Last updated {timestamp} via `cargo xtask parity-report`._\n\n"
+    ));
+    doc.push_str("The tables below enumerate which framework adapters ship for each component. ");
+    doc.push_str("Material adapters are discovered by scanning the adapter modules under `crates/rustic-ui-material/src`, and the Joy rows come from the Yew-first modules declared in `crates/rustic-ui-joy/src/lib.rs`. ");
+    doc.push_str("Parity is validated by the cross-adapter regression suites such as [`button_adapters.rs`](../../crates/rustic-ui-material/tests/button_adapters.rs) and [`joy_yew.rs`](../../crates/rustic-ui-material/tests/joy_yew.rs). Run `cargo xtask parity-report` after adding or removing adapters so CI can confirm this dashboard stays in sync.\n\n");
+
+    doc.push_str("## Material adapters\n\n");
+    doc.push_str(&coverage_summary(&material_components));
+    doc.push_str("\n\n");
+    doc.push_str(&render_table(&material_components));
+    doc.push_str("\n\n");
+
+    doc.push_str("## Joy adapters\n\n");
+    doc.push_str(&coverage_summary(&joy_components));
+    doc.push_str("\n\n");
+    doc.push_str(&render_table(&joy_components));
+    doc.push_str("\n");
+
+    let output_path =
+        output.unwrap_or_else(|| workspace.join("docs/architecture/adapter-parity.md"));
+    fs::write(&output_path, doc).with_context(|| {
+        format!(
+            "failed to write adapter parity report to {}",
+            output_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn collect_material_components(workspace: &Path) -> Result<Vec<ComponentCoverage>> {
+    let src_dir = workspace.join("crates/rustic-ui-material/src");
+    let mut components = Vec::new();
+    let skip = [
+        "lib.rs",
+        "macros.rs",
+        "render_helpers.rs",
+        "style_helpers.rs",
+        "telemetry.rs",
+    ];
+
+    for entry in WalkDir::new(&src_dir).max_depth(1) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.into_path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let file_name = match path.file_name().and_then(|name| name.to_str()) {
+            Some(name) => name,
+            None => continue,
+        };
+        if skip.contains(&file_name) {
+            continue;
+        }
+
+        let content = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "failed to read material component source {}",
+                path.display()
+            )
+        })?;
+        let mut frameworks = BTreeSet::new();
+        for (slug, _) in FRAMEWORKS {
+            let marker = format!("pub mod {slug}");
+            if content.contains(&marker) {
+                frameworks.insert(slug.to_string());
+            }
+        }
+
+        if frameworks.is_empty() {
+            continue;
+        }
+
+        let name = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(to_title_case)
+            .unwrap_or_else(|| "Unknown".to_string());
+        components.push(ComponentCoverage { name, frameworks });
+    }
+
+    components.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(components)
+}
+
+fn collect_joy_components(workspace: &Path) -> Result<Vec<ComponentCoverage>> {
+    let lib_path = workspace.join("crates/rustic-ui-joy/src/lib.rs");
+    let content = fs::read_to_string(&lib_path)
+        .with_context(|| format!("failed to read joy lib {}", lib_path.display()))?;
+    let module_regex = Regex::new(
+        r#"(?m)#\s*\[\s*cfg\(feature\s*=\s*"yew"\s*\)\s*]\s*pub\s+mod\s+([a-z0-9_]+)\s*;"#,
+    )?;
+    let mut components = Vec::new();
+    for capture in module_regex.captures_iter(&content) {
+        let module = &capture[1];
+        let name = to_title_case(module);
+        let mut frameworks = BTreeSet::new();
+        frameworks.insert("yew".to_string());
+        components.push(ComponentCoverage { name, frameworks });
+    }
+
+    components.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(components)
+}
+
+fn coverage_summary(components: &[ComponentCoverage]) -> String {
+    if components.is_empty() {
+        return "_No adapters discovered._".to_string();
+    }
+
+    let total = components.len();
+    let mut lines = Vec::new();
+    for (slug, label) in FRAMEWORKS {
+        let count = components
+            .iter()
+            .filter(|component| component.frameworks.contains(slug))
+            .count();
+        lines.push(format!("- {label} adapters: {count}/{total}"));
+    }
+
+    lines.join("\n")
+}
+
+fn render_table(components: &[ComponentCoverage]) -> String {
+    if components.is_empty() {
+        return "_No data available._".to_string();
+    }
+
+    let mut table = String::new();
+    table.push_str("| Component | React | Yew | Leptos | Dioxus | Sycamore |\n");
+    table.push_str("| --- | --- | --- | --- | --- | --- |\n");
+
+    for component in components {
+        table.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} |\n",
+            component.name,
+            coverage_cell(component, "react"),
+            coverage_cell(component, "yew"),
+            coverage_cell(component, "leptos"),
+            coverage_cell(component, "dioxus"),
+            coverage_cell(component, "sycamore"),
+        ));
+    }
+
+    table
+}
+
+fn coverage_cell(component: &ComponentCoverage, framework: &str) -> &'static str {
+    if component.frameworks.contains(framework) {
+        "✅"
+    } else {
+        "⬜"
+    }
+}
+
+fn to_title_case(value: &str) -> String {
+    value
+        .split('_')
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -37,11 +37,13 @@ use tokio::runtime::Builder;
 use walkdir::WalkDir;
 use xtask_docs::{docs_build, docs_package, docs_test, DocsPackageOutcome};
 
+mod adapter_parity;
 mod coverage_report;
 mod dev;
 mod docs_assets;
 mod new_component;
 mod selection_controls_web;
+use adapter_parity::adapter_parity_report;
 use coverage_report::{coverage_report, CoverageReportArgs};
 use dev::{dev, DevArgs};
 use docs_assets::{docs_assets, DocsAssetsArgs};
@@ -228,6 +230,9 @@ enum Commands {
     /// Recompute the RusticUI Joy inventory to highlight missing Rust bindings.
     #[command(name = "joy-inventory", alias = "joy-parity")]
     JoyParity,
+    /// Regenerate the cross-adapter parity dashboard consumed by docs and CI.
+    #[command(name = "parity-report")]
+    ParityReport,
     /// Run the Rust and TypeScript selection control regression suites.
     SelectionControls(SelectionControlsArgs),
     /// Execute every quick-start bootstrap script to guarantee docs remain accurate.
@@ -290,6 +295,7 @@ fn main() -> Result<()> {
         } => themes_bundle(overrides, format, joy, compat, out_dir),
         Commands::MaterialParity => material_parity(),
         Commands::JoyParity => joy_parity(),
+        Commands::ParityReport => adapter_parity_report(None),
         Commands::SelectionControls(args) => selection_controls(args),
         Commands::QuickStart { skip_checks } => quick_start(skip_checks),
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,15 @@ scale before the compatibility layer is removed.
   The diagrams call out every `data-rustic-*` automation hook and
   `data-rustic-analytics-id` bridge so enterprise telemetry can assert SSR and
   hydration parity without bespoke selectors.
+- **Layout decision tree** –
+  [`architecture/component-decision-guides.md`](./architecture/component-decision-guides.md)
+  compares `Box`, `Container`, `Grid`, `Stack`, and `Hidden`, includes
+  automation callouts, and links the regression tests you should run before
+  touching layout tokens.
+- **Adapter coverage dashboard** –
+  [`architecture/adapter-parity.md`](./architecture/adapter-parity.md)
+  is generated via `cargo xtask parity-report` and lists which frameworks ship
+  adapters for every Material and Joy component.
 - **Diagram guardrail** – `cargo xtask docs-build` now walks every
   `mermaid`-fenced block under `docs/` and validates it using a Rust-side parser
   before the docs host builds. The validator covers the state, sequence, and

--- a/docs/architecture/adapter-parity.md
+++ b/docs/architecture/adapter-parity.md
@@ -1,0 +1,74 @@
+# Adapter Parity
+
+_Last updated 2025-10-07T03:12:01Z via `cargo xtask parity-report`._
+
+The tables below enumerate which framework adapters ship for each component. Material adapters are discovered by scanning the adapter modules under `crates/rustic-ui-material/src`, and the Joy rows come from the Yew-first modules declared in `crates/rustic-ui-joy/src/lib.rs`. Parity is validated by the cross-adapter regression suites such as [`button_adapters.rs`](../../crates/rustic-ui-material/tests/button_adapters.rs) and [`joy_yew.rs`](../../crates/rustic-ui-material/tests/joy_yew.rs). Run `cargo xtask parity-report` after adding or removing adapters so CI can confirm this dashboard stays in sync.
+
+## Material adapters
+
+- React adapters: 23/35
+- Yew adapters: 28/35
+- Leptos adapters: 29/35
+- Dioxus adapters: 35/35
+- Sycamore adapters: 35/35
+
+| Component | React | Yew | Leptos | Dioxus | Sycamore |
+| --- | --- | --- | --- | --- | --- |
+| App Bar | ⬜ | ⬜ | ⬜ | ✅ | ✅ |
+| Bottom Navigation | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Box | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Breadcrumbs | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Button | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Card | ⬜ | ⬜ | ⬜ | ✅ | ✅ |
+| Checkbox | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Chip | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Click Away | ⬜ | ✅ | ✅ | ✅ | ✅ |
+| Collapsible | ⬜ | ✅ | ✅ | ✅ | ✅ |
+| Container | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Dialog | ✅ | ⬜ | ✅ | ✅ | ✅ |
+| Divider | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Drawer | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Focus Trap | ⬜ | ⬜ | ⬜ | ✅ | ✅ |
+| Grid | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Hidden | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Image List | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Input Base | ✅ | ⬜ | ⬜ | ✅ | ✅ |
+| Link | ✅ | ✅ | ✅ | ✅ | ✅ |
+| List | ⬜ | ✅ | ✅ | ✅ | ✅ |
+| Menu | ⬜ | ✅ | ✅ | ✅ | ✅ |
+| Pagination | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Radio | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Rating | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Select | ⬜ | ✅ | ✅ | ✅ | ✅ |
+| Speed Dial | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Stack | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Stepper | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Switch | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Table | ⬜ | ✅ | ✅ | ✅ | ✅ |
+| Tabs | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Text Field | ⬜ | ⬜ | ⬜ | ✅ | ✅ |
+| Tooltip | ⬜ | ✅ | ✅ | ✅ | ✅ |
+| Unstable Trap Focus | ⬜ | ⬜ | ⬜ | ✅ | ✅ |
+
+
+## Joy adapters
+
+- React adapters: 0/10
+- Yew adapters: 10/10
+- Leptos adapters: 0/10
+- Dioxus adapters: 0/10
+- Sycamore adapters: 0/10
+
+| Component | React | Yew | Leptos | Dioxus | Sycamore |
+| --- | --- | --- | --- | --- | --- |
+| Accordion | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Aspect Ratio | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Autocomplete | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Button | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Card | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Chip | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Slider | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Snackbar | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Stepper | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+| Toggle Button Group | ⬜ | ✅ | ⬜ | ⬜ | ⬜ |
+

--- a/docs/architecture/component-decision-guides.md
+++ b/docs/architecture/component-decision-guides.md
@@ -1,0 +1,165 @@
+# Component Decision Guides: Box, Container, Grid & Beyond
+
+RusticUI ships a family of layout primitives that all expose the same headless
+state machines and adapter surfaces, yet they target different layout problems.
+This guide explains when to reach for each component, how their automation hooks
+behave, and the tooling you can run to keep parity guarantees intact across
+React, Yew, Leptos, Dioxus, and Sycamore adapters.
+
+## Choosing the right primitive
+
+| Scenario | Recommended primitive | Why it fits |
+| --- | --- | --- |
+| Apply theme-aware spacing, backgrounds, or analytics hooks around arbitrary content | [`Box`](#box) | Provides the thinnest wrapper over [`render_box`](../../crates/rustic-ui-material/src/box.rs) so adapters simply forward `BoxState` snapshots without touching layout logic. |
+| Constrain page width or switch between fluid/fixed breakpoints | [`Container`](#container) | Builds on [`render_container`](../../crates/rustic-ui-material/src/container.rs) to emit deterministic max-width + density attributes that line up with Material Design breakpoints. |
+| Compose responsive two-dimensional layouts | [`Grid`](#grid) | Delegates to [`render_grid`](../../crates/rustic-ui-material/src/grid.rs) for breakpoint-aware column counts, gaps, and dense layouts, keeping SSR and hydration output identical. |
+| Arrange one-dimensional flows with predictable gaps/dividers | [`Stack`](#stack) | Leverages [`render_stack`](../../crates/rustic-ui-material/src/stack.rs) so adapters only choose direction/density while analytics markers stay centralized. |
+| Hide or reveal content at specific breakpoints without branching adapters | [`Hidden`](#hidden) | Wraps [`render_hidden`](../../crates/rustic-ui-material/src/hidden.rs) so automation identifiers and breakpoints stay aligned with the grid system. |
+
+## Box
+
+`Box` should be your default wrapper when you need theme-aware spacing,
+backgrounds, or automation identifiers without imposing layout semantics. The
+component consumes a [`BoxState`](../../crates/rustic-ui-headless/src/box.rs)
+and forwards it through [`render_box`](../../crates/rustic-ui-material/src/box.rs)
+so every adapter returns the same inline style string and `data-rustic-*`
+markers.【F:crates/rustic-ui-material/src/box.rs†L108-L224】
+
+```rust
+use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+use rustic_ui_headless::r#box::{BoxRole, BoxState, BoxTokens};
+use rustic_ui_material::render_box;
+
+let tokens = BoxTokens {
+    padding: ResponsiveValue::from(String::from("16px")),
+    margin: ResponsiveValue::new(String::from("0"))
+        .with_override(Breakpoint::Lg, String::from("auto")),
+    background: ResponsiveValue::from(String::from("var(--surface)")),
+};
+let state = BoxState::new(tokens, BreakpointConfig::material()).with_role(BoxRole::Region);
+let render = render_box(&state);
+assert!(render.inline_style().contains("--rustic_ui_box_padding"));
+```
+
+:::info Automation
+Run `cargo test -p rustic-ui-material --test layout_renderers -- material_box`
+to confirm the SSR snapshot stays aligned with the adapter wrappers whenever you
+change padding tokens or automation identifiers.
+:::
+
+## Container
+
+Use `Container` when you need responsive gutters or fixed-width layouts. The
+adapter delegates to [`render_container`](../../crates/rustic-ui-material/src/container.rs),
+which emits max-width breakpoints, density toggles, and automation IDs that are
+shared across every framework integration.【F:crates/rustic-ui-material/src/container.rs†L94-L220】
+
+```rust
+use rustic_ui_headless::container::{ContainerRole, ContainerState, ContainerTokens};
+use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+use rustic_ui_material::render_container;
+
+let tokens = ContainerTokens {
+    max_width: ResponsiveValue::new(String::from("540px"))
+        .with_override(Breakpoint::Md, String::from("960px")),
+    padding_inline: ResponsiveValue::new(String::from("16px"))
+        .with_override(Breakpoint::Lg, String::from("32px")),
+};
+let state = ContainerState::new(tokens, BreakpointConfig::material())
+    .with_role(ContainerRole::Presentation)
+    .fixed(true);
+let render = render_container(&state);
+assert!(render.inline_style().contains("--rustic_ui_container_padding_inline"));
+```
+
+:::tip Automation
+`cargo test -p rustic-ui-material --test layout_renderers -- material_container`
+keeps the container snapshot (including `data-breakpoint-*` hooks) synchronized
+across adapters. Pair it with `cargo xtask parity-report` before landing changes
+so the docs parity dashboard refreshes automatically.
+:::
+
+## Grid
+
+Reach for `Grid` when you need responsive, multi-column layouts that collapse or
+densify across breakpoints. The adapters call
+[`render_grid`](../../crates/rustic-ui-material/src/grid.rs), guaranteeing that
+column counts, gaps, and automation attributes remain identical across SSR and
+client renderers.【F:crates/rustic-ui-material/src/grid.rs†L92-L220】
+
+```rust
+use rustic_ui_headless::grid::{GridState, GridTokens};
+use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+use rustic_ui_material::render_grid;
+
+let tokens = GridTokens {
+    columns: ResponsiveValue::new(2)
+        .with_override(Breakpoint::Sm, 4)
+        .with_override(Breakpoint::Lg, 6),
+    column_gap: ResponsiveValue::new(String::from("16px"))
+        .with_override(Breakpoint::Md, String::from("24px")),
+    row_gap: ResponsiveValue::from(String::from("32px")),
+};
+let state = GridState::new(tokens, BreakpointConfig::material()).dense(true);
+let render = render_grid(&state);
+assert!(render.inline_style().contains("--rustic_ui_grid_column_gap"));
+```
+
+:::warning Automation
+The same `layout_renderers` suite exposes `material_grid` snapshots. Execute
+`cargo test -p rustic-ui-material --test layout_renderers -- material_grid`
+after adjusting breakpoints so the recorded HTML/CSS stays current.
+:::
+
+## Stack
+
+`Stack` targets one-dimensional flows such as button groups or media cards. It
+uses [`render_stack`](../../crates/rustic-ui-material/src/stack.rs) to apply
+responsive direction changes, spacing, and optional dividers—all while stamping
+consistent automation hooks.【F:crates/rustic-ui-material/src/stack.rs†L83-L210】
+This keeps React/Yew/Leptos adapters thin wrappers that simply switch between
+horizontal and vertical layouts based on the shared state.
+
+```rust
+use rustic_ui_headless::layout::{Breakpoint, BreakpointConfig, ResponsiveValue};
+use rustic_ui_headless::stack::{StackDirection, StackRole, StackState, StackTokens};
+use rustic_ui_material::render_stack;
+
+let tokens = StackTokens {
+    direction: ResponsiveValue::new(StackDirection::Vertical)
+        .with_override(Breakpoint::Lg, StackDirection::Horizontal),
+    gap: ResponsiveValue::from(String::from("12px")),
+    divider: ResponsiveValue::new(Some(String::from("1px solid var(--border)"))),
+};
+let state = StackState::new(tokens, BreakpointConfig::material()).with_role(StackRole::List);
+let render = render_stack(&state);
+assert!(render.inline_style().contains("--rustic_ui_stack_gap"));
+```
+
+## Hidden
+
+When you need to hide content at specific breakpoints without branching adapter
+logic, `Hidden` wraps [`render_hidden`](../../crates/rustic-ui-material/src/hidden.rs)
+and emits the same deterministic automation hooks that power the grid system.【F:crates/rustic-ui-material/src/hidden.rs†L68-L182】
+This keeps SSR snapshots aligned with hydration regardless of which framework is
+rendering the tree.
+
+:::info Automation
+Hidden participates in the same layout renderer tests. Run
+`cargo test -p rustic-ui-material --test layout_renderers -- material_hidden`
+when changing breakpoint logic, followed by `cargo xtask parity-report` to
+refresh the docs tables and CI parity checks.
+:::
+
+## Keep the docs in sync
+
+All of these primitives surface in the cross-adapter parity dashboard. After
+updating any of them:
+
+1. Refresh the markdown via `cargo xtask parity-report` so
+   [`adapter-parity.md`](./adapter-parity.md) reflects the latest adapter
+   coverage.
+2. Run the targeted `layout_renderers` tests listed above to ensure SSR snapshots
+   and automation hooks stay deterministic.
+3. Commit both the source changes and regenerated docs so CI parity guards stay
+green.

--- a/docs/data/docs/pages.ts
+++ b/docs/data/docs/pages.ts
@@ -30,6 +30,17 @@ const pages: readonly MuiPage[] = [
       },
     ],
   },
+  {
+    pathname: '/docs/architecture',
+    title: 'Architecture playbooks',
+    children: [
+      { pathname: '/docs/architecture/component-decision-guides', title: 'Component decision guides' },
+      { pathname: '/docs/architecture/adapter-parity', title: 'Adapter parity' },
+      { pathname: '/docs/architecture/headless-state-machines', title: 'Headless state machines' },
+      { pathname: '/docs/architecture/selection-controls', title: 'Selection controls telemetry' },
+      { pathname: '/docs/architecture/type-safety-audit', title: 'Type-safety audit' },
+    ],
+  },
   { pathname: 'https://mui.com/versions/' },
   {
     pathname: 'https://mui.com/store/',

--- a/docs/data/material/components/box/box.md
+++ b/docs/data/material/components/box/box.md
@@ -14,6 +14,14 @@ githubSource: archives/mui-packages/mui-material/src/Box
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::info Architecture reference
+Read the [Component decision guides](/docs/architecture/component-decision-guides/)
+for a side-by-side comparison of `Box`, `Container`, `Grid`, `Stack`, and
+`Hidden`, plus the regression tests and automation commands to run before
+shipping layout changes. The cross-adapter coverage dashboard lives in
+[Adapter parity](/docs/architecture/adapter-parity/).
+:::
+
 ## Introduction
 
 The Box component is a generic container for grouping other components.

--- a/docs/data/material/components/container/container.md
+++ b/docs/data/material/components/container/container.md
@@ -14,6 +14,13 @@ While containers can be nested, most layouts do not require a nested container.
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::tip Architecture reference
+See the [Component decision guides](/docs/architecture/component-decision-guides/)
+for when to choose `Container` over `Box`, `Grid`, or `Stack`, and consult the
+[Adapter parity dashboard](/docs/architecture/adapter-parity/) before enabling a
+new framework so you understand current coverage.
+:::
+
 ## Fluid
 
 A fluid container width is bounded by the `maxWidth` prop value.

--- a/docs/data/material/components/grid/grid.md
+++ b/docs/data/material/components/grid/grid.md
@@ -16,6 +16,13 @@ The columns can be configured with multiple breakpoints to specify the column sp
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::info Architecture reference
+Pair this API reference with the [Component decision guides](/docs/architecture/component-decision-guides/)
+for guidance on when to reach for `Grid` versus `Stack` or `Hidden`. The
+[Adapter parity dashboard](/docs/architecture/adapter-parity/) lists which
+framework adapters currently ship SSR/hydration support for the grid renderer.
+:::
+
 ## How it works
 
 The grid system is implemented with the `Grid` component:


### PR DESCRIPTION
## Summary
- add a `cargo xtask parity-report` command that emits `docs/architecture/adapter-parity.md` from the current Material and Joy adapters and enforce it in CI
- document component layout decision guidance with automation callouts and link it from the docs navigation and API pages
- surface the new architecture guides from the global docs navigation and refreshed parity dashboard

## Testing
- cargo fmt
- cargo xtask parity-report

------
https://chatgpt.com/codex/tasks/task_e_68e47f677658832e94118607e9486b93