### PR TITLE
Add parity-report guardrails and refresh layout docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
         run: cargo xtask build-docs
       - name: Verify mdBook diagrams render
         run: cargo xtask docs-build
+      - name: Ensure adapter parity dashboard is current (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo xtask parity-report --check
       - name: Install grcov (Linux only)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y grcov

--- a/crates/xtask/src/adapter_parity.rs
+++ b/crates/xtask/src/adapter_parity.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
 use regex::Regex;
 use walkdir::WalkDir;
@@ -23,35 +23,41 @@ struct ComponentCoverage {
     frameworks: BTreeSet<String>,
 }
 
-pub fn adapter_parity_report(output: Option<PathBuf>) -> Result<()> {
+pub fn adapter_parity_report(output: Option<PathBuf>, check: bool) -> Result<()> {
     let workspace = workspace_root();
     let material_components = collect_material_components(&workspace)?;
     let joy_components = collect_joy_components(&workspace)?;
 
-    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
-    let mut doc = String::new();
-    doc.push_str("# Adapter Parity\n\n");
-    doc.push_str(&format!(
-        "_Last updated {timestamp} via `cargo xtask parity-report`._\n\n"
-    ));
-    doc.push_str("The tables below enumerate which framework adapters ship for each component. ");
-    doc.push_str("Material adapters are discovered by scanning the adapter modules under `crates/rustic-ui-material/src`, and the Joy rows come from the Yew-first modules declared in `crates/rustic-ui-joy/src/lib.rs`. ");
-    doc.push_str("Parity is validated by the cross-adapter regression suites such as [`button_adapters.rs`](../../crates/rustic-ui-material/tests/button_adapters.rs) and [`joy_yew.rs`](../../crates/rustic-ui-material/tests/joy_yew.rs). Run `cargo xtask parity-report` after adding or removing adapters so CI can confirm this dashboard stays in sync.\n\n");
-
-    doc.push_str("## Material adapters\n\n");
-    doc.push_str(&coverage_summary(&material_components));
-    doc.push_str("\n\n");
-    doc.push_str(&render_table(&material_components));
-    doc.push_str("\n\n");
-
-    doc.push_str("## Joy adapters\n\n");
-    doc.push_str(&coverage_summary(&joy_components));
-    doc.push_str("\n\n");
-    doc.push_str(&render_table(&joy_components));
-    doc.push_str("\n");
-
     let output_path =
         output.unwrap_or_else(|| workspace.join("docs/architecture/adapter-parity.md"));
+
+    let current_timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let existing = if check {
+        Some(fs::read_to_string(&output_path).unwrap_or_default())
+    } else {
+        None
+    };
+    let timestamp = existing
+        .as_ref()
+        .and_then(|doc| extract_timestamp(doc))
+        .unwrap_or(current_timestamp);
+    let doc = build_report(timestamp, &material_components, &joy_components);
+
+    if check {
+        // The `--check` flag is wired into CI so contributors cannot forget to
+        // refresh the parity dashboard after adding or removing adapters. We
+        // read the current file (if any) and compare it to the freshly
+        // generated payload without mutating the workspace. A mismatch produces
+        // a targeted error message that points developers at the automated
+        // regeneration command rather than leaving them to guess why CI failed.
+        if existing.unwrap_or_default() != doc {
+            bail!(
+                "adapter parity dashboard is stale; run `cargo xtask parity-report` and commit the refreshed docs"
+            );
+        }
+        return Ok(());
+    }
+
     fs::write(&output_path, doc).with_context(|| {
         format!(
             "failed to write adapter parity report to {}",
@@ -60,6 +66,41 @@ pub fn adapter_parity_report(output: Option<PathBuf>) -> Result<()> {
     })?;
 
     Ok(())
+}
+
+fn build_report(
+    timestamp: String,
+    material_components: &[ComponentCoverage],
+    joy_components: &[ComponentCoverage],
+) -> String {
+    let mut doc = String::new();
+    doc.push_str("# Adapter Parity\n\n");
+    doc.push_str(&format!(
+        "_Last updated {timestamp} via `cargo xtask parity-report`._\n\n"
+    ));
+    doc.push_str("The tables below enumerate which framework adapters ship for each component. ");
+    doc.push_str("Material adapters are discovered by scanning the adapter modules under `crates/rustic-ui-material/src`, and the Joy rows come from the Yew-first modules declared in `crates/rustic-ui-joy/src/lib.rs`. ");
+    doc.push_str("Parity is validated by the cross-adapter regression suites such as [`button_adapters.rs`](../../crates/rustic-ui-material/tests/button_adapters.rs) and [`joy_yew.rs`](../../crates/rustic-ui-material/tests/joy_yew.rs). Run `cargo xtask parity-report` after adding or removing adapters, and `cargo xtask parity-report --check` in CI, so this dashboard stays in sync.\n\n");
+
+    doc.push_str("## Material adapters\n\n");
+    doc.push_str(&coverage_summary(material_components));
+    doc.push_str("\n\n");
+    doc.push_str(&render_table(material_components));
+    doc.push_str("\n\n");
+
+    doc.push_str("## Joy adapters\n\n");
+    doc.push_str(&coverage_summary(joy_components));
+    doc.push_str("\n\n");
+    doc.push_str(&render_table(joy_components));
+    doc.push_str("\n");
+
+    doc
+}
+
+fn extract_timestamp(doc: &str) -> Option<String> {
+    let regex = Regex::new(r"^_Last updated ([^ ]+) via `cargo xtask parity-report`\._$").ok()?;
+    doc.lines()
+        .find_map(|line| regex.captures(line).map(|caps| caps[1].to_string()))
 }
 
 fn collect_material_components(workspace: &Path) -> Result<Vec<ComponentCoverage>> {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -236,7 +236,14 @@ enum Commands {
     JoyParity,
     /// Regenerate the cross-adapter parity dashboard consumed by docs and CI.
     #[command(name = "parity-report")]
-    ParityReport,
+    ParityReport {
+        /// Fail if `docs/architecture/adapter-parity.md` would change.
+        #[arg(long)]
+        check: bool,
+        /// Override the default output path (used by release tooling).
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
     /// Run the Rust and TypeScript selection control regression suites.
     SelectionControls(SelectionControlsArgs),
     /// Execute every quick-start bootstrap script to guarantee docs remain accurate.
@@ -300,7 +307,7 @@ fn main() -> Result<()> {
         } => themes_bundle(overrides, format, joy, compat, out_dir),
         Commands::MaterialParity => material_parity(),
         Commands::JoyParity => joy_parity(),
-        Commands::ParityReport => adapter_parity_report(None),
+        Commands::ParityReport { check, output } => adapter_parity_report(output, check),
         Commands::SelectionControls(args) => selection_controls(args),
         Commands::QuickStart { skip_checks } => quick_start(skip_checks),
     }

--- a/docs/architecture/adapter-parity.md
+++ b/docs/architecture/adapter-parity.md
@@ -1,8 +1,8 @@
 # Adapter Parity
 
-_Last updated 2025-10-07T03:12:01Z via `cargo xtask parity-report`._
+_Last updated 2025-10-07T16:01:32Z via `cargo xtask parity-report`._
 
-The tables below enumerate which framework adapters ship for each component. Material adapters are discovered by scanning the adapter modules under `crates/rustic-ui-material/src`, and the Joy rows come from the Yew-first modules declared in `crates/rustic-ui-joy/src/lib.rs`. Parity is validated by the cross-adapter regression suites such as [`button_adapters.rs`](../../crates/rustic-ui-material/tests/button_adapters.rs) and [`joy_yew.rs`](../../crates/rustic-ui-material/tests/joy_yew.rs). Run `cargo xtask parity-report` after adding or removing adapters so CI can confirm this dashboard stays in sync.
+The tables below enumerate which framework adapters ship for each component. Material adapters are discovered by scanning the adapter modules under `crates/rustic-ui-material/src`, and the Joy rows come from the Yew-first modules declared in `crates/rustic-ui-joy/src/lib.rs`. Parity is validated by the cross-adapter regression suites such as [`button_adapters.rs`](../../crates/rustic-ui-material/tests/button_adapters.rs) and [`joy_yew.rs`](../../crates/rustic-ui-material/tests/joy_yew.rs). Run `cargo xtask parity-report` after adding or removing adapters, and `cargo xtask parity-report --check` in CI, so this dashboard stays in sync.
 
 ## Material adapters
 

--- a/docs/architecture/component-decision-guides.md
+++ b/docs/architecture/component-decision-guides.md
@@ -44,7 +44,9 @@ assert!(render.inline_style().contains("--rustic_ui_box_padding"));
 :::info Automation
 Run `cargo test -p rustic-ui-material --test layout_renderers -- material_box`
 to confirm the SSR snapshot stays aligned with the adapter wrappers whenever you
-change padding tokens or automation identifiers.
+change padding tokens or automation identifiers. Pair the snapshot refresh with
+`cargo xtask parity-report --check` so CI blocks merges when the adapter
+dashboard drifts from the regenerated renderer output.
 :::
 
 ## Container
@@ -75,8 +77,8 @@ assert!(render.inline_style().contains("--rustic_ui_container_padding_inline"));
 :::tip Automation
 `cargo test -p rustic-ui-material --test layout_renderers -- material_container`
 keeps the container snapshot (including `data-breakpoint-*` hooks) synchronized
-across adapters. Pair it with `cargo xtask parity-report` before landing changes
-so the docs parity dashboard refreshes automatically.
+across adapters. Pair it with `cargo xtask parity-report --check` before landing
+changes so the docs parity dashboard and CI guardrail stay in lockstep.
 :::
 
 ## Grid
@@ -147,8 +149,9 @@ rendering the tree.
 :::info Automation
 Hidden participates in the same layout renderer tests. Run
 `cargo test -p rustic-ui-material --test layout_renderers -- material_hidden`
-when changing breakpoint logic, followed by `cargo xtask parity-report` to
-refresh the docs tables and CI parity checks.
+when changing breakpoint logic, followed by `cargo xtask parity-report`
+locally and `cargo xtask parity-report --check` in CI to refresh the docs
+tables and parity checks automatically.
 :::
 
 ## Keep the docs in sync
@@ -158,8 +161,9 @@ updating any of them:
 
 1. Refresh the markdown via `cargo xtask parity-report` so
    [`adapter-parity.md`](./adapter-parity.md) reflects the latest adapter
-   coverage.
+   coverage, then run `cargo xtask parity-report --check` to confirm no drift
+   remains.
 2. Run the targeted `layout_renderers` tests listed above to ensure SSR snapshots
    and automation hooks stay deterministic.
 3. Commit both the source changes and regenerated docs so CI parity guards stay
-green.
+   green.

--- a/docs/data/joy/components/box/box.md
+++ b/docs/data/joy/components/box/box.md
@@ -13,6 +13,16 @@ githubLabel: 'component: Box'
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::info Architecture reference
+Read the [Component decision guides](/docs/architecture/component-decision-guides/)
+for a side-by-side comparison of `Box`, `Container`, `Grid`, `Stack`, and
+`Hidden`, plus the regression tests and automation commands to run before
+shipping layout changes. When you touch layout tokens or automation IDs, run
+`cargo xtask parity-report` locally and let CI enforce
+`cargo xtask parity-report --check` so the [Adapter parity](/docs/architecture/adapter-parity/)
+dashboard always matches the available adapters.
+:::
+
 ## Introduction
 
 The Box component is a generic container for grouping other components.

--- a/docs/data/joy/components/grid/grid.md
+++ b/docs/data/joy/components/grid/grid.md
@@ -11,6 +11,15 @@ githubLabel: 'component: Grid'
 
 {{"component": "@mui/docs/ComponentLinkHeader"}}
 
+:::info Architecture reference
+Pair this API reference with the [Component decision guides](/docs/architecture/component-decision-guides/)
+for guidance on when to reach for `Grid` versus `Stack` or `Hidden`. The
+[Adapter parity dashboard](/docs/architecture/adapter-parity/) lists which
+framework adapters currently ship SSR/hydration support for the grid renderer.
+Regenerate it with `cargo xtask parity-report` and lean on
+`cargo xtask parity-report --check` in CI whenever you add or remove adapters.
+:::
+
 ## Introduction
 
 The Grid component, based on a 12-column grid layout, creates visual consistency between layouts while allowing flexibility across a wide variety of designs.

--- a/docs/data/joy/components/stack/stack.md
+++ b/docs/data/joy/components/stack/stack.md
@@ -11,6 +11,15 @@ githubLabel: 'component: Stack'
 
 {{"component": "@mui/docs/ComponentLinkHeader"}}
 
+:::info Architecture reference
+Coordinate `Stack` usage with the [Component decision guides](/docs/architecture/component-decision-guides/)
+to validate when to prefer one-dimensional stacks over `Grid`, `Box`, or `Hidden`.
+Run `cargo xtask parity-report` locally and depend on
+`cargo xtask parity-report --check` in CI so the
+[Adapter parity dashboard](/docs/architecture/adapter-parity/) always mirrors
+the adapters published for each framework.
+:::
+
 ## Introduction
 
 The Stack component manages the layout of its immediate children along the vertical or horizontal axis, with optional spacing and dividers between each child.

--- a/docs/data/material/components/box/box.md
+++ b/docs/data/material/components/box/box.md
@@ -18,8 +18,10 @@ githubSource: archives/mui-packages/mui-material/src/Box
 Read the [Component decision guides](/docs/architecture/component-decision-guides/)
 for a side-by-side comparison of `Box`, `Container`, `Grid`, `Stack`, and
 `Hidden`, plus the regression tests and automation commands to run before
-shipping layout changes. The cross-adapter coverage dashboard lives in
-[Adapter parity](/docs/architecture/adapter-parity/).
+shipping layout changes. When you touch layout tokens or automation IDs, run
+`cargo xtask parity-report` locally and let CI enforce
+`cargo xtask parity-report --check` so the [Adapter parity](/docs/architecture/adapter-parity/)
+dashboard always matches the available adapters.
 :::
 
 ## Introduction

--- a/docs/data/material/components/container/container.md
+++ b/docs/data/material/components/container/container.md
@@ -17,8 +17,9 @@ While containers can be nested, most layouts do not require a nested container.
 :::tip Architecture reference
 See the [Component decision guides](/docs/architecture/component-decision-guides/)
 for when to choose `Container` over `Box`, `Grid`, or `Stack`, and consult the
-[Adapter parity dashboard](/docs/architecture/adapter-parity/) before enabling a
-new framework so you understand current coverage.
+[Adapter parity dashboard](/docs/architecture/adapter-parity/). Run
+`cargo xtask parity-report` locally and rely on `cargo xtask parity-report --check`
+in CI so coverage stays aligned with the adapters you ship.
 :::
 
 ## Fluid

--- a/docs/data/material/components/grid/grid.md
+++ b/docs/data/material/components/grid/grid.md
@@ -21,6 +21,8 @@ Pair this API reference with the [Component decision guides](/docs/architecture/
 for guidance on when to reach for `Grid` versus `Stack` or `Hidden`. The
 [Adapter parity dashboard](/docs/architecture/adapter-parity/) lists which
 framework adapters currently ship SSR/hydration support for the grid renderer.
+Regenerate it with `cargo xtask parity-report` and lean on
+`cargo xtask parity-report --check` in CI whenever you add or remove adapters.
 :::
 
 ## How it works

--- a/docs/data/material/components/stack/stack.md
+++ b/docs/data/material/components/stack/stack.md
@@ -20,6 +20,15 @@ Stack is ideal for one-dimensional layouts, while Grid is preferable when you ne
 
 {{"component": "@mui/docs/ComponentLinkHeader"}}
 
+:::info Architecture reference
+Coordinate `Stack` usage with the [Component decision guides](/docs/architecture/component-decision-guides/)
+to validate when to prefer one-dimensional stacks over `Grid`, `Box`, or `Hidden`.
+Run `cargo xtask parity-report` locally and depend on
+`cargo xtask parity-report --check` in CI so the
+[Adapter parity dashboard](/docs/architecture/adapter-parity/) always mirrors
+the adapters published for each framework.
+:::
+
 ## Basics
 
 ```jsx

--- a/docs/data/system/components/box/box.md
+++ b/docs/data/system/components/box/box.md
@@ -13,6 +13,16 @@ githubLabel: 'component: Box'
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::info Architecture reference
+Read the [Component decision guides](/docs/architecture/component-decision-guides/)
+for a side-by-side comparison of `Box`, `Container`, `Grid`, `Stack`, and
+`Hidden`, plus the regression tests and automation commands to run before
+shipping layout changes. When you touch layout tokens or automation IDs, run
+`cargo xtask parity-report` locally and let CI enforce
+`cargo xtask parity-report --check` so the [Adapter parity](/docs/architecture/adapter-parity/)
+dashboard always matches the available adapters.
+:::
+
 ## Introduction
 
 The Box component is a generic container for grouping other components.

--- a/docs/data/system/components/container/container.md
+++ b/docs/data/system/components/container/container.md
@@ -13,6 +13,14 @@ While containers can be nested, most layouts do not require a nested container.
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::tip Architecture reference
+See the [Component decision guides](/docs/architecture/component-decision-guides/)
+for when to choose `Container` over `Box`, `Grid`, or `Stack`, and consult the
+[Adapter parity dashboard](/docs/architecture/adapter-parity/). Run
+`cargo xtask parity-report` locally and rely on `cargo xtask parity-report --check`
+in CI so coverage stays aligned with the adapters you ship.
+:::
+
 ## Fluid
 
 A fluid container width is bounded by the `maxWidth` prop value.

--- a/docs/data/system/components/grid/grid.md
+++ b/docs/data/system/components/grid/grid.md
@@ -10,6 +10,15 @@ githubLabel: 'component: Grid'
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::info Architecture reference
+Pair this API reference with the [Component decision guides](/docs/architecture/component-decision-guides/)
+for guidance on when to reach for `Grid` versus `Stack` or `Hidden`. The
+[Adapter parity dashboard](/docs/architecture/adapter-parity/) lists which
+framework adapters currently ship SSR/hydration support for the grid renderer.
+Regenerate it with `cargo xtask parity-report` and lean on
+`cargo xtask parity-report --check` in CI whenever you add or remove adapters.
+:::
+
 The `Grid` component works well for a layout with known columns. The columns can be configured in multiple breakpoints which you have to specify the column span of each child.
 
 ## How it works

--- a/docs/data/system/components/stack/stack.md
+++ b/docs/data/system/components/stack/stack.md
@@ -19,6 +19,15 @@ Stack is ideal for one-dimensional layouts, while Grid is preferable when you ne
 
 {{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
+:::info Architecture reference
+Coordinate `Stack` usage with the [Component decision guides](/docs/architecture/component-decision-guides/)
+to validate when to prefer one-dimensional stacks over `Grid`, `Box`, or `Hidden`.
+Run `cargo xtask parity-report` locally and depend on
+`cargo xtask parity-report --check` in CI so the
+[Adapter parity dashboard](/docs/architecture/adapter-parity/) always mirrors
+the adapters published for each framework.
+:::
+
 ## Basics
 
 ```jsx


### PR DESCRIPTION
## Summary
- add a `--check` mode to `cargo xtask parity-report` so CI can detect stale adapter dashboards without rewriting files
- expand layout component docs across Material, Joy, and System to link back to the architecture guides and new parity automation flow
- refresh the adapter parity markdown and reinforce `cargo xtask parity-report --check` usage in the component decision guide

## Testing
- cargo fmt
- cargo xtask parity-report
- cargo xtask parity-report --check

------
https://chatgpt.com/codex/tasks/task_e_68e534064f74832eaf9ae0edb3b840fa