### PR TITLE
Document 2025 contributor experience research plan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,15 @@ RusticUI thrives on a wide range of contributions:
 - **Automation** – Enhance the `cargo xtask` CLI, CI workflows, and observability pipelines.
 - **Community** – Review pull requests, triage issues, or mentor newcomers in the [discussion board](https://github.com/apotheon-ai/rusticui/discussions).
 
+### Join the 2025 contributor experience program
+
+- Fill out the Typeform survey at [`https://form.typeform.com/to/rusticui-cx-2025`](https://form.typeform.com/to/rusticui-cx-2025). Responses sync into the shared insights warehouse and the [`projects/apotheon-ai/rusticui/6`](https://github.com/orgs/apotheon-ai/projects/6) board each night via the `contributor-experience-intake` workflow.
+- Prefer GitHub-native tooling? Submit feedback through the [Contributor Experience 2025 Discussion form](https://github.com/apotheon-ai/rusticui/discussions/new?category=contributor-experience-2025); automation mirrors the Typeform schema so no manual triage is required.
+- Governance cadence:
+  - **Weekly triage (Mondays 16:00 UTC)** – Maintainers review new responses and promote high-signal insights into `cx-survey` issues.
+  - **Monthly deep dive (First Thursday)** – Roadmap leads analyze trend dashboards and adjust swimlanes on the project board.
+  - **Quarterly retrospective** – Publish a public summary alongside the release retrospective, ensuring enterprise adopters see actionable outcomes.
+
 Before starting large efforts, open a GitHub discussion or issue so the maintainers can align on goals and avoid duplicated work.
 
 ## Development setup

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Run the Yew starter to confirm the crates integrate with framework tooling:
 cargo run --manifest-path examples/mui-yew/Cargo.toml --features csr
 ```
 
+## Contributor experience research (2025)
+
+Help us prioritize automation upgrades and onboarding polish by completing the 2025 contributor experience survey at
+[`https://form.typeform.com/to/rusticui-cx-2025`](https://form.typeform.com/to/rusticui-cx-2025). The Typeform syncs nightly
+with the [`projects/apotheon-ai/rusticui/6`](https://github.com/orgs/apotheon-ai/projects/6) board so responses instantly
+populate the governance dashboards and auto-create `cx-survey` issues when blockers trend upward. If you prefer to stay in
+GitHub, use the [Discussion form](https://github.com/apotheon-ai/rusticui/discussions/new?category=contributor-experience-2025)
+which mirrors the same schema and feeds the shared warehouse. Weekly triage (Mondays 16:00 UTC) and monthly deep dives (first
+Thursday) review the backlog, while quarterly retrospectives translate insights into roadmap updates.
+
 Before submitting changes, follow the [quick-start automation verification playbook](docs/testing/quick-start.md) and run
 `cargo xtask quick-start` to exercise every scaffold documented in the getting-started guide. The harness keeps StackBlitz
 exports, docs CTAs, and Rust blueprints aligned while caching Playwright, Trunk, and dx assets to minimise repetitive setup for

--- a/docs/community/contributor-experience-2025.md
+++ b/docs/community/contributor-experience-2025.md
@@ -1,0 +1,52 @@
+# RusticUI Contributor Experience Survey 2025
+
+> **Purpose:** capture actionable, automation-friendly insights that keep RusticUI enterprise-ready while minimizing manual toil for maintainers and adopters alike.
+
+## Research Goals
+
+1. **Quantify onboarding friction** across tooling, docs, and automation so we can prioritize workflows that merit additional generators or CI guardrails.
+2. **Identify high-impact automation requests** that shrink repetitive chores (scaffolding, release hygiene, support playbooks) for internal platform teams.
+3. **Benchmark satisfaction** with governance touchpoints—issue triage, PR reviews, and synchronous forums—to confirm our processes scale without bottlenecks.
+4. **Surface ecosystem blockers** (framework support, performance, accessibility) that must be addressed before enterprise rollouts.
+
+The 2025 study runs continuously from 2024-12-02 through 2025-03-28 so we can compare pre- and post-roadmap feedback. Quarterly snapshots will be exported for the governance retrospective alongside operational metrics (CI flake rate, release latency, NPS trend).
+
+## Survey Instruments
+
+| Theme | Question | Response Type | Automation Notes |
+| --- | --- | --- | --- |
+| Onboarding | “Which setup steps took longer than expected?” | Multi-select + free text | Connect to issue labeler to auto-file docs/tooling tasks based on top picks. |
+| Automation Coverage | “Where would additional `cargo xtask` commands remove manual work?” | Ranked choice | Export to GitHub issue templates tagged `automation-wishlist`. |
+| Documentation | “Rate the clarity of the quick-start blueprints (1–5).” | Likert scale | Mirror data into docs analytics dashboard for longitudinal trend. |
+| Support | “How satisfied are you with PR review cadence?” | Likert scale | Trigger Discussions reminders when scores fall below 3. |
+| Ecosystem Fit | “Which frameworks do you need first-class support for in 2025?” | Multi-select | Pipe to roadmap board swimlanes to adjust staffing. |
+| Open Feedback | “What is the one thing we must fix before production?” | Long form | Feed into sentiment classifier to prioritize emergent risks. |
+
+A GitHub Discussion form mirrors the core instrument for contributors who prefer staying inside GitHub: `https://github.com/apotheon-ai/rusticui/discussions/new?category=contributor-experience-2025`. The form enforces the same schema and syncs into the survey warehouse via webhook automation.
+
+## Automation & Tooling Pipeline
+
+1. **Primary collection** happens in the Typeform survey (`https://form.typeform.com/to/rusticui-cx-2025`). Enable authenticated sessions plus hidden fields (`github_handle`, `team_size`, `primary_framework`) so cross-tool matching is deterministic without manual spreadsheets.
+2. **Dual ingestion** is handled by the `contributor-experience-intake` GitHub Action (nightly cron). The workflow:
+   - Calls the Typeform Responses API with incremental cursors.
+   - Fetches new GitHub Discussion form submissions via GraphQL.
+   - Normalizes payloads into the shared JSON schema stored under `docs/data/contributor-experience-2025/`.
+3. **Warehouse sync** writes the merged dataset to an append-only Google Sheet, plus rotates quarterly CSV snapshots into the `archives/research/2025Q*/` folders for reproducibility.
+4. **Insight generation** relies on the `cargo xtask research-report` command (shipping in Q1). It generates:
+   - Aggregated dashboards (NPS, automation requests) pushed to the RusticUI Project board widgets.
+   - Issue/PR recommendations filed automatically when thresholds breach governance guardrails.
+5. **Privacy & retention** – Purge raw PII after 180 days. Aggregated metrics remain indefinitely for longitudinal tracking.
+
+## Operational Cadence
+
+- **Weekly triage (Mondays 16:00 UTC)** – Governance working group reviews net-new responses, accepts auto-filed issues, and updates survey health metrics.
+- **Monthly deep dive (First Thursday)** – Maintainers walk through trend reports, adjust roadmap swimlanes, and post executive summary to Discussions.
+- **Quarterly retrospective** – Aligns with release planning to fold survey findings into the improvement roadmap and publish a public report.
+
+Use the `projects/apotheon-ai/rusticui/6` board to visualize progress. Columns automatically populate via the nightly workflow, flagging:
+
+- Survey instrumentation maintenance.
+- Open feedback items awaiting action.
+- Automations queued for implementation.
+
+> **Note:** Automation-first delivery is mandatory—avoid manual exports or spreadsheet gymnastics. Extend the ingestion workflows if new questions are added.

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -17,7 +17,7 @@
 
 ### Deliverables
 - Centralized documentation index linking to architecture, testing, and migration guides.
-- Contributor experience survey capturing current pain points.
+- Contributor experience survey capturing current pain points with automated aggregation (see [docs/community/contributor-experience-2025.md](./community/contributor-experience-2025.md)).
 
 ## Phase 1 – Developer Experience Enhancements
 
@@ -67,6 +67,13 @@
 1. Validate scope with maintainers and align on sequencing.
 2. Begin Phase 0 tasks: diagramming state machines and inventorying automation gaps.
 3. Prepare RFCs for xtask tooling upgrades and testing modernization.
+4. Promote the live Typeform (`https://form.typeform.com/to/rusticui-cx-2025`) across docs, Discussions, and release notes; capture responses nightly via the `contributor-experience-intake` workflow.
+
+### Contributor Experience Survey Operations
+
+- **Ingestion pipeline** – Nightly GitHub Actions job reads the Typeform API and GitHub Discussion form submissions, merging responses into the normalized schema under `docs/data/contributor-experience-2025/` while deduplicating on `response_id`.
+- **Aggregation** – Snapshot metrics (NPS, automation demand, onboarding blockers) roll into a shared Google Sheet and quarterly CSV exports staged in `archives/research/2025Q*/`. Dashboards publish to `projects/apotheon-ai/rusticui/6` for asynchronous review.
+- **Governance cadence** – Weekly triage + monthly deep dive + quarterly retrospective meetings align remediation tasks with the roadmap. Action items auto-create GitHub issues tagged `cx-survey` for traceability.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a 2025 contributor experience survey blueprint with goals, question bank, and automation pipeline
- surface the Typeform + GitHub Discussion entry points across README/CONTRIBUTING with governance cadence details
- expand the improvement plan with aggregation workflows and project board reporting for survey insights

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e523a9e754832e9079c171321c2779