### PR TITLE
Link collapsible region property tests to architecture diagrams

### DIFF
--- a/crates/rustic-ui-headless/tests/collapsible_region_state.rs
+++ b/crates/rustic-ui-headless/tests/collapsible_region_state.rs
@@ -2,10 +2,14 @@
 //!
 //! Each property in this suite is heavily annotated so new contributors can
 //! trace the expectations back to the architectural state diagrams and the
-//! enterprise-grade focus orchestration guarantees the component promises.  The
-//! goal is to document *why* each invariant matters for large scale surfaces so
-//! future refactors have guard rails baked into CI instead of relying on tribal
-//! knowledge.
+//! enterprise-grade focus orchestration guarantees the component promises.
+//! Cross-check the expectations with the diagrams in
+//! [`docs/architecture/headless-state-machines.md#collapsible-region-state-machine`](../../../docs/architecture/headless-state-machines.md#collapsible-region-state-machine)
+//! and the token lifecycle walkthrough under
+//! [`#token-lifecycle-orchestration`](../../../docs/architecture/headless-state-machines.md#token-lifecycle-orchestration).
+//! The goal is to document *why* each invariant matters for large scale
+//! surfaces so future refactors have guard rails baked into CI instead of
+//! relying on tribal knowledge.
 
 use std::collections::BTreeSet;
 

--- a/docs/testing/headless-state-machines.md
+++ b/docs/testing/headless-state-machines.md
@@ -12,17 +12,21 @@ controlled/uncontrolled diagrams outlined in
 - **Uncontrolled transitions stay deterministic.**
   `tests/collapsible_region_state.rs` models user-driven expand/collapse/toggle
   flows as a pure boolean latch to guarantee that snapshots, hydration cycles,
-  and analytics hooks see the same ordering documented in the diagrams.
+  and analytics hooks see the same ordering documented in the
+  [controlled/uncontrolled diagram](../architecture/headless-state-machines.md#collapsible-region-state-machine).
 - **Controlled consumers must call `sync`.** The controlled-mode property keeps
   `CollapsibleRegionState` frozen until a `sync` arrives, validating that React
   and Leptos integrations can safely render without racing asynchronous
-  callbacks.
+  callbacks. This corresponds to the
+  [adapter handshake in the same diagram](../architecture/headless-state-machines.md#collapsible-region-state-machine).
 - **Transition token serialization is stable.** A shadow `BTreeSet` asserts that
   tokens never duplicate and that `is_transitioning()` mirrors the architectural
-  expectation that animations complete in a deterministic order.
+  expectation that animations complete in a deterministic order, matching the
+  [token lifecycle walkthrough](../architecture/headless-state-machines.md#token-lifecycle-orchestration).
 - **Focus returns remain intact.** The focus-return property walks through
   repeated collapses/expands to guarantee keyboard users always land on the last
-  configured trigger.
+  configured trigger, mirroring the
+  [automation checklist guidance](../architecture/headless-state-machines.md#automation-checklist).
 
 Each property is annotated with extensive commentary so teams rolling out new
 automation or analytics pipelines can extend the suite without reverse-


### PR DESCRIPTION
## Summary
- cross-link the collapsible region property suite to the architectural diagrams for quick traceability
- update the headless state machine testing guide with direct links back to the controlled/uncontrolled and token lifecycle diagrams

## Testing
- cargo test -p rustic-ui-headless --test collapsible_region_state

------
https://chatgpt.com/codex/tasks/task_e_68e57a7a5868832e8b29ba213cbb1422